### PR TITLE
Add that the keywords AFTER, BEFORE and BETWEEN define closed intervals

### DIFF
--- a/bql/lexer/lexer.go
+++ b/bql/lexer/lexer.go
@@ -101,7 +101,7 @@ const (
 	ItemBlankNode
 	// ItemLiteral represents a BadWolf literal in BQL.
 	ItemLiteral
-	// ItemPredicate represents a BadWolf predicates in BQL.
+	// ItemPredicate represents a BadWolf predicate in BQL.
 	ItemPredicate
 	// ItemPredicateBound represents a BadWolf predicate bound in BQL.
 	ItemPredicateBound

--- a/docs/bql.md
+++ b/docs/bql.md
@@ -406,6 +406,10 @@ that would require multiple clauses and extra bindings:
   BETWEEN 2004-01-01T15:04:05.999999999Z07:00, 2004-03-01T15:04:05.999999999Z07:00;
 ```
 
+Note that the intervals defined by `before`, `after`, and `between` are always closed (the 
+limits of the intervals are included). You can then understand the `after` as a '>=', the 
+`before` as a `<=` and the `between` as a combination of them.
+
 Also, remember that bindings may take time anchor values so you could also query
 for all users that first followed Joe and then followed Mary. Such query would
 look like:

--- a/triple/predicate/predicate.go
+++ b/triple/predicate/predicate.go
@@ -146,7 +146,7 @@ func NewImmutable(id string) (*Predicate, error) {
 // NewTemporal creates a new temporal predicate.
 func NewTemporal(id string, t time.Time) (*Predicate, error) {
 	if id == "" {
-		return nil, fmt.Errorf("predicate.NewTemporal(%q, %v) cannot create a temporal predicate  with empty ID", id, t)
+		return nil, fmt.Errorf("predicate.NewTemporal(%q, %v) cannot create a temporal predicate with empty ID", id, t)
 	}
 	return &Predicate{
 		id:     ID(id),


### PR DESCRIPTION
When using the keywords `AFTER`, `BEFORE` and `BETWEEN` to filter triples based on time bounds, the intervals defined by these keywords are closed intervals, which means that the limits of those intervals are also included. The documentation should reflect this specification.