### PR TITLE
Fix the string representation of a ConstructPredicateObjectPair and add more tests

### DIFF
--- a/bql/semantic/semantic.go
+++ b/bql/semantic/semantic.go
@@ -458,11 +458,9 @@ func (c *ConstructPredicateObjectPair) String() string {
 
 	// Object section.
 	if c.O != nil {
-		// Node portion.
 		b.WriteString(" ")
 		b.WriteString(c.O.String())
 	} else {
-		// Predicate portion.
 		if c.OBinding != "" {
 			b.WriteString(" ")
 			b.WriteString(c.OBinding)

--- a/bql/semantic/semantic.go
+++ b/bql/semantic/semantic.go
@@ -457,19 +457,12 @@ func (c *ConstructPredicateObjectPair) String() string {
 	}
 
 	// Object section.
-	// Node portion.
-	object := false
 	if c.O != nil {
+		// Node portion.
 		b.WriteString(" ")
 		b.WriteString(c.O.String())
-		object = true
 	} else {
-		b.WriteString(" ")
-		b.WriteString(c.OBinding)
-		object = true
-	}
-	// Predicate portion.
-	if !object {
+		// Predicate portion.
 		if c.OBinding != "" {
 			b.WriteString(" ")
 			b.WriteString(c.OBinding)

--- a/bql/semantic/semantic_test.go
+++ b/bql/semantic/semantic_test.go
@@ -455,6 +455,72 @@ func TestInputOutputBindings(t *testing.T) {
 	}
 }
 
+func TestConstructPredicateObjectPairString(t *testing.T) {
+	// Testing that NewNodeFromStrings is not the point of this package. Taking the example from the unit tests.
+	n, _ := node.NewNodeFromStrings("/some/type", "id_1")
+	// Testing NewImmutable is not the point of this package.
+	immutFoo, _ := predicate.NewImmutable("foo")
+	o := triple.NewNodeObject(n)
+
+	table := []struct {
+		pop  *ConstructPredicateObjectPair
+		want string
+	}{
+		{&ConstructPredicateObjectPair{}, `@[]][]`},
+		{
+			&ConstructPredicateObjectPair{
+				P:              immutFoo,
+				PID:            "?predID",
+				PBinding:       "?predBinding",
+				PAnchorBinding: "?predAnchorBinding",
+				PTemporal:      true,
+				O:              o,
+				OBinding:       "?objBinding",
+				OID:            "?objID",
+				OAnchorBinding: "?Popeyes",
+				OTemporal:      true,
+			},
+			` "foo"@[] ?predBinding "?predID" /some/type<id_1>`,
+		},
+		{
+			&ConstructPredicateObjectPair{
+				P:              nil,
+				PID:            "?predID",
+				PBinding:       "?predBinding",
+				PAnchorBinding: "?predAnchorBinding",
+				PTemporal:      true,
+				O:              nil,
+				OBinding:       "?objBinding",
+				OID:            "?objID",
+				OAnchorBinding: "?Popeyes",
+				OTemporal:      false,
+			},
+			` ?predBinding "?predID"@[?predAnchorBinding] ?objBinding "?objID"[]`,
+		},
+		{
+			&ConstructPredicateObjectPair{
+				P:              nil,
+				PID:            "?predID",
+				PBinding:       "?predBinding",
+				PAnchorBinding: "?predAnchorBinding",
+				PTemporal:      false,
+				O:              nil,
+				OBinding:       "?objBinding",
+				OID:            "?objID",
+				OAnchorBinding: "?Popeyes",
+				OTemporal:      true,
+			},
+			` ?predBinding "?predID"@[]] ?objBinding "?objID"[?Popeyes]`,
+		},
+	}
+
+	for i, entry := range table {
+		if got, want := entry.pop.String(), entry.want; got != want {
+			t.Errorf("[case %d] failed; got `%v`, want `%v`", i, got, want)
+		}
+	}
+}
+
 func TestHasAlias(t *testing.T) {
 	accept := []*GraphClause{
 		{

--- a/bql/semantic/semantic_test.go
+++ b/bql/semantic/semantic_test.go
@@ -108,13 +108,14 @@ func TestGraphClauseString(t *testing.T) {
 	immutFoo, _ := predicate.NewImmutable("foo")
 	nO, _ := node.NewNodeFromStrings("/some/other/type", "id_2")
 	o := triple.NewNodeObject(nO)
+
 	table := []struct {
 		gc   *GraphClause
 		want string
 	}{
-		{&GraphClause{}, `{ opt=false @[][] }`},
+		{gc: &GraphClause{}, want: `{ opt=false @[][] }`},
 		{
-			&GraphClause{
+			gc: &GraphClause{
 				Optional:         true,
 				S:                n,
 				SBinding:         "?nBinding",
@@ -147,10 +148,10 @@ func TestGraphClauseString(t *testing.T) {
 				OUpperBoundAlias: "?seemsSoFarAway",
 				OTemporal:        true,
 			},
-			`{ opt=true /some/type<id_1> AS ?nAlias TYPE ?nTypeAlias ID ?nIDAlias "foo"@[] ?predBinding "?predID" AS ?predAlias ID ?predIDAlias AT ?predAnchorAlias /some/other/type<id_2> AS ?objAlias TYPE ?objTypeAlias ID ?objCuteID AT ?Olive AS ?objAlias ID ?objCuteID }`,
+			want: `{ opt=true /some/type<id_1> AS ?nAlias TYPE ?nTypeAlias ID ?nIDAlias "foo"@[] ?predBinding "?predID" AS ?predAlias ID ?predIDAlias AT ?predAnchorAlias /some/other/type<id_2> AS ?objAlias TYPE ?objTypeAlias ID ?objCuteID AT ?Olive AS ?objAlias ID ?objCuteID }`,
 		},
 		{
-			&GraphClause{
+			gc: &GraphClause{
 				Optional:         true,
 				S:                nil,
 				SBinding:         "?nBinding",
@@ -177,10 +178,10 @@ func TestGraphClauseString(t *testing.T) {
 				OUpperBoundAlias: "?seemsSoFarAway",
 				OTemporal:        false,
 			},
-			`{ opt=true ?nBinding AS ?nAlias TYPE ?nTypeAlias ID ?nIDAlias ?predBinding "?predID"@[] AS ?predAlias ID ?predIDAlias AT ?predAnchorAlias[] }`,
+			want: `{ opt=true ?nBinding AS ?nAlias TYPE ?nTypeAlias ID ?nIDAlias ?predBinding "?predID"@[] AS ?predAlias ID ?predIDAlias AT ?predAnchorAlias[] }`,
 		},
 		{
-			&GraphClause{
+			gc: &GraphClause{
 				Optional:         true,
 				S:                nil,
 				SBinding:         "?nBinding",
@@ -212,7 +213,7 @@ func TestGraphClauseString(t *testing.T) {
 				OUpperBoundAlias: "?seemsSoFarAway",
 				OTemporal:        true,
 			},
-			`{ opt=true ?nBinding AS ?nAlias TYPE ?nTypeAlias ID ?nIDAlias ?predBinding "?predID"@[?predAnchorBinding at ?predAnchorAlias] AS ?predAlias ID ?predIDAlias AT ?predAnchorAlias ?objBinding "?objID"[2019-11-30T22:10:50.000000003Z,2019-12-02T17:00:10.000000015Z] AS ?objAlias TYPE ?objTypeAlias ID ?objCuteID AT ?Olive AS ?objAlias ID ?objCuteID }`,
+			want: `{ opt=true ?nBinding AS ?nAlias TYPE ?nTypeAlias ID ?nIDAlias ?predBinding "?predID"@[?predAnchorBinding at ?predAnchorAlias] AS ?predAlias ID ?predIDAlias AT ?predAnchorAlias ?objBinding "?objID"[2019-11-30T22:10:50.000000003Z,2019-12-02T17:00:10.000000015Z] AS ?objAlias TYPE ?objTypeAlias ID ?objCuteID AT ?Olive AS ?objAlias ID ?objCuteID }`,
 		},
 	}
 
@@ -224,6 +225,7 @@ func TestGraphClauseString(t *testing.T) {
 }
 
 func TestGraphClauseSpecificity(t *testing.T) {
+
 	table := []struct {
 		gc   *GraphClause
 		want int
@@ -233,6 +235,7 @@ func TestGraphClauseSpecificity(t *testing.T) {
 		{&GraphClause{S: &node.Node{}, P: &predicate.Predicate{}}, 2},
 		{&GraphClause{S: &node.Node{}, P: &predicate.Predicate{}, O: &triple.Object{}}, 3},
 	}
+
 	for _, entry := range table {
 		if got, want := entry.gc.Specificity(), entry.want; got != want {
 			t.Errorf("semantic.GraphClause.Specificity failed to return the proper value for %v; got %d, want %d", entry.gc, got, want)
@@ -466,9 +469,9 @@ func TestConstructPredicateObjectPairString(t *testing.T) {
 		pop  *ConstructPredicateObjectPair
 		want string
 	}{
-		{&ConstructPredicateObjectPair{}, `@[]][]`},
+		{pop: &ConstructPredicateObjectPair{}, want: `@[]][]`},
 		{
-			&ConstructPredicateObjectPair{
+			pop: &ConstructPredicateObjectPair{
 				P:              immutFoo,
 				PID:            "?predID",
 				PBinding:       "?predBinding",
@@ -480,10 +483,10 @@ func TestConstructPredicateObjectPairString(t *testing.T) {
 				OAnchorBinding: "?Popeyes",
 				OTemporal:      true,
 			},
-			` "foo"@[] ?predBinding "?predID" /some/type<id_1>`,
+			want: ` "foo"@[] ?predBinding "?predID" /some/type<id_1>`,
 		},
 		{
-			&ConstructPredicateObjectPair{
+			pop: &ConstructPredicateObjectPair{
 				P:              nil,
 				PID:            "?predID",
 				PBinding:       "?predBinding",
@@ -495,10 +498,10 @@ func TestConstructPredicateObjectPairString(t *testing.T) {
 				OAnchorBinding: "?Popeyes",
 				OTemporal:      false,
 			},
-			` ?predBinding "?predID"@[?predAnchorBinding] ?objBinding "?objID"[]`,
+			want: ` ?predBinding "?predID"@[?predAnchorBinding] ?objBinding "?objID"[]`,
 		},
 		{
-			&ConstructPredicateObjectPair{
+			pop: &ConstructPredicateObjectPair{
 				P:              nil,
 				PID:            "?predID",
 				PBinding:       "?predBinding",
@@ -510,7 +513,7 @@ func TestConstructPredicateObjectPairString(t *testing.T) {
 				OAnchorBinding: "?Popeyes",
 				OTemporal:      true,
 			},
-			` ?predBinding "?predID"@[]] ?objBinding "?objID"[?Popeyes]`,
+			want: ` ?predBinding "?predID"@[]] ?objBinding "?objID"[?Popeyes]`,
 		},
 	}
 

--- a/bql/semantic/semantic_test.go
+++ b/bql/semantic/semantic_test.go
@@ -17,6 +17,7 @@ package semantic
 import (
 	"reflect"
 	"testing"
+	"time"
 
 	"github.com/google/badwolf/triple"
 	"github.com/google/badwolf/triple/literal"
@@ -93,6 +94,132 @@ func TestStatementAddData(t *testing.T) {
 	st.AddData(tr)
 	if got, want := st.Data(), []*triple.Triple{tr}; !reflect.DeepEqual(got, want) {
 		t.Errorf("semantic.AddData returned the wrong data available; got %v, want %v", got, want)
+	}
+}
+
+func TestGraphClauseString(t *testing.T) {
+	timeObj1 := time.Date(2019, 11, 20, 2, 30, 10, 5, time.UTC)
+	timeObj2 := time.Date(2019, 12, 3, 5, 40, 20, 7, time.UTC)
+	timeObj3 := time.Date(2019, 11, 30, 22, 10, 50, 3, time.UTC)
+	timeObj4 := time.Date(2019, 12, 2, 17, 0, 10, 15, time.UTC)
+	// Testing that NewNodeFromStrings is not the point of this package. Taking the example from the unit tests.
+	n, _ := node.NewNodeFromStrings("/some/type", "id_1")
+	// Testing NewImmutable is not the point of this package.
+	immutFoo, _ := predicate.NewImmutable("foo")
+	nO, _ := node.NewNodeFromStrings("/some/other/type", "id_2")
+	o := triple.NewNodeObject(nO)
+	table := []struct {
+		gc   *GraphClause
+		want string
+	}{
+		{&GraphClause{}, `{ opt=false @[][] }`},
+		{
+			&GraphClause{
+				Optional:         true,
+				S:                n,
+				SBinding:         "?nBinding",
+				SAlias:           "?nAlias",
+				STypeAlias:       "?nTypeAlias",
+				SIDAlias:         "?nIDAlias",
+				P:                immutFoo,
+				PID:              "?predID",
+				PBinding:         "?predBinding",
+				PAlias:           "?predAlias",
+				PIDAlias:         "?predIDAlias",
+				PAnchorBinding:   "?predAnchorBinding",
+				PAnchorAlias:     "?predAnchorAlias",
+				PLowerBound:      &timeObj1,
+				PUpperBound:      &timeObj2,
+				PLowerBoundAlias: "?earlyYesterday",
+				PUpperBoundAlias: "?someTimeInTheFuture",
+				PTemporal:        true,
+				O:                o,
+				OBinding:         "?objBinding",
+				OAlias:           "?objAlias",
+				OID:              "?objID",
+				OTypeAlias:       "?objTypeAlias",
+				OIDAlias:         "?objCuteID",
+				OAnchorBinding:   "?Popeyes",
+				OAnchorAlias:     "?Olive",
+				OLowerBound:      &timeObj3,
+				OUpperBound:      &timeObj4,
+				OLowerBoundAlias: "?SometimeSoon",
+				OUpperBoundAlias: "?seemsSoFarAway",
+				OTemporal:        true,
+			},
+			`{ opt=true /some/type<id_1> AS ?nAlias TYPE ?nTypeAlias ID ?nIDAlias "foo"@[] ?predBinding "?predID" AS ?predAlias ID ?predIDAlias AT ?predAnchorAlias /some/other/type<id_2> AS ?objAlias TYPE ?objTypeAlias ID ?objCuteID AT ?Olive AS ?objAlias ID ?objCuteID }`,
+		},
+		{
+			&GraphClause{
+				Optional:         true,
+				S:                nil,
+				SBinding:         "?nBinding",
+				SAlias:           "?nAlias",
+				STypeAlias:       "?nTypeAlias",
+				SIDAlias:         "?nIDAlias",
+				P:                nil,
+				PID:              "?predID",
+				PBinding:         "?predBinding",
+				PAlias:           "?predAlias",
+				PIDAlias:         "?predIDAlias",
+				PAnchorBinding:   "?predAnchorBinding",
+				PAnchorAlias:     "?predAnchorAlias",
+				PLowerBound:      &timeObj1,
+				PUpperBound:      &timeObj2,
+				PLowerBoundAlias: "?earlyYesterday",
+				PUpperBoundAlias: "?someTimeInTheFuture",
+				PTemporal:        false,
+				O:                nil,
+				OAnchorBinding:   "?Popeyes",
+				OLowerBound:      &timeObj3,
+				OUpperBound:      &timeObj4,
+				OLowerBoundAlias: "?SometimeSoon",
+				OUpperBoundAlias: "?seemsSoFarAway",
+				OTemporal:        false,
+			},
+			`{ opt=true ?nBinding AS ?nAlias TYPE ?nTypeAlias ID ?nIDAlias ?predBinding "?predID"@[] AS ?predAlias ID ?predIDAlias AT ?predAnchorAlias[] }`,
+		},
+		{
+			&GraphClause{
+				Optional:         true,
+				S:                nil,
+				SBinding:         "?nBinding",
+				SAlias:           "?nAlias",
+				STypeAlias:       "?nTypeAlias",
+				SIDAlias:         "?nIDAlias",
+				P:                nil,
+				PID:              "?predID",
+				PBinding:         "?predBinding",
+				PAlias:           "?predAlias",
+				PIDAlias:         "?predIDAlias",
+				PAnchorBinding:   "?predAnchorBinding",
+				PAnchorAlias:     "?predAnchorAlias",
+				PLowerBound:      &timeObj1,
+				PUpperBound:      &timeObj2,
+				PLowerBoundAlias: "?earlyYesterday",
+				PUpperBoundAlias: "?someTimeInTheFuture",
+				PTemporal:        true,
+				O:                nil,
+				OBinding:         "?objBinding",
+				OAlias:           "?objAlias",
+				OID:              "?objID",
+				OTypeAlias:       "?objTypeAlias",
+				OIDAlias:         "?objCuteID",
+				OAnchorAlias:     "?Olive",
+				OLowerBound:      &timeObj3,
+				OUpperBound:      &timeObj4,
+				OLowerBoundAlias: "?SometimeSoon",
+				OUpperBoundAlias: "?seemsSoFarAway",
+				OTemporal:        true,
+			},
+			`{ opt=true ?nBinding AS ?nAlias TYPE ?nTypeAlias ID ?nIDAlias ?predBinding "?predID"@[?predAnchorBinding at ?predAnchorAlias] AS ?predAlias ID ?predIDAlias AT ?predAnchorAlias ?objBinding "?objID"[2019-11-30T22:10:50.000000003Z,2019-12-02T17:00:10.000000015Z] AS ?objAlias TYPE ?objTypeAlias ID ?objCuteID AT ?Olive AS ?objAlias ID ?objCuteID }`,
+		},
+	}
+
+	for i, entry := range table {
+		if got, want := entry.gc.String(), entry.want; got != want {
+			t.Errorf("[case %d] failed; got %v, want %v", i, got, want)
+		}
 	}
 }
 

--- a/triple/node/node.go
+++ b/triple/node/node.go
@@ -76,7 +76,15 @@ func (n *Node) ID() *ID {
 
 // String returns a pretty printing representation of Node.
 func (n *Node) String() string {
-	return fmt.Sprintf("%s<%s>", n.t.String(), n.id.String())
+	nodeType := ""
+	if n.t != nil {
+		nodeType = n.t.String()
+	}
+	nodeID := ""
+	if n.id != nil {
+		nodeID = n.id.String()
+	}
+	return fmt.Sprintf("%s<%s>", nodeType, nodeID)
 }
 
 // Parse returns a node given a pretty printed representation of a Node or a BlankNode.

--- a/triple/node/node_test.go
+++ b/triple/node/node_test.go
@@ -101,6 +101,23 @@ func TestNewNodeFromString(t *testing.T) {
 		t.Errorf("node.h Covariant: %q should not be market as covariant of %q", nB, nA)
 	}
 }
+func TestNodeString(t *testing.T) {
+	// NewNodeFromString's error output has already been tested in its own dedicated unit tests
+	nA, _ := NewNodeFromStrings("/some/type", "id_1")
+	table := []struct {
+		n    *Node
+		want string
+	}{
+		// Do not crash on unitialize node
+		{&Node{}, "<>"},
+		{nA, "/some/type<id_1>"},
+	}
+	for i, entry := range table {
+		if got, want := entry.n.String(), entry.want; got != want {
+			t.Errorf("[case %d] failed; got %v, want %v", i, got, want)
+		}
+	}
+}
 
 func TestParse(t *testing.T) {
 	table := []struct {

--- a/triple/node/node_test.go
+++ b/triple/node/node_test.go
@@ -101,17 +101,20 @@ func TestNewNodeFromString(t *testing.T) {
 		t.Errorf("node.h Covariant: %q should not be market as covariant of %q", nB, nA)
 	}
 }
+
 func TestNodeString(t *testing.T) {
 	// NewNodeFromString's error output has already been tested in its own dedicated unit tests
 	nA, _ := NewNodeFromStrings("/some/type", "id_1")
+
 	table := []struct {
 		n    *Node
 		want string
 	}{
 		// Do not crash on unitialize node
-		{&Node{}, "<>"},
-		{nA, "/some/type<id_1>"},
+		{n: &Node{}, want: "<>"},
+		{n: nA, want: "/some/type<id_1>"},
 	}
+
 	for i, entry := range table {
 		if got, want := entry.n.String(), entry.want; got != want {
 			t.Errorf("[case %d] failed; got %v, want %v", i, got, want)


### PR DESCRIPTION
Hi guys,

In the current `ConstructPredicateObjectPair.String()` when we look for an object binding, whether `c.O` is nil or not we set object to true meaning that we just never enter the Predicate portion.

This will lead to only partially returning the representation of the object (leaving out the ID an the anchorBinding).

Plus in the predicate portion we already take care of printing the binding so basically it's doing twice the same thing.

Joseph 