### PR TITLE
minor: remove double assignment of ctx in TestPlannerQuery

### DIFF
--- a/bql/planner/planner_test.go
+++ b/bql/planner/planner_test.go
@@ -266,7 +266,6 @@ func populateStoreWithTriples(ctx context.Context, s storage.Store, gn string, t
 }
 
 func TestPlannerQuery(t *testing.T) {
-	ctx := context.Background()
 	testTable := []struct {
 		q    string
 		nbs  int
@@ -479,19 +478,19 @@ func TestPlannerQuery(t *testing.T) {
 			nrws: 4,
 		},
 		{
-			q: `SELECT ?car 
-			    FROM ?test 
-			    WHERE { 
-				   /c<model s> as ?car "is_a"@[] /t<car> 
+			q: `SELECT ?car
+			    FROM ?test
+			    WHERE {
+				   /c<model s> as ?car "is_a"@[] /t<car>
 				};`,
 			nbs:  1,
 			nrws: 1,
 		},
 		{
-			q: `SELECT ?car 
-			    FROM ?test 
-			    WHERE { 
-				   ?car "is_a"@[] /t<car> . 
+			q: `SELECT ?car
+			    FROM ?test
+			    WHERE {
+				   ?car "is_a"@[] /t<car> .
 				   /c<model z> as ?car "is_a"@[] /t<car>
 				};`,
 			nbs:  1,


### PR DESCRIPTION
Hi,

In TestPlannerQuery, ctx is assigned as the 1st step of the test and then again to the same value right after the table allocation without using it in between.
This PR removes the 1st assignment (and some trailing spaces too).

Thanks,
Joseph