### PR TITLE
Added input and output graph lists.

### DIFF
--- a/bql/grammar/grammar.go
+++ b/bql/grammar/grammar.go
@@ -34,7 +34,7 @@ func BQL() *Grammar {
 					NewTokenType(lexer.ItemQuery),
 					NewSymbol("VARS"),
 					NewTokenType(lexer.ItemFrom),
-					NewSymbol("GRAPHS"),
+					NewSymbol("INPUT_GRAPHS"),
 					NewSymbol("WHERE"),
 					NewSymbol("GROUP_BY"),
 					NewSymbol("ORDER_BY"),
@@ -49,7 +49,7 @@ func BQL() *Grammar {
 					NewTokenType(lexer.ItemInsert),
 					NewTokenType(lexer.ItemData),
 					NewTokenType(lexer.ItemInto),
-					NewSymbol("GRAPHS"),
+					NewSymbol("OUTPUT_GRAPHS"),
 					NewTokenType(lexer.ItemLBracket),
 					NewTokenType(lexer.ItemNode),
 					NewTokenType(lexer.ItemPredicate),
@@ -64,7 +64,7 @@ func BQL() *Grammar {
 					NewTokenType(lexer.ItemDelete),
 					NewTokenType(lexer.ItemData),
 					NewTokenType(lexer.ItemFrom),
-					NewSymbol("GRAPHS"),
+					NewSymbol("INPUT_GRAPHS"),
 					NewTokenType(lexer.ItemLBracket),
 					NewTokenType(lexer.ItemNode),
 					NewTokenType(lexer.ItemPredicate),
@@ -93,9 +93,9 @@ func BQL() *Grammar {
 					NewTokenType(lexer.ItemConstruct),
 					NewSymbol("CONSTRUCT_FACTS"),
 					NewTokenType(lexer.ItemInto),
-					NewSymbol("GRAPHS"),
+					NewSymbol("OUTPUT_GRAPHS"),
 					NewTokenType(lexer.ItemFrom),
-					NewSymbol("GRAPHS"),
+					NewSymbol("INPUT_GRAPHS"),
 					NewSymbol("WHERE"),
 					NewSymbol("HAVING"),
 					NewTokenType(lexer.ItemSemicolon),
@@ -190,6 +190,42 @@ func BQL() *Grammar {
 					NewTokenType(lexer.ItemComma),
 					NewTokenType(lexer.ItemBinding),
 					NewSymbol("MORE_GRAPHS"),
+				},
+			},
+			{},
+		},
+		"INPUT_GRAPHS": []*Clause{
+			{
+				Elements: []Element{
+					NewTokenType(lexer.ItemBinding),
+					NewSymbol("MORE_INPUT_GRAPHS"),
+				},
+			},
+		},
+		"MORE_INPUT_GRAPHS": []*Clause{
+			{
+				Elements: []Element{
+					NewTokenType(lexer.ItemComma),
+					NewTokenType(lexer.ItemBinding),
+					NewSymbol("MORE_INPUT_GRAPHS"),
+				},
+			},
+			{},
+		},
+		"OUTPUT_GRAPHS": []*Clause{
+			{
+				Elements: []Element{
+					NewTokenType(lexer.ItemBinding),
+					NewSymbol("MORE_OUTPUT_GRAPHS"),
+				},
+			},
+		},
+		"MORE_OUTPUT_GRAPHS": []*Clause{
+			{
+				Elements: []Element{
+					NewTokenType(lexer.ItemComma),
+					NewTokenType(lexer.ItemBinding),
+					NewSymbol("MORE_OUTPUT_GRAPHS"),
 				},
 			},
 			{},
@@ -918,6 +954,14 @@ func SemanticBQL() *Grammar {
 	// Add graph binding collection to GRAPHS and MORE_GRAPHS clauses.
 	graphSymbols := []semantic.Symbol{"GRAPHS", "MORE_GRAPHS"}
 	setElementHook(semanticBQL, graphSymbols, semantic.GraphAccumulatorHook(), nil)
+
+	// Add graph binding collection to INPUT_GRAPHS and MORE_INPUT_GRAPHS clauses.
+	inputGraphSymbols := []semantic.Symbol{"INPUT_GRAPHS", "MORE_INPUT_GRAPHS"}
+	setElementHook(semanticBQL, inputGraphSymbols, semantic.InputGraphAccumulatorHook(), nil)
+
+	// Add graph binding collection to OUTPUT_GRAPHS and MORE_OUTPUT_GRAPHS clauses.
+	outputGraphSymbols := []semantic.Symbol{"OUTPUT_GRAPHS", "MORE_OUTPUT_GRAPHS"}
+	setElementHook(semanticBQL, outputGraphSymbols, semantic.OutputGraphAccumulatorHook(), nil)
 
 	// Insert and Delete semantic hooks addition.
 	insertSymbols := []semantic.Symbol{

--- a/bql/grammar/grammar_test.go
+++ b/bql/grammar/grammar_test.go
@@ -15,6 +15,7 @@
 package grammar
 
 import (
+	"reflect"
 	"testing"
 
 	"github.com/google/badwolf/bql/semantic"
@@ -255,87 +256,54 @@ func TestRejectByParse(t *testing.T) {
 	}
 }
 
-func TestAcceptCreateAndDropGraphOpsByParseAndSemantic(t *testing.T) {
+func TestAcceptGraphOpsByParseAndSemantic(t *testing.T) {
+	var empty []string
 	table := []struct {
-		query   string
-		graphs  int
-		triples int
+		query        string
+		graphs       []string
+		inputGraphs  []string
+		outputGraphs []string
+		triples      int
 	}{
-		// Create graphs.
-		{`create graph ?foo;`, 1, 0},
-		// Drop graphs.
-		{`drop graph ?foo, ?bar;`, 2, 0},
-	}
-	p, err := NewParser(SemanticBQL())
-	if err != nil {
-		t.Errorf("grammar.NewParser: Should have produced a valid BQL parser, %v", err)
-	}
-	for _, entry := range table {
-		st := &semantic.Statement{}
-		if err := p.Parse(NewLLk(entry.query, 1), st); err != nil {
-			t.Errorf("Parser.consume: Failed to accept entry %q with error %v", entry, err)
-		}
-		if got, want := len(st.GraphNames()), entry.graphs; got != want {
-			t.Errorf("Parser.consume: Failed to collect right number of graphs for case %v; got %d, want %d", entry, got, want)
-		}
-		if got, want := len(st.Data()), entry.triples; got != want {
-			t.Errorf("Parser.consume: Failed to collect right number of triples for case %v; got %d, want %d", entry, got, want)
-		}
-	}
-}
+		// Create graphs. All graphs are regular graphs.
+		{`create graph ?foo1, ?bar1;`, []string{"?foo1", "?bar1"}, empty, empty, 0},
+		// Drop graphs. All graphs are regular graphs.
+		{`drop graph ?foo2, ?bar2;`, []string{"?foo2", "?bar2"}, empty, empty, 0},
 
-
-func TestAcceptInsertDataIntoGraphOpByParseAndSemantic(t *testing.T) {
-	table := []struct {
-		query   string
-		graphs  int
-		triples int
-	}{
-		// Insert data.
-		{`insert data into ?a {/_<foo> "bar"@[1975-01-01T00:01:01.999999999Z] /_<foo>};`, 1, 1},
-		{`insert data into ?a {/_<foo> "bar"@[] "bar"@[1975-01-01T00:01:01.999999999Z]};`, 1, 1},
-		{`insert data into ?a {/_<foo> "bar"@[] "yeah"^^type:text};`, 1, 1},
-		// Insert into multiple graphs.
-		{`insert data into ?a,?b,?c {/_<foo> "bar"@[] /_<foo>};`, 3, 1},
+		// Insert data. All graphs are output graphs.
+		{`insert data into ?a {/_<foo> "bar"@[1975-01-01T00:01:01.999999999Z] /_<foo>};`, empty, empty, []string{"?a"}, 1},
+		{`insert data into ?a {/_<foo> "bar"@[] "bar"@[1975-01-01T00:01:01.999999999Z]};`, empty, empty, []string{"?a"}, 1},
+		{`insert data into ?a {/_<foo> "bar"@[] "yeah"^^type:text};`, empty, empty, []string{"?a"}, 1},
+		// Insert into multiple output graphs.
+		{`insert data into ?a,?b,?c {/_<foo> "bar"@[] /_<foo>};`, empty, empty, []string{"?a", "?b", "?c"}, 1},
 		// Insert multiple data.
 		{`insert data into ?a {/_<foo> "bar"@[] /_<foo> .
 				                      /_<foo> "bar"@[] "bar"@[1975-01-01T00:01:01.999999999Z] .
-				                      /_<foo> "bar"@[] "yeah"^^type:text};`, 1, 3},
-	}
-	p, err := NewParser(SemanticBQL())
-	if err != nil {
-		t.Errorf("grammar.NewParser: Should have produced a valid BQL parser, %v", err)
-	}
-	for _, entry := range table {
-		st := &semantic.Statement{}
-		if err := p.Parse(NewLLk(entry.query, 1), st); err != nil {
-			t.Errorf("Parser.consume: Failed to accept entry %q with error %v", entry, err)
-		}
-		if got, want := len(st.OutputGraphNames()), entry.graphs; got != want {
-			t.Errorf("Parser.consume: Failed to collect right number of graphs for case %v; got %d, want %d", entry, got, want)
-		}
-		if got, want := len(st.Data()), entry.triples; got != want {
-			t.Errorf("Parser.consume: Failed to collect right number of triples for case %v; got %d, want %d", entry, got, want)
-		}
-	}
-}
+				                      /_<foo> "bar"@[] "yeah"^^type:text};`, empty, empty, []string{"?a"}, 3},
 
-func TestAcceptDeleteDataFromGraphOpsByParseAndSemantic(t *testing.T) {
-	table := []struct {
-		query   string
-		graphs  int
-		triples int
-	}{
-		// Delete data.
-		{`delete data from ?a {/_<foo> "bar"@[] /_<foo>};`, 1, 1},
-		{`delete data from ?a {/_<foo> "bar"@[] "bar"@[1975-01-01T00:01:01.999999999Z]};`, 1, 1},
-		{`delete data from ?a {/_<foo> "bar"@[] "yeah"^^type:text};`, 1, 1},
-		// Delete from multiple graphs.
-		{`delete data from ?a,?b,?c {/_<foo> "bar"@[1975-01-01T00:01:01.999999999Z] /_<foo>};`, 3, 1},
+		// Delete data. All graphs are input graphs.
+		{`delete data from ?a {/_<foo> "bar"@[] /_<foo>};`, empty, []string{"?a"}, empty, 1},
+		{`delete data from ?a {/_<foo> "bar"@[] "bar"@[1975-01-01T00:01:01.999999999Z]};`, empty, []string{"?a"}, empty, 1},
+		{`delete data from ?a {/_<foo> "bar"@[] "yeah"^^type:text};`, empty, []string{"?a"}, empty, 1},
+		// Delete from multiple input graphs.
+		{`delete data from ?a,?b,?c {/_<foo> "bar"@[1975-01-01T00:01:01.999999999Z] /_<foo>};`, empty, []string{"?a", "?b", "?c"}, empty, 1},
 		// Delete multiple data.
 		{`delete data from ?a {/_<foo> "bar"@[] /_<foo> .
 				                      /_<foo> "bar"@[] "bar"@[1975-01-01T00:01:01.999999999Z] .
-				                      /_<foo> "bar"@[] "yeah"^^type:text};`, 1, 3},
+				                      /_<foo> "bar"@[] "yeah"^^type:text};`, empty, []string{"?a"}, empty, 3},
+
+		// Construct data. Graphs can be input or output graphs.
+		{`construct {?s "predicate_1"@[] ?o1;
+		                "predicate_2"@[] ?o2} into ?a from ?b where {?s "old_predicate_1"@[,] ?o1.
+					                                     ?s "old_predicate_2"@[,] ?o2.
+									     ?s "old_predicate_3"@[,] ?o3};`,
+		 empty, []string{"?b"}, []string{"?a"}, 0},
+		// construct data into multiple output graphs from multple input graphs.
+		{`construct {?s "predicate_1"@[] ?o1;
+		                "predicate_2"@[] ?o2} into ?a, ?b from ?c, ?d where {?s "old_predicate_1"@[,] ?o1.
+										     ?s "old_predicate_2"@[,] ?o2.
+									             ?s "old_predicate_3"@[,] ?o3};`,
+		 empty, []string{"?c", "?d"}, []string{"?a", "?b"}, 0},
 	}
 	p, err := NewParser(SemanticBQL())
 	if err != nil {
@@ -346,8 +314,14 @@ func TestAcceptDeleteDataFromGraphOpsByParseAndSemantic(t *testing.T) {
 		if err := p.Parse(NewLLk(entry.query, 1), st); err != nil {
 			t.Errorf("Parser.consume: Failed to accept entry %q with error %v", entry, err)
 		}
-		if got, want := len(st.InputGraphNames()), entry.graphs; got != want {
-			t.Errorf("Parser.consume: Failed to collect right number of graphs for case %v; got %d, want %d", entry, got, want)
+		if got, want := st.GraphNames(), entry.graphs; !reflect.DeepEqual(got, want) {
+			t.Errorf("Parser.consume: Failed to collect the right graphs for case %v; got %d, want %d", entry, got, want)
+		}
+		if got, want := st.InputGraphNames(), entry.inputGraphs; !reflect.DeepEqual(got, want) {
+			t.Errorf("Parser.consume: Failed to collect the right input graphs for case %v; got %d, want %d", entry, got, want)
+		}
+		if got, want := st.OutputGraphNames(), entry.outputGraphs; !reflect.DeepEqual(got, want) {
+			t.Errorf("Parser.consume: Failed to collect the right output graphs for case %v; got %d, want %d", entry, got, want)
 		}
 		if got, want := len(st.Data()), entry.triples; got != want {
 			t.Errorf("Parser.consume: Failed to collect right number of triples for case %v; got %d, want %d", entry, got, want)

--- a/bql/planner/planner_test.go
+++ b/bql/planner/planner_test.go
@@ -501,14 +501,14 @@ func TestPlannerQuery(t *testing.T) {
 		}
 		tbl, err := plnr.Execute(ctx)
 		if err != nil {
-			t.Errorf("planner.Excecute failed for query %q with error %v", entry.q, err)
+			t.Errorf("planner.Execute failed for query %q with error %v", entry.q, err)
 			continue
 		}
 		if got, want := len(tbl.Bindings()), entry.nbs; got != want {
 			t.Errorf("tbl.Bindings returned the wrong number of bindings for %q; got %d, want %d", entry.q, got, want)
 		}
 		if got, want := len(tbl.Rows()), entry.nrws; got != want {
-			t.Errorf("planner.Excecute failed to return the expected number of rows for query %q; got %d want %d\nGot:\n%v\n", entry.q, got, want, tbl)
+			t.Errorf("planner.Execute failed to return the expected number of rows for query %q; got %d want %d\nGot:\n%v\n", entry.q, got, want, tbl)
 		}
 	}
 }
@@ -552,13 +552,13 @@ func TestTreeTraversalToRoot(t *testing.T) {
 	}
 	tbl, err := plnr.Execute(ctx)
 	if err != nil {
-		t.Errorf("planner.Excecute failed for query %q with error %v", traversalQuery, err)
+		t.Errorf("planner.Execute failed for query %q with error %v", traversalQuery, err)
 	}
 	if got, want := len(tbl.Bindings()), 1; got != want {
 		t.Errorf("tbl.Bindings returned the wrong number of bindings for %q; got %d, want %d", traversalQuery, got, want)
 	}
 	if got, want := len(tbl.Rows()), 1; got != want {
-		t.Errorf("planner.Excecute failed to return the expected number of rows for query %q; got %d want %d\nGot:\n%v\n", traversalQuery, got, want, tbl)
+		t.Errorf("planner.Execute failed to return the expected number of rows for query %q; got %d want %d\nGot:\n%v\n", traversalQuery, got, want, tbl)
 	}
 }
 
@@ -599,13 +599,13 @@ func TestChaining(t *testing.T) {
 	}
 	tbl, err := plnr.Execute(ctx)
 	if err != nil {
-		t.Errorf("planner.Excecute failed for query %q with error %v", traversalQuery, err)
+		t.Errorf("planner.Execute failed for query %q with error %v", traversalQuery, err)
 	}
 	if got, want := len(tbl.Bindings()), 1; got != want {
 		t.Errorf("tbl.Bindings returned the wrong number of bindings for %q; got %d, want %d", traversalQuery, got, want)
 	}
 	if got, want := len(tbl.Rows()), 1; got != want {
-		t.Errorf("planner.Excecute failed to return the expected number of rows for query %q; got %d want %d\nGot:\n%v\n", traversalQuery, got, want, tbl)
+		t.Errorf("planner.Execute failed to return the expected number of rows for query %q; got %d want %d\nGot:\n%v\n", traversalQuery, got, want, tbl)
 	}
 }
 
@@ -657,13 +657,13 @@ func TestReificationResolutionIssue70(t *testing.T) {
 	}
 	tbl, err := plnr.Execute(ctx)
 	if err != nil {
-		t.Fatalf("planner.Excecute failed for query %q with error %v", query, err)
+		t.Fatalf("planner.Execute failed for query %q with error %v", query, err)
 	}
 	if got, want := len(tbl.Bindings()), 2; got != want {
 		t.Errorf("tbl.Bindings returned the wrong number of bindings for %q; got %d, want %d", query, got, want)
 	}
 	if got, want := len(tbl.Rows()), 1; got != want {
-		t.Errorf("planner.Excecute failed to return the expected number of rows for query %q; got %d want %d\nGot:\n%v\n", query, got, want, tbl)
+		t.Errorf("planner.Execute failed to return the expected number of rows for query %q; got %d want %d\nGot:\n%v\n", query, got, want, tbl)
 	}
 }
 
@@ -688,7 +688,7 @@ func benchmarkQuery(query string, b *testing.B) {
 		}
 		_, err = plnr.Execute(ctx)
 		if err != nil {
-			b.Errorf("planner.Excecute failed for query %q with error %v", query, err)
+			b.Errorf("planner.Execute failed for query %q with error %v", query, err)
 		}
 	}
 }

