### PR TITLE
Remove double assignment of ctx in benchmarkQuery

### DIFF
--- a/bql/planner/planner_test.go
+++ b/bql/planner/planner_test.go
@@ -1100,8 +1100,6 @@ func TestReificationResolutionIssue70(t *testing.T) {
 
 // benchmarkQuery is a helper function that runs a specified query on the testing data set for benchmarking purposes.
 func benchmarkQuery(query string, b *testing.B) {
-	ctx := context.Background()
-
 	s, ctx := memory.NewStore(), context.Background()
 	populateStoreWithTriples(ctx, s, "?test", testTriples, b)
 	p, err := grammar.NewParser(grammar.SemanticBQL())


### PR DESCRIPTION
Hi guys,

I missed this last time I was looking at ineffassign.
ctx here is re-reclared on the next line so just cleaning up the first unused assignment.

Thanks,
Joseph