### PR TITLE
Run the bql examples as part of the CI process

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,6 +32,9 @@ jobs:
     - name: Run go test
       run: go test -v -race -coverprofile=coverage.txt -covermode=atomic ./...
 
+    - name: Run go examples
+      run: go test ./... && go build ./tools/vcli/bw && for f in ./examples/bql/*.bql; do ./bw run $f || break; done
+
   # On Windows, just run the local tests.  Don't bother with checking gofmt, go vet
   windows:
     strategy:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -33,7 +33,7 @@ jobs:
       run: go test -v -race -coverprofile=coverage.txt -covermode=atomic ./...
 
     - name: Run go examples
-      run: go test ./... && go build ./tools/vcli/bw && for f in ./examples/bql/*.bql; do ./bw run $f || break; done
+      run: go test ./... && go build ./tools/vcli/bw && for f in ./examples/bql/*.bql; do ./bw run $f || exit 1; done
 
   # On Windows, just run the local tests.  Don't bother with checking gofmt, go vet
   windows:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,7 +32,7 @@ jobs:
     - name: Run go test
       run: go test -v -race -coverprofile=coverage.txt -covermode=atomic ./...
 
-    - name: Run examples in the bw command-line tool
+    - name: Run the bql examples in the bw command-line tool
       run: go build ./tools/vcli/bw && for f in ./examples/bql/*.bql; do ./bw run $f || exit 1; done
 
   # On Windows, just run the local tests.  Don't bother with checking gofmt, go vet

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,7 +32,7 @@ jobs:
     - name: Run go test
       run: go test -v -race -coverprofile=coverage.txt -covermode=atomic ./...
 
-    - name: Run go examples
+    - name: Run examples in the bw command-line tool
       run: go test ./... && go build ./tools/vcli/bw && for f in ./examples/bql/*.bql; do ./bw run $f || exit 1; done
 
   # On Windows, just run the local tests.  Don't bother with checking gofmt, go vet

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,8 +32,11 @@ jobs:
     - name: Run go test
       run: go test -v -race -coverprofile=coverage.txt -covermode=atomic ./...
 
-    - name: Run examples in the bw command-line tool
+    - name: Run the bql examples in the bw command-line tool
       run: go build ./tools/vcli/bw && for f in ./examples/bql/*.bql; do ./bw run $f || exit 1; done
+
+    - name: Run the compliance examples in the bw command-line tool
+      run: go build ./tools/vcli/bw && bw assert examples/compliance
 
   # On Windows, just run the local tests.  Don't bother with checking gofmt, go vet
   windows:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,11 +32,8 @@ jobs:
     - name: Run go test
       run: go test -v -race -coverprofile=coverage.txt -covermode=atomic ./...
 
-    - name: Run the bql examples in the bw command-line tool
+    - name: Run examples in the bw command-line tool
       run: go build ./tools/vcli/bw && for f in ./examples/bql/*.bql; do ./bw run $f || exit 1; done
-
-    - name: Run the compliance examples in the bw command-line tool
-      run: go build ./tools/vcli/bw && bw assert examples/compliance
 
   # On Windows, just run the local tests.  Don't bother with checking gofmt, go vet
   windows:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -33,7 +33,7 @@ jobs:
       run: go test -v -race -coverprofile=coverage.txt -covermode=atomic ./...
 
     - name: Run examples in the bw command-line tool
-      run: go test ./... && go build ./tools/vcli/bw && for f in ./examples/bql/*.bql; do ./bw run $f || exit 1; done
+      run: go build ./tools/vcli/bw && for f in ./examples/bql/*.bql; do ./bw run $f || exit 1; done
 
   # On Windows, just run the local tests.  Don't bother with checking gofmt, go vet
   windows:

--- a/bql/table/table.go
+++ b/bql/table/table.go
@@ -231,7 +231,7 @@ func (t *Table) AppendTable(t2 *Table) error {
 		return nil
 	}
 	if len(t.AvailableBindings) > 0 && !equalBindings(t.mbs, t2.mbs) {
-		return fmt.Errorf("AppendTable can only append to an empty table or equally binded table; instead got %v and %v", t.AvailableBindings, t2.AvailableBindings)
+		return fmt.Errorf("AppendTable can only append to an empty table or equally binded table; intead got %v and %v", t.AvailableBindings, t2.AvailableBindings)
 	}
 	if len(t.AvailableBindings) == 0 {
 		t.AvailableBindings, t.mbs = t2.AvailableBindings, t2.mbs

--- a/bql/table/table.go
+++ b/bql/table/table.go
@@ -231,7 +231,7 @@ func (t *Table) AppendTable(t2 *Table) error {
 		return nil
 	}
 	if len(t.AvailableBindings) > 0 && !equalBindings(t.mbs, t2.mbs) {
-		return fmt.Errorf("AppendTable can only append to an empty table or equally binded table; intead got %v and %v", t.AvailableBindings, t2.AvailableBindings)
+		return fmt.Errorf("AppendTable can only append to an empty table or equally binded table; instead got %v and %v", t.AvailableBindings, t2.AvailableBindings)
 	}
 	if len(t.AvailableBindings) == 0 {
 		t.AvailableBindings, t.mbs = t2.AvailableBindings, t2.mbs


### PR DESCRIPTION
This change adds the build of the bw command-line tool and the execution of the bql examples against it.
This gives us higher level testing capabilities for the CI.