--- a/bql/semantic/hooks.go
+++ b/bql/semantic/hooks.go
@@ -54,6 +54,16 @@ func GraphAccumulatorHook() ElementHook {
 	return graphAccumulator()
 }
 
+// InputGraphAccumulatorHook returns the singleton for input graph accumulation.
+func InputGraphAccumulatorHook() ElementHook {
+	return inputGraphAccumulator()
+}
+
+// OutputGraphAccumulatorHook returns the singleton for output graph accumulation.
+func OutputGraphAccumulatorHook() ElementHook {
+	return outputGraphAccumulator()
+}
+
 // WhereInitWorkingClauseHook returns the singleton for graph accumulation.
 func WhereInitWorkingClauseHook() ClauseHook {
 	return whereInitWorkingClause()
@@ -271,7 +281,51 @@ func graphAccumulator() ElementHook {
 			st.AddGraph(strings.TrimSpace(tkn.Text))
 			return hook, nil
 		default:
-			return nil, fmt.Errorf("hook.GrapAccumulator requires a binding to refer to a graph, got %v instead", tkn)
+			return nil, fmt.Errorf("hook.GraphAccumulator requires a binding to refer to a graph, got %v instead", tkn)
+		}
+	}
+	return hook
+}
+
+// inputGraphAccumulator returns an element hook that keeps track of the graphs
+// listed in a statement.
+func inputGraphAccumulator() ElementHook {
+	var hook ElementHook
+	hook = func(st *Statement, ce ConsumedElement) (ElementHook, error) {
+		if ce.IsSymbol() {
+			return hook, nil
+		}
+		tkn := ce.Token()
+		switch tkn.Type {
+		case lexer.ItemComma:
+			return hook, nil
+		case lexer.ItemBinding:
+			st.AddInputGraph(strings.TrimSpace(tkn.Text))
+			return hook, nil
+		default:
+			return nil, fmt.Errorf("hook.InputGraphAccumulator requires a binding to refer to a graph, got %v instead", tkn)
+		}
+	}
+	return hook
+}
+
+// outputGraphAccumulator returns an element hook that keeps track of the graphs
+// listed in a statement.
+func outputGraphAccumulator() ElementHook {
+	var hook ElementHook
+	hook = func(st *Statement, ce ConsumedElement) (ElementHook, error) {
+		if ce.IsSymbol() {
+			return hook, nil
+		}
+		tkn := ce.Token()
+		switch tkn.Type {
+		case lexer.ItemComma:
+			return hook, nil
+		case lexer.ItemBinding:
+			st.AddOutputGraph(strings.TrimSpace(tkn.Text))
+			return hook, nil
+		default:
+			return nil, fmt.Errorf("hook.OutputGraphAccumulator requires a binding to refer to a graph, got %v instead", tkn)
 		}
 	}
 	return hook

--- a/bql/semantic/hooks_test.go
+++ b/bql/semantic/hooks_test.go
@@ -91,7 +91,7 @@ func TestDataAccumulatorHook(t *testing.T) {
 	}
 }
 
-func TestSemanticAcceptInsertDelete(t *testing.T) {
+func TestGraphAccumulatorElementHooks(t *testing.T) {
 	st := &Statement{}
 	ces := []ConsumedElement{
 		NewConsumedSymbol("FOO"),
@@ -111,6 +111,7 @@ func TestSemanticAcceptInsertDelete(t *testing.T) {
 	}
 	var (
 		hook ElementHook
+		data []string
 		err  error
 	)
 	hook = graphAccumulator()
@@ -120,13 +121,47 @@ func TestSemanticAcceptInsertDelete(t *testing.T) {
 			t.Errorf("semantic.GraphAccumulator hook should have never failed for %v with error %v", ce, err)
 		}
 	}
-	data := st.GraphNames()
+	data = st.GraphNames()
 	if len(data) != 2 {
 		t.Errorf("semantic.GraphAccumulator hook should have produced 2 graph bindings; instead produced %v", st.Graphs())
 	}
 	for _, g := range data {
 		if g != "?foo" && g != "?bar" {
 			t.Errorf("semantic.GraphAccumulator hook failed to provied either ?foo or ?bar; got %v instead", g)
+		}
+	}
+
+	hook = inputGraphAccumulator()
+	for _, ce := range ces {
+		hook, err = hook(st, ce)
+		if err != nil {
+			t.Errorf("semantic.InputGraphAccumulator hook should have never failed for %v with error %v", ce, err)
+		}
+	}
+	data = st.InputGraphNames()
+	if len(data) != 2 {
+		t.Errorf("semantic.InputGraphAccumulator hook should have produced 2 graph bindings; instead produced %v", st.Graphs())
+	}
+	for _, g := range data {
+		if g != "?foo" && g != "?bar" {
+			t.Errorf("semantic.InputGraphAccumulator hook failed to provied either ?foo or ?bar; got %v instead", g)
+		}
+	}
+
+	hook = outputGraphAccumulator()
+	for _, ce := range ces {
+		hook, err = hook(st, ce)
+		if err != nil {
+			t.Errorf("semantic.OutputGraphAccumulator hook should have never failed for %v with error %v", ce, err)
+		}
+	}
+	data = st.OutputGraphNames()
+	if len(data) != 2 {
+		t.Errorf("semantic.OutputGraphAccumulator hook should have produced 2 graph bindings; instead produced %v", st.Graphs())
+	}
+	for _, g := range data {
+		if g != "?foo" && g != "?bar" {
+			t.Errorf("semantic.OutputGraphAccumulator hook failed to provied either ?foo or ?bar; got %v instead", g)
 		}
 	}
 }

--- a/bql/semantic/semantic.go
+++ b/bql/semantic/semantic.go
@@ -76,6 +76,10 @@ type Statement struct {
 	sType                     StatementType
 	graphNames                []string
 	graphs                    []storage.Graph
+	inputGraphNames           []string
+	inputGraphs               []storage.Graph
+	outputGraphNames          []string
+	outputGraphs              []storage.Graph
 	data                      []*triple.Triple
 	pattern                   []*GraphClause
 	workingClause             *GraphClause
@@ -409,7 +413,37 @@ func (s *Statement) Graphs() []storage.Graph {
 	return s.graphs
 }
 
-// Init initialize the graphs givne the graph names.
+// InputGraphNames returns the list of input graphs listed on the statement.
+func (s *Statement) InputGraphNames() []string {
+	return s.inputGraphNames
+}
+
+// AddInputGraph adds an input graph to a given statement.
+func (s *Statement) AddInputGraph(g string) {
+	s.inputGraphNames = append(s.inputGraphNames, g)
+}
+
+// InputGraphs returns the list of input graphs listed on the statement.
+func (s *Statement) InputGraphs() []storage.Graph {
+	return s.inputGraphs
+}
+
+// OutputGraphNames returns the list of output graphs listed on the statement.
+func (s *Statement) OutputGraphNames() []string {
+	return s.outputGraphNames
+}
+
+// AddOutputGraph adds an output graph to a given statement.
+func (s *Statement) AddOutputGraph(g string) {
+	s.outputGraphNames = append(s.outputGraphNames, g)
+}
+
+// OutputGraphs returns the list of output graphs listed on the statement.
+func (s *Statement) OutputGraphs() []storage.Graph {
+	return s.outputGraphs
+}
+
+// Init initializes all graphs given the graph names.
 func (s *Statement) Init(ctx context.Context, st storage.Store) error {
 	for _, gn := range s.graphNames {
 		g, err := st.Graph(ctx, gn)
@@ -417,6 +451,20 @@ func (s *Statement) Init(ctx context.Context, st storage.Store) error {
 			return err
 		}
 		s.graphs = append(s.graphs, g)
+	}
+	for _, ign := range s.inputGraphNames {
+		ig, err := st.Graph(ctx, ign)
+		if err != nil {
+			return err
+		}
+		s.inputGraphs = append(s.inputGraphs, ig)
+	}
+	for _, ogn := range s.outputGraphNames {
+		og, err := st.Graph(ctx, ogn)
+		if err != nil {
+			return err
+		}
+		s.outputGraphs = append(s.outputGraphs, og)
 	}
 	return nil
 }

--- a/bql/semantic/semantic_test.go
+++ b/bql/semantic/semantic_test.go
@@ -41,6 +41,24 @@ func TestStatementAddGraph(t *testing.T) {
 	}
 }
 
+func TestStatementAddInputGraph(t *testing.T) {
+	st := &Statement{}
+	st.BindType(Query)
+	st.AddInputGraph("?foo")
+	if got, want := st.InputGraphNames(), []string{"?foo"}; !reflect.DeepEqual(got, want) {
+		t.Errorf("semantic.AddInputGraph returned the wrong graphs available; got %v, want %v", got, want)
+	}
+}
+
+func TestStatementAddOutputGraph(t *testing.T) {
+	st := &Statement{}
+	st.BindType(Query)
+	st.AddOutputGraph("?foo")
+	if got, want := st.OutputGraphNames(), []string{"?foo"}; !reflect.DeepEqual(got, want) {
+		t.Errorf("semantic.AddOutputGraph returned the wrong graphs available; got %v, want %v", got, want)
+	}
+}
+
 func TestStatementAddData(t *testing.T) {
 	tr, err := triple.Parse(`/_<foo> "foo"@[] /_<bar>`, literal.DefaultBuilder())
 	if err != nil {


### PR DESCRIPTION
This PR is to add input and output graph lists to the statement, along with the regular graph lists. The idea is to use the regular graph lists to collect graphs for creation/deletion, and the input graph lists to collect graphs that act as a source of information (such as information queried in a WHERE clause) and the output graph lists to collect graphs that act as a destination of information (such as triples added in an INSERT or CONSTRUCT clause).

There are a couple of reasons for this change. Primarily, there needs to be a distinction between input and output graphs in a CONSTRUCT...WHERE BQL statement. Also, having the distinction helps to reason through the code.