### PR TITLE
Fix AS keyword bug

### DIFF
--- a/bql/planner/planner_test.go
+++ b/bql/planner/planner_test.go
@@ -461,6 +461,7 @@ func TestPlannerQuery(t *testing.T) {
 		tbl, err := plnr.Excecute(ctx)
 		if err != nil {
 			t.Errorf("planner.Excecute failed for query %q with error %v", entry.q, err)
+			continue
 		}
 		if got, want := len(tbl.Bindings()), entry.nbs; got != want {
 			t.Errorf("tbl.Bindings returned the wrong number of bindings for %q; got %d, want %d", entry.q, got, want)

--- a/bql/planner/planner_test.go
+++ b/bql/planner/planner_test.go
@@ -273,7 +273,17 @@ func TestPlannerQuery(t *testing.T) {
 			nrws: len(strings.Split(testTriples, "\n")) - 1,
 		},
 		{
+			q:    `select ?s as ?s1, ?p as ?p1, ?o as ?o1 from ?test where {?s ?p ?o};`,
+			nbs:  3,
+			nrws: len(strings.Split(testTriples, "\n")) - 1,
+		},
+		{
 			q:    `select ?p, ?o from ?test where {/u<joe> ?p ?o};`,
+			nbs:  2,
+			nrws: 2,
+		},
+		{
+			q:    `select ?p as ?p1, ?o as ?o1 from ?test where {/u<joe> ?p ?o};`,
 			nbs:  2,
 			nrws: 2,
 		},
@@ -309,6 +319,11 @@ func TestPlannerQuery(t *testing.T) {
 		},
 		{
 			q:    `select ?s from ?test where {?s "is_a"@[] /t<car>};`,
+			nbs:  1,
+			nrws: 4,
+		},
+		{
+			q:    `select ?s as ?s1 from ?test where {?s "is_a"@[] /t<car>};`,
 			nbs:  1,
 			nrws: 4,
 		},


### PR DESCRIPTION
The root of this bug seems to stem from the planner not registering the output bindings with the table before projecting, causing the table to throw an error that the output bindings are unknown. These changes register the output bindings with the table before projecting and copy the values for the input bindings to the output bindings for each row of the table. Tests and benchmarks are included. Also, query testing was modified so no additional testing is performed on a query with failed planner execution to avoid superfluous errors.