### PR TITLE
Update and fix typos in the bql documentation

### DIFF
--- a/docs/bql.md
+++ b/docs/bql.md
@@ -21,21 +21,21 @@ graphs:
 * _Create_: Creates a new graph in the store you are connected to.
 * _Drop_: Drops an existing graph in the store you are connected to.
 * _Shows_: Shows the list of available graphs.
-* _Select_: Allows querying data form one or more graphs.
-* _Insert_: Allows inserting data form one or more graphs.
-* _Delete_: Allows deleting data form one or more graphs.
+* _Select_: Allows querying data from one or more graphs.
+* _Insert_: Allows inserting data from one or more graphs.
+* _Delete_: Allows deleting data from one or more graphs.
 * _Construct_: Allows creating new statements into graphs by querying existing statements.
-* _Destruct_: Allows remove statements from graphs by querying existing statements.
+* _Destruct_: Allows removing statements from graphs by querying existing statements.
 
 Currently _insert_ and _delete_ operations require you to explicitly state
 the fully qualified triple. In its current form it is not intended to deal with
-large data manipulation. Also they do not allow  use queries as sources of
+large data manipulation. Also they do not allow to use queries as sources of
 the triples to insert or delete.
 
 ## Creating a New Graph
 
 All data in BadWolf is stored in graphs. Graph need to be explicitly created.
-The ```CREATE``` graph statement allows you to create a graph as shown below.
+The `CREATE` graph statement allows you to create a graph as shown below.
 
 ```
 CREATE GRAPH ?a;
@@ -43,7 +43,7 @@ CREATE GRAPH ?a;
 
 The name of the graph is represented by a non interpreted binding (more on
 this will be discussed in the next section.) Hence, in the previous example
-the statement would create a graph named ```?a```. You can create multiple
+the statement would create a graph named `?a`. You can create multiple
 graphs in a single statement as shown in the example below.
 
 ```
@@ -58,7 +58,7 @@ the rest.
 
 ## Dropping an Existing Graph
 
-Existing graphs can be dropped via the ```DROP``` statement. Be *very*
+Existing graphs can be dropped via the `DROP` statement. Be *very*
 *careful* when dropping graphs. The operation is assumed to be irreversible.
 Hence, all data contained in the graph with be lost. You can drop a graph via:
 
@@ -76,7 +76,7 @@ The same consideration about failures on graph creation apply to dropping
 graphs. If you try to drop a graph that does not exist, it will fail saying that
 the graph does not exist. You should not expect dropping multiple graphs to be
 atomic. If one of the graphs fails, there is no guarantee that others will have
-been created, usually failing fast and not even attempting to create the rest.
+been dropped, usually failing fast and not even attempting to drop the rest.
 
 ## Listing all the available graphs
 
@@ -92,12 +92,12 @@ store.
 
 ## Bindings and Graph Patterns
 
-BQL relies on the concept of binding, or a place holder to represent a value.
+BQL relies on the concept of binding, or a placeholder to represent a value.
 Bindings can be read as immutable variables given scoped context. Bindings
-start with a '?' and are followed by letters or digits. Some examples of
-bindings are: ```?foo```, ```?bar```, ```?id12```.
+start with a `?` and are followed by letters or digits. Some examples of
+bindings are: `?foo`, `?bar`, `?id12`.
 
-Bindings, once they take a value in a context, cannot bind to a different
+Once a binding takes a value in a context, cannot bind to a different
 value. Bindings allow expression of graph matching patterns. The simplest form
 of a graph pattern is the fully specified triple.
 
@@ -134,45 +134,46 @@ second pattern asks if Joe ever followed Mary after a certain date, as opposed
 to the third pattern that asks if Joe ever followed Mary before a certain date.
 Finally, the fourth pattern asks if Joe followed Mary between two specific dates.
 
-Bindings represent potential values in a given context. For instance,
+Bindings represent potential values in a given context. For instance:
 
 ```
   /user<Joe> "follows"@[,] ?user
 ```
 
 represents a pattern that matches against all the users that Joe followed ever.
-As opposed to
+As opposed to:
 
 ```
   ?user "follows"@[,] /user<Mary>
 ```
 
-which represents all the users that ever followed Mary. You could also ask about
-all the predicates about Joe related to Mary, we would just write
+which represents all the users that ever followed Mary.
+
+You could also ask about all the predicates about Joe related to Mary, we would just write:
 
 ```
   /user<Joe> ?p /user<Mary>
 ```
 
-Where ?p represents all possible predicates. Bindings become more interesting
+Where `?p` represents all possible predicates. Bindings become more interesting
 when we start building complex graph patterns that contain more than one clause.
 Imagine you want to get the list of all users that are grandparents. You could
-express such pattern as
+express such pattern as:
 
 ```
   ?grandparent "parent_of"@[] ?x . ?x "parent_of"@[] ?grand_child
 ```
 
-You can combine multiple graph patterns together using '.' to separate clauses.
+You can combine multiple graph patterns together using `.` to separate clauses.
 The important thing to keep in mind is that the above composite clause
-represents a single context. That means that ?x is a binding that once
+represents a single context. That means that `?x` is a binding that, once
 instantiated, cannot change the value in that context. Imagine Joe is the
 parent of Peter and Peter is the parent of Mary. Once the first part of the
-clause is matched against Joe as the parent of Peter, ```?grandparent``` gets
-bound against Joe and ```?x``` against Peter. To satisfy the second part of
+clause is matched against Joe as the parent of Peter, `?grandparent` gets
+bound against Joe and `?x` against Peter. To satisfy the second part of
 the composite clause, we now need to find triples where the subject is Peter
 (remember that once the value is bound in a context it cannot change) and the
-predicate is parent of. If one exists, then ```?grand_child``` would get bound
+predicate is parent of. If one exists, then `?grand_child` would get bound
 and take the value of Mary.
 
 As we will see in later examples, bindings can also be used to identify
@@ -180,8 +181,8 @@ nodes, literals, predicates, or time anchors.
 
 ## Querying Data from graphs
 
-Querying data in BQL is done via the ```select``` statement. The simple form
-of a query is expressed as follows
+Querying data in BQL is done via the `SELECT` statement. The simple form
+of a query is expressed as follows:
 
 ```
   SELECT ?grand_child
@@ -192,10 +193,11 @@ of a query is expressed as follows
 ```
 
 The above query would return all the grandchildren of Joe. BQL uses binding
-notation to identify a graph to use. It uses the '?' to indicate the name
+notation to identify a graph to use. It uses the `?` to indicate the name
 of the graph. In the above example that query would be run against a graph
-which ID is equal to "?family_tree". You can also query against multiple
-graphs.
+which ID is equal to `?family_tree`.
+
+You can also query against multiple graphs:
 
 ```
   SELECT ?grand_child
@@ -219,7 +221,7 @@ variables instead as shown below.
 The above query would return all grandparents together with the name of their
 grandchildren, one pair per row. In some cases it is useful to return a different
 name for the variables, and not use the biding name used in the graph pattern
-directly. This is achieved using the "as" keyword as shown below.
+directly. This is achieved using the `as` keyword as shown below.
 
 ```
   SELECT ?grandparent as ?gp, ?grand_child as ?gc
@@ -233,7 +235,7 @@ It is important to note that aliases are defined outside the graph pattern scope
 Hence, aliases cannot be used in graph patterns.
 
 BQL supports basic grouping and aggregation. It is accomplished via
-```group by```. The above query may return duplicates depending on the data
+`group by`. The above query may return duplicates depending on the data
 available on the graph. If we want to get rid of the duplicates we could just
 group them as follows.
 
@@ -247,8 +249,8 @@ group them as follows.
 ```
 
 As you may have expected, you can group by multiple bindings or aliases. Also,
-grouping allows a small subset of aggregates. Those include ```count``` its
-variant with distinct, and ```sum```. Other functions will be added as needed.
+grouping allows a small subset of aggregates. Those include `count` its
+variant with `distinct`, and `sum`. Other functions will be added as needed.
 The queries below illustrate how these simple aggregations can be used.
 
 ```
@@ -263,7 +265,7 @@ The queries below illustrate how these simple aggregations can be used.
 Would return the number of grandchildren per grandparent. However, it would
 be better if the distinct version was used to guaranteed that all duplicates
 resulting on the graph data are removed. The query below illustrates how
-the distinct variant work.
+the `distinct` variant work.
 
 ```
   SELECT ?grandparent as ?gp, count(distinct ?grand_child) as ?gc
@@ -275,18 +277,18 @@ the distinct variant work.
 ```
 
 The sum aggregation only works if the binding is done against a literal of type
-```int64``` or ```float64```, as shown on the example below.
+`int64` or `float64`, as shown on the example below.
 
 ```
   SELECT sum(?capacity) as ?total_capacity
   FROM ?gas_tanks
   WHERE {
     ?tank "capacity"@[] ?capacity
-  }
+  };
 ```
 
-You can also use ```sum``` to do partial accumulations in the same manner as was
-done in the ```count``` examples above.
+You can also use `sum` to do partial accumulations in the same manner as was
+done in the `count` examples above.
 
 Results of the query can be sorted. By default, it is sorted in ascending
 order based on the provided variables. The example below orders first by
@@ -302,7 +304,7 @@ descending based on the grandchild name.
   ORDER BY ?grandparent, ?grand_child DESC;
 ```
 
-The "having" modifier allows us to filter the returned data further. For
+The `having` modifier allows us to filter the returned data further. For
 instance, the query below would only return tanks with a capacity bigger
 than 10.
 
@@ -332,7 +334,7 @@ The above query would return at most only 20 rows.
 
 BQL also provides syntactic sugar to make ease specifying time bounds. Imagine
 you want to get all users who followed Joe and also followed Mary after a
-certain date. You could write it as
+certain date. You could write it as:
 
 ```
   SELECT ?user
@@ -340,13 +342,14 @@ certain date. You could write it as
   WHERE {
     ?user "folows"@[2006-01-01T15:04:05.999999999Z07:00,] /user<Joe> .
     ?user "folows"@[2006-01-01T15:04:05.999999999Z07:00,] /user<Mary>
-  }
+  };
 ```
+
 You can also imagine that this can become tedious fast if your graph pattern
 contains multiple clauses. BQL allows you to specify it in a more compact and
-readable form using composable ```before```, ```after```, and ```between```
-keywords. They can be composed together using ```not```, ```and```, and
-```or``` operators.
+readable form using composable `before`, `after`, and `between`
+keywords. They can be composed together using `not`, `and`, and
+`or` operators.
 
 ```
   SELECT ?user
@@ -355,7 +358,7 @@ keywords. They can be composed together using ```not```, ```and```, and
     ?user "folows"@[,] /user<Joe> .
     ?user "folows"@[,] /user<Mary>
   }
-  AFTER 2006-01-01T15:04:05.999999999Z07:00
+  AFTER 2006-01-01T15:04:05.999999999Z07:00;
 ```
 
 This is easier to read. It also allow expressing complex global time bounds
@@ -369,12 +372,12 @@ that would require multiple clauses and extra bindings.
     ?user "folows"@[,] /user<Mary>
   }
   AFTER 2006-01-01T15:04:05.999999999Z07:00 OR
-  BETWEEN 2004-01-01T15:04:05.999999999Z07:00, 2004-03-01T15:04:05.999999999Z07:00
+  BETWEEN 2004-01-01T15:04:05.999999999Z07:00, 2004-03-01T15:04:05.999999999Z07:00;
 ```
 
 Also remember that bindings may take time anchor values so you could also query
 for all users that first followed Joe and then followed Mary. Such query would
-look like
+look like:
 
 ```
   SELECT ?user, ?tj, ?tm
@@ -389,7 +392,7 @@ look like
 ## Inserting data into graphs
 
 Triples can be inserted into one or more graphs. This can be achieved by
-running the following insert statements.
+running the following insert statements:
 
 ```
   INSERT DATA INTO ?family_tree, ?other_family_tree {
@@ -404,8 +407,8 @@ with the driver implementation.
 
 ## Deleting data from graphs
 
-Triples can be deleted from one or more graphs. That can be achieve by just
-running the following delete statements.
+Triples can be deleted from one or more graphs. That can be achieved by just
+running the following delete statements:
 
 ```
   DELETE DATA FROM ?family_tree, ?other_family_tree {
@@ -438,11 +441,11 @@ illustrative example is:
 ```
 
 The above statement would copy all facts from graph `?src` to graph `?dest`.
-The where clause will bind to all available predicates. Each binding will
+The `WHERE` clause will bind to all available predicates. Each binding will
 then be used in the construct part to create the new triples.
 
 A more elaborate example would be to create a new fact `grandparent` into
-the destination graphs by properly extracting graph patterns via the `WHERE`
+the destination graph by properly extracting graph patterns via the `WHERE`
 clause.
 
 ```
@@ -465,7 +468,7 @@ clauses. All bindings from all graphs in the `FROM` clause are going to be
 gathered together. The new facts will be inserted into all the graphs
 indicated in the `INTO` list.
 
-Also, you can create multiple new facts based on the bindings.
+Also, you can create multiple new facts based on the bindings:
 
 ```
   CONSTRUCT {
@@ -504,7 +507,7 @@ live in the exact same city. Please note the `;` syntax. All partial
 statements after it will be attached to the reified statement.
 
 Another way to express the same fact is to use the explicit blank node
-notation. `CONSTRUCT` supports the following.
+notation. `CONSTRUCT` supports the following:
 
 ```
   CONSTRUCT {
@@ -536,7 +539,7 @@ Example of multiple blank nodes generated at once are `_:v0`, `_:v1`, etc.
 ## Removing complex facts out of existing graphs using existing statements
 
 In some cases you want to create remove facts--remove existing triples---in an
-existing graph or graphs based on facts existing on the same or other graphs. 
+existing graph or graphs based on facts existing on the same or other graphs.
 Deconstructing facts requires two steps: (1) querying for the information that
 is going to be used to remove facts, and (2) how the facts to be removed are
 going to be assembled. An illustrative example is:
@@ -576,6 +579,6 @@ clause.
 
 The `DECONSTRUCT` statement does not support neither the blank node notation
 nor the reification syntax. Those are used to refer to newly created nodes
-introduced by the statement, which makes sends on `CONSTRUCT` statements.
-However, `DECONSTRUTC` statements already have all the required information
+introduced by the statement, which makes sense on `CONSTRUCT` statements.
+However, `DECONSTRUCT` statements already have all the required information
 to assemble the triples to remove.


### PR DESCRIPTION
Hi,

This PR fix a few typos and tries to get a more homogeneous usage of backticks and `:` in the BQL documentation (Pretty nice doc by the way! :wink:  ).
Let me know if you want some of these suggestions changed.

Thanks,
Joseph