### PR TITLE
Switch to go modules

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,11 @@ language: go
 
 sudo: false
 
-env: GO111MODULE=on
+env:
+  - GO111MODULE=on
+
+git:
+  depth: 1
 
 go:
   - "1.12"
@@ -11,4 +15,4 @@ go:
   - tip
 
 script:
-  - go test ./bql/... ./io/... ./storage/... ./tools/... ./triple/...
+  - go test -v -race ./bql/... ./io/... ./storage/... ./tools/... ./triple/...

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,14 +3,12 @@ language: go
 
 sudo: false
 
-go:
-  - "1.11"
-  - "1.12"
-  - tip
+env: GO111MODULE=on
 
-before_install:
-  - go get golang.org/x/sync/errgroup
-  - go get github.com/pborman/uuid
+go:
+  - "1.12"
+  - "1.13"
+  - tip
 
 script:
   - go test ./bql/... ./io/... ./storage/... ./tools/... ./triple/...

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,8 @@
+module github.com/google/badwolf
+
+go 1.13
+
+require (
+	github.com/pborman/uuid v1.2.0
+	golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,6 @@
+github.com/google/uuid v1.0.0 h1:b4Gk+7WdP/d3HZH8EJsZpvV7EtDOgaZLtnaNGIu1adA=
+github.com/google/uuid v1.0.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/pborman/uuid v1.2.0 h1:J7Q5mO4ysT1dv8hyrUGHb9+ooztCXu1D8MY8DZYsu3g=
+github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=
+golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e h1:vcxGaoTs7kV8m5Np9uUNQin4BrLOthgV7252N8V+FwY=
+golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=


### PR DESCRIPTION
Hi guys,

As it's been a bit over a year that the main projects have started to use the go modules, I figured that maybe it would be good to switch badwolf to use go modules too.
So here's the PR for it.

Note: it also switches travis to:
* use go modules
* test on go 1.12, 1.13 and tip (removes 1.11)
* adds the `-v -race` options to the tests to have better visibility and check for race conditions
* limit the depth of the tree cloning to 1 as we don't look at the history (makes the clone more efficient)

Thanks for your time,
Joseph