### PR TITLE
Fix syntax parsing of BEFORE, AFTER and BETWEEN clauses

### DIFF
--- a/bql/grammar/grammar.go
+++ b/bql/grammar/grammar.go
@@ -775,9 +775,7 @@ func BQL() *Grammar {
 			{
 				Elements: []Element{
 					NewTokenType(lexer.ItemBetween),
-					NewTokenType(lexer.ItemPredicate),
-					NewTokenType(lexer.ItemComma),
-					NewTokenType(lexer.ItemPredicate),
+					NewTokenType(lexer.ItemPredicateBound),
 				},
 			},
 			{},

--- a/bql/grammar/grammar_test.go
+++ b/bql/grammar/grammar_test.go
@@ -78,9 +78,9 @@ func TestAcceptByParse(t *testing.T) {
 		`select ?a from ?b where {?a ?p ?o} having (?b and ?b) or not (?b = ?b);`,
 		`select ?a from ?b where {?a ?p ?o} having ((?b and ?b) or not (?b = ?b));`,
 		// Test global time bounds.
-		`select ?a from ?b where {?s ?p ?o} before ""@["123"];`,
-		`select ?a from ?b where {?s ?p ?o} after ""@["123"];`,
-		`select ?a from ?b where {?s ?p ?o} between ""@["123"], ""@["123"];`,
+		`select ?a from ?b where {?s ?p ?o} before 2006-01-01T15:04:05.999999999Z07:00;`,
+		`select ?a from ?b where {?s ?p ?o} after 2006-02-03T15:04:05.999999999Z07:00;`,
+		`select ?a from ?b where {?s ?p ?o} between 2006-01-01T15:04:05.999999999Z07:00, 2006-02-03T15:04:05.999999999Z07:00;`,
 		// Test limit clause.
 		`select ?a from ?b where {?s ?p ?o} limit "10"^^type:int64;`,
 		// Test optional clauses.
@@ -229,11 +229,10 @@ func TestRejectByParse(t *testing.T) {
 		// Reject invalid global time bounds.
 		`select ?a from ?b where {?s ?p ?o} before ;`,
 		`select ?a from ?b where {?s ?p ?o} after ;`,
-		`select ?a from ?b where {?s ?p ?o} between "foo"@["123"], ;`,
-		`select ?a from ?b where {?s ?p ?o} before "foo"@["123"]);`,
-		`select ?a from ?b where {?s ?p ?o} before "foo"@["123"]  before "foo"@["123"];`,
-		`select ?a from ?b where {?s ?p ?o} before "foo"@["123"] or before "foo"@["123"] ,;`,
-		`select ?a from ?b where {?s ?p ?o} before "foo"@["123"] or before "foo"@["123"] and before "foo"@["123"]);`,
+		`select ?a from ?b where {?s ?p ?o} between 0101;`,
+		`select ?a from ?b where {?s ?p ?o} before 2006-01-01T15:04:05.999999999Z07:00  before 2006-01-01T15:04:05.999999999Z07:00;`,
+		`select ?a from ?b where {?s ?p ?o} before 2006-01-01T15:04:05.999999999Z07:00 or before 2006-01-01T15:04:05.999999999Z07:00 ,;`,
+		`select ?a from ?b where {?s ?p ?o} before 2006-01-01T15:04:05.999999999Z07:00 or before 2006-01-01T15:04:05.999999999Z07:00 and before 2006-01-01T15:04:05.999999999Z07:00);`,
 		// Test limit clause.
 		`select ?a from ?b where {?s ?p ?o} limit ?b;`,
 		`select ?a from ?b where {?s ?p ?o} limit ;`,

--- a/bql/planner/planner_test.go
+++ b/bql/planner/planner_test.go
@@ -437,17 +437,17 @@ func TestPlannerQuery(t *testing.T) {
 			nrws: 2,
 		},
 		{
-			q:    `select ?o from ?test where {/u<peter> "bought"@[2015-01-01T00:00:00-08:00,2017-01-01T00:00:00-08:00] ?o} before ""@[2014-01-01T00:00:00-08:00];`,
+			q:    `select ?o from ?test where {/u<peter> "bought"@[2015-01-01T00:00:00-08:00,2017-01-01T00:00:00-08:00] ?o} before 2014-01-01T00:00:00-08:00;`,
 			nbs:  1,
 			nrws: 0,
 		},
 		{
-			q:    `select ?o from ?test where {/u<peter> "bought"@[2015-01-01T00:00:00-08:00,2017-01-01T00:00:00-08:00] ?o} after ""@[2017-01-01T00:00:00-08:00];`,
+			q:    `select ?o from ?test where {/u<peter> "bought"@[2015-01-01T00:00:00-08:00,2017-01-01T00:00:00-08:00] ?o} after 2017-01-01T00:00:00-08:00;`,
 			nbs:  1,
 			nrws: 0,
 		},
 		{
-			q:    `select ?o from ?test where {/u<peter> "bought"@[2015-01-01T00:00:00-08:00,2017-01-01T00:00:00-08:00] ?o} between ""@[2014-01-01T00:00:00-08:00], ""@[2017-01-01T00:00:00-08:00];`,
+			q:    `select ?o from ?test where {/u<peter> "bought"@[2015-01-01T00:00:00-08:00,2017-01-01T00:00:00-08:00] ?o} between 2014-01-01T00:00:00-08:00, 2017-01-01T00:00:00-08:00;`,
 			nbs:  1,
 			nrws: 4,
 		},

--- a/bql/semantic/hooks_test.go
+++ b/bql/semantic/hooks_test.go
@@ -1801,7 +1801,7 @@ func TestCollectGlobalBounds(t *testing.T) {
 	if err != nil {
 		t.Fatalf("time.Parse failed to parse valid time %s with error %v", date, err)
 	}
-	pretty, invalid := fmt.Sprintf("\"\"@[%s]", date), fmt.Sprintf("\"INVALID\"@[%s]", date)
+	pretty, invalid := date, fmt.Sprintf("\"INVALID\"@[%s]", date)
 	testTable := []struct {
 		id   string
 		in   []ConsumedElement
@@ -1855,17 +1855,8 @@ func TestCollectGlobalBounds(t *testing.T) {
 				}),
 				NewConsumedSymbol("FOO"),
 				NewConsumedToken(&lexer.Token{
-					Type: lexer.ItemPredicate,
-					Text: pretty,
-				}),
-				NewConsumedSymbol("FOO"),
-				NewConsumedToken(&lexer.Token{
-					Type: lexer.ItemComma,
-				}),
-				NewConsumedSymbol("FOO"),
-				NewConsumedToken(&lexer.Token{
-					Type: lexer.ItemPredicate,
-					Text: pretty,
+					Type: lexer.ItemPredicateBound,
+					Text: fmt.Sprintf("%s, %s", date, date),
 				}),
 				NewConsumedSymbol("FOO"),
 			},
@@ -1916,17 +1907,24 @@ func TestCollectGlobalBounds(t *testing.T) {
 				}),
 				NewConsumedSymbol("FOO"),
 				NewConsumedToken(&lexer.Token{
-					Type: lexer.ItemPredicate,
-					Text: pretty,
+					Type: lexer.ItemPredicateBound,
+					Text: fmt.Sprintf("%s, notADate", date),
+				}),
+				NewConsumedSymbol("FOO"),
+			},
+			fail: true,
+		},
+		{
+			id: "between X, NO_UPPER_BOUND",
+			in: []ConsumedElement{
+				NewConsumedSymbol("FOO"),
+				NewConsumedToken(&lexer.Token{
+					Type: lexer.ItemBetween,
 				}),
 				NewConsumedSymbol("FOO"),
 				NewConsumedToken(&lexer.Token{
-					Type: lexer.ItemComma,
-				}),
-				NewConsumedSymbol("FOO"),
-				NewConsumedToken(&lexer.Token{
-					Type: lexer.ItemPredicate,
-					Text: invalid,
+					Type: lexer.ItemPredicateBound,
+					Text: fmt.Sprintf("%s, ", date),
 				}),
 				NewConsumedSymbol("FOO"),
 			},


### PR DESCRIPTION
As @xllora and @rbkloss were discussing about in #90 , the current syntax for the AFTER block does not reflect what the doc says it's supposed to be.

In fact the problem extends to the BEFORE and BETWEEN clauses too.

This PR changes the lexer and hook to behave as expected for those 3 clauses.

Note: I haven't added unit tests specific to the new lexer function as I think the higher level tests at the grammar and planner level already catch that but I can add more tests there if needed. Just let me know.

Closes: #90 