### PR TITLE
Abort early on pre-existing failures in filterOnExistence

### DIFF
--- a/bql/planner/planner.go
+++ b/bql/planner/planner.go
@@ -517,7 +517,7 @@ func (p *queryPlan) filterOnExistence(ctx context.Context, cls *semantic.GraphCl
 	grp, gCtx := errgroup.WithContext(ctx)
 	for _, tmp := range data {
 		if gCtx.Err() != nil {
-			// Fail fast (in case another goroutine alredy failed, just abort)
+			// Fail fast by not processing more record (in case another goroutine alredy failed, just abort)
 			break
 		}
 		r := tmp

--- a/bql/planner/planner.go
+++ b/bql/planner/planner.go
@@ -522,7 +522,7 @@ func (p *queryPlan) filterOnExistence(ctx context.Context, cls *semantic.GraphCl
 		}
 		r := tmp
 		cls := ocls
-		grp.Go(func() error {	
+		grp.Go(func() error {
 			sbj, prd, obj := cls.S, cls.P, cls.O
 			// Attempt to rebind the subject.
 			if sbj == nil && p.tbl.HasBinding(cls.SBinding) {


### PR DESCRIPTION
Hi,

Currently we use the context of the errgroup only when checking the existence of the inputgraph (note: we don't seem to be doing anything with it concretely in the Exist method but that's a story for another time) but previously we had some "fail-fast" logic to avoid executing code when a failure already occurred (as we only cared about the data if there is no error).
This change avoids starting goroutines if other routines already started and aborts the filtering when an error already occurred in the errgroup. This might make sense if the clients properly check the error output every time and should improve the performance if we parse a lot of data with errors found early on (aka the performance gain might be really random).


At the beginning I thought this was handled magically because of the presence of the context but it's not the case. Simple example: https://gist.github.com/aerostitch/ae7874b41076d61e3f4ecfef5761ad3e

Just let me know in case that is not a behavior we want anymore (aborting before all the filtering is done when at least 1 case failed).

Thanks,
Joseph