### PR TITLE
Fix support for comparison between ID/TYPE bindings and text literals inside HAVING clauses

### DIFF
--- a/bql/planner/planner_test.go
+++ b/bql/planner/planner_test.go
@@ -767,30 +767,30 @@ func TestPlannerQuery(t *testing.T) {
 
 		st := &semantic.Statement{}
 		if err := p.Parse(grammar.NewLLk(entry.q, 1), st); err != nil {
-			t.Errorf("Parser.consume: failed to parse query %q with error: %v", entry.q, err)
+			t.Errorf("parser.Parse(%s)\n= %v; want nil error", entry.q, err)
 		}
 		plnr, err := New(ctx, s, st, 0, 10, nil)
 		if err != nil {
-			t.Errorf("planner.New failed to create a valid query plan with error: %v", err)
+			t.Errorf("planner.New() = _, %v; want nil error", err)
 		}
 		tbl, err := plnr.Execute(ctx)
 		if !entry.wantErr && err != nil {
-			t.Errorf("planner.Execute failed for query %q with error: %v", entry.q, err)
+			t.Errorf("planner.Execute(%s)\n= _, %v; want nil error", entry.q, err)
 			continue
 		}
 		if entry.wantErr && err == nil {
-			t.Errorf("planner.Execute for query %q should have returned an error, but did not", entry.q)
+			t.Errorf("planner.Execute(%s)\n= _, nil; want non-nil error", entry.q)
 			continue
 		}
 		if entry.wantErr {
-			// an error was expected and it was indeed caught above.
+			// an error was expected and it was indeed caught.
 			continue
 		}
 		if got, want := len(tbl.Bindings()), entry.nbs; got != want {
-			t.Errorf("tbl.Bindings returned the wrong number of bindings for %q; got %d, want %d", entry.q, got, want)
+			t.Errorf("planner.Execute(%s)\n= a Table with %d bindings; want %d", entry.q, got, want)
 		}
 		if got, want := len(tbl.Rows()), entry.nrws; got != want {
-			t.Errorf("planner.Execute failed to return the expected number of rows for query %q; got %d want %d\nGot:\n%v\n", entry.q, got, want, tbl)
+			t.Errorf("planner.Execute(%s)\n= a Table with %d rows; want %d\nTable:\n%v\n", entry.q, got, want, tbl)
 		}
 	}
 }

--- a/bql/planner/planner_test.go
+++ b/bql/planner/planner_test.go
@@ -760,19 +760,21 @@ func TestPlannerQuery(t *testing.T) {
 	s, ctx := memory.NewStore(), context.Background()
 	populateStoreWithTriples(ctx, s, "?test", testTriples, t)
 	for _, entry := range testTable {
+		// Test setup:
 		p, err := grammar.NewParser(grammar.SemanticBQL())
 		if err != nil {
 			t.Fatalf("grammar.NewParser should have produced a valid BQL parser but got error: %v", err)
 		}
-
 		st := &semantic.Statement{}
 		if err := p.Parse(grammar.NewLLk(entry.q, 1), st); err != nil {
-			t.Errorf("parser.Parse(%s)\n= %v; want nil error", entry.q, err)
+			t.Fatalf("parser.Parse failed for query \"%s\"\nwith error: %v", entry.q, err)
 		}
 		plnr, err := New(ctx, s, st, 0, 10, nil)
 		if err != nil {
-			t.Errorf("planner.New() = _, %v; want nil error", err)
+			t.Fatalf("planner.New failed to create a valid query plan with error: %v", err)
 		}
+
+		// Actual test:
 		tbl, err := plnr.Execute(ctx)
 		if !entry.wantErr && err != nil {
 			t.Errorf("planner.Execute(%s)\n= _, %v; want nil error", entry.q, err)

--- a/bql/planner/planner_test.go
+++ b/bql/planner/planner_test.go
@@ -566,6 +566,26 @@ func TestPlannerQuery(t *testing.T) {
 			nbs:  2,
 			nrws: 4,
 		},
+		{
+			q: `SELECT ?s_id, ?height
+					FROM ?test
+					WHERE {
+						?s ID ?s_id "height_cm"@[] ?height
+					}
+					HAVING ?s_id = "alice"^^type:text;`,
+			nbs:  2,
+			nrws: 1,
+		},
+		{
+			q: `SELECT ?p_id, ?o
+					FROM ?test
+					WHERE {
+						/u<peter> ?p ID ?p_id ?o
+					}
+					HAVING ?p_id < "parent_of"^^type:text;`,
+			nbs:  2,
+			nrws: 4,
+		},
 	}
 
 	s, ctx := memory.NewStore(), context.Background()

--- a/bql/planner/planner_test.go
+++ b/bql/planner/planner_test.go
@@ -707,6 +707,50 @@ func TestPlannerQuery(t *testing.T) {
 			nbs:  2,
 			nrws: 7,
 		},
+		{
+			q: `SELECT ?p, ?p_id, ?o
+				FROM ?test
+				WHERE {
+					/u<peter> ?p ID ?p_id ?o
+				}
+				HAVING ?p_id = "bought"^^type:text
+				AFTER 2016-03-01T00:00:00-08:00;`,
+			nbs:  3,
+			nrws: 2,
+		},
+		{
+			q: `SELECT ?p, ?p_id, ?o
+				FROM ?test
+				WHERE {
+					/u<peter> ?p ID ?p_id ?o
+				}
+				HAVING ?p_id < "parent_of"^^type:text
+				BEFORE 2016-03-01T00:00:00-08:00;`,
+			nbs:  3,
+			nrws: 3,
+		},
+		{
+			q: `SELECT ?p, ?p_id, ?o
+				FROM ?test
+				WHERE {
+					/u<peter> ?p ID ?p_id ?o
+				}
+				HAVING ?p_id = "bought"^^type:text
+				BETWEEN 2016-02-01T00:00:00-08:00, 2016-03-01T00:00:00-08:00;`,
+			nbs:  3,
+			nrws: 2,
+		},
+		{
+			q: `SELECT ?p, ?p_id, ?o
+				FROM ?test
+				WHERE {
+					/u<peter> ?p ID ?p_id ?o
+				}
+				HAVING ?p_id < "work_with"^^type:text
+				BEFORE 2016-02-01T00:00:00-08:00;`,
+			nbs:  3,
+			nrws: 4,
+		},
 	}
 
 	s, ctx := memory.NewStore(), context.Background()

--- a/bql/planner/planner_test.go
+++ b/bql/planner/planner_test.go
@@ -685,6 +685,28 @@ func TestPlannerQuery(t *testing.T) {
 			nbs:  2,
 			nrws: 4,
 		},
+		{
+			q: `SELECT ?s, ?s_type
+				FROM ?test
+				WHERE {
+					?s TYPE ?s_type ?p ?o
+				}
+				HAVING ?s_type = "/c"^^type:text;`,
+			err:  false,
+			nbs:  2,
+			nrws: 4,
+		},
+		{
+			q: `SELECT ?s, ?s_type
+				FROM ?test
+				WHERE {
+					?s TYPE ?s_type ?p ?o
+				}
+				HAVING ?s_type < "/l"^^type:text;`,
+			err:  false,
+			nbs:  2,
+			nrws: 7,
+		},
 	}
 
 	s, ctx := memory.NewStore(), context.Background()

--- a/bql/planner/planner_test.go
+++ b/bql/planner/planner_test.go
@@ -108,7 +108,7 @@ func insertAndDeleteTest(t *testing.T) {
                                /_<foo> "bar"@[] "yeah"^^type:text};`
 	p, err := grammar.NewParser(grammar.SemanticBQL())
 	if err != nil {
-		t.Errorf("grammar.NewParser: should have produced a valid BQL parser, %v", err)
+		t.Errorf("grammar.NewParser should have produced a valid BQL parser but got error: %v", err)
 	}
 	stm := &semantic.Statement{}
 	if err = p.Parse(grammar.NewLLk(bql, 1), stm); err != nil {
@@ -145,7 +145,7 @@ func insertAndDeleteTest(t *testing.T) {
 			      /_<foo> "bar"@[] "yeah"^^type:text};`
 	p, err = grammar.NewParser(grammar.SemanticBQL())
 	if err != nil {
-		t.Errorf("grammar.NewParser: should have produced a valid BQL parser, %v", err)
+		t.Errorf("grammar.NewParser should have produced a valid BQL parser but got error: %v", err)
 	}
 	stm = &semantic.Statement{}
 	if err = p.Parse(grammar.NewLLk(bql, 1), stm); err != nil {
@@ -194,7 +194,7 @@ func TestPlannerCreateGraph(t *testing.T) {
 	bql := `create graph ?foo, ?bar;`
 	p, err := grammar.NewParser(grammar.SemanticBQL())
 	if err != nil {
-		t.Errorf("grammar.NewParser: should have produced a valid BQL parser, %v", err)
+		t.Errorf("grammar.NewParser should have produced a valid BQL parser but got error: %v", err)
 	}
 	stm := &semantic.Statement{}
 	if err = p.Parse(grammar.NewLLk(bql, 1), stm); err != nil {
@@ -225,7 +225,7 @@ func TestPlannerDropGraph(t *testing.T) {
 	bql := `drop graph ?foo, ?bar;`
 	p, err := grammar.NewParser(grammar.SemanticBQL())
 	if err != nil {
-		t.Errorf("grammar.NewParser: should have produced a valid BQL parser")
+		t.Errorf("grammar.NewParser should have produced a valid BQL parser but got error: %v", err)
 	}
 	stm := &semantic.Statement{}
 	if err = p.Parse(grammar.NewLLk(bql, 1), stm); err != nil {
@@ -711,11 +711,12 @@ func TestPlannerQuery(t *testing.T) {
 
 	s, ctx := memory.NewStore(), context.Background()
 	populateStoreWithTriples(ctx, s, "?test", testTriples, t)
-	p, err := grammar.NewParser(grammar.SemanticBQL())
-	if err != nil {
-		t.Fatalf("grammar.NewParser should have produced a valid BQL parser but got error: %v", err)
-	}
 	for _, entry := range testTable {
+		p, err := grammar.NewParser(grammar.SemanticBQL())
+		if err != nil {
+			t.Fatalf("grammar.NewParser should have produced a valid BQL parser but got error: %v", err)
+		}
+
 		st := &semantic.Statement{}
 		if err := p.Parse(grammar.NewLLk(entry.q, 1), st); err != nil {
 			t.Errorf("Parser.consume: failed to parse query %q with error: %v", entry.q, err)
@@ -809,11 +810,12 @@ func TestPlannerConstructAddsCorrectNumberofTriples(t *testing.T) {
 			trps: 3,
 		},
 	}
-	p, err := grammar.NewParser(grammar.SemanticBQL())
-	if err != nil {
-		t.Errorf("grammar.NewParser: should have produced a valid BQL parser, %v", err)
-	}
+
 	for _, entry := range testTable {
+		p, err := grammar.NewParser(grammar.SemanticBQL())
+		if err != nil {
+			t.Errorf("grammar.NewParser should have produced a valid BQL parser but got error: %v", err)
+		}
 
 		s, ctx := memory.NewStore(), context.Background()
 		populateStoreWithTriples(ctx, s, "?src", constructTestSrcTriples, t)
@@ -865,7 +867,7 @@ func TestPlannerConstructAddsCorrectTriples(t *testing.T) {
 		       ?s "met_at"@[?t] ?o};`
 	p, err := grammar.NewParser(grammar.SemanticBQL())
 	if err != nil {
-		t.Errorf("grammar.NewParser: should have produced a valid BQL parser, %v", err)
+		t.Errorf("grammar.NewParser should have produced a valid BQL parser but got error: %v", err)
 	}
 	s, ctx := memory.NewStore(), context.Background()
 	populateStoreWithTriples(ctx, s, "?src", constructTestSrcTriples, t)
@@ -1025,11 +1027,12 @@ func TestPlannerDeconstructRemovesCorrectTriples(t *testing.T) {
 				fmt.Sprintf("%s\t%s\t%s", `/person<B>`, `"met"@[]`, `/person<D>`)},
 		},
 	}
-	p, err := grammar.NewParser(grammar.SemanticBQL())
-	if err != nil {
-		t.Errorf("grammar.NewParser: should have produced a valid BQL parser, %v", err)
-	}
+
 	for _, entry := range testTable {
+		p, err := grammar.NewParser(grammar.SemanticBQL())
+		if err != nil {
+			t.Errorf("grammar.NewParser should have produced a valid BQL parser but got error: %v", err)
+		}
 
 		s, ctx := memory.NewStore(), context.Background()
 		populateStoreWithTriples(ctx, s, "?src", deconstructTestSrcTriples, t)
@@ -1111,7 +1114,7 @@ func TestTreeTraversalToRoot(t *testing.T) {
 	}
 	p, pErr := grammar.NewParser(grammar.SemanticBQL())
 	if pErr != nil {
-		t.Fatalf("grammar.NewParser: should have produced a valid BQL parser with error %v", pErr)
+		t.Fatalf("grammar.NewParser should have produced a valid BQL parser but got error: %v", pErr)
 	}
 	st := &semantic.Statement{}
 	if err := p.Parse(grammar.NewLLk(traversalQuery, 1), st); err != nil {
@@ -1158,7 +1161,7 @@ func TestChaining(t *testing.T) {
 	}
 	p, pErr := grammar.NewParser(grammar.SemanticBQL())
 	if pErr != nil {
-		t.Fatalf("grammar.NewParser: should have produced a valid BQL parser with error %v", pErr)
+		t.Fatalf("grammar.NewParser should have produced a valid BQL parser but got error: %v", pErr)
 	}
 	st := &semantic.Statement{}
 	if err := p.Parse(grammar.NewLLk(traversalQuery, 1), st); err != nil {
@@ -1206,7 +1209,7 @@ func BenchmarkChaining(b *testing.B) {
 	for n := 0; n < b.N; n++ {
 		p, pErr := grammar.NewParser(grammar.SemanticBQL())
 		if pErr != nil {
-			b.Fatalf("grammar.NewParser: should have produced a valid BQL parser with error %v", pErr)
+			b.Fatalf("grammar.NewParser should have produced a valid BQL parser but got error: %v", pErr)
 		}
 		st := &semantic.Statement{}
 		if err := p.Parse(grammar.NewLLk(traversalQuery, 1), st); err != nil {
@@ -1265,7 +1268,7 @@ func TestReificationResolutionIssue70(t *testing.T) {
 	}
 	p, pErr := grammar.NewParser(grammar.SemanticBQL())
 	if pErr != nil {
-		t.Fatalf("grammar.NewParser: should have produced a valid BQL parser with error %v", pErr)
+		t.Fatalf("grammar.NewParser should have produced a valid BQL parser but got error: %v", pErr)
 	}
 	st := &semantic.Statement{}
 	if err := p.Parse(grammar.NewLLk(query, 1), st); err != nil {
@@ -1291,12 +1294,13 @@ func TestReificationResolutionIssue70(t *testing.T) {
 func benchmarkQuery(query string, b *testing.B) {
 	s, ctx := memory.NewStore(), context.Background()
 	populateStoreWithTriples(ctx, s, "?test", testTriples, b)
-	p, err := grammar.NewParser(grammar.SemanticBQL())
-	if err != nil {
-		b.Fatalf("grammar.NewParser: should have produced a valid BQL parser with error %v", err)
-	}
 	b.ResetTimer()
 	for n := 0; n < b.N; n++ {
+		p, err := grammar.NewParser(grammar.SemanticBQL())
+		if err != nil {
+			b.Fatalf("grammar.NewParser should have produced a valid BQL parser but got error: %v", err)
+		}
+
 		st := &semantic.Statement{}
 		if err := p.Parse(grammar.NewLLk(query, 1), st); err != nil {
 			b.Errorf("Parser.consume: failed to parse query %q with error %v", query, err)

--- a/bql/planner/planner_test.go
+++ b/bql/planner/planner_test.go
@@ -272,286 +272,286 @@ func populateStoreWithTriples(ctx context.Context, s storage.Store, gn string, t
 
 func TestPlannerQuery(t *testing.T) {
 	testTable := []struct {
-		q    string
-		err  bool
-		nbs  int
-		nrws int
+		q       string
+		wantErr bool
+		nbs     int
+		nrws    int
 	}{
 		{
-			q:    `select ?s, ?p, ?o from ?test where {?s ?p ?o};`,
-			err:  false,
-			nbs:  3,
-			nrws: len(strings.Split(testTriples, "\n")) - 1,
+			q:       `select ?s, ?p, ?o from ?test where {?s ?p ?o};`,
+			wantErr: false,
+			nbs:     3,
+			nrws:    len(strings.Split(testTriples, "\n")) - 1,
 		},
 		{
-			q:    `select ?s as ?s1, ?p as ?p1, ?o as ?o1 from ?test where {?s ?p ?o};`,
-			err:  false,
-			nbs:  3,
-			nrws: len(strings.Split(testTriples, "\n")) - 1,
+			q:       `select ?s as ?s1, ?p as ?p1, ?o as ?o1 from ?test where {?s ?p ?o};`,
+			wantErr: false,
+			nbs:     3,
+			nrws:    len(strings.Split(testTriples, "\n")) - 1,
 		},
 		{
-			q:    `select ?p, ?o from ?test where {/u<joe> ?p ?o};`,
-			err:  false,
-			nbs:  2,
-			nrws: 2,
+			q:       `select ?p, ?o from ?test where {/u<joe> ?p ?o};`,
+			wantErr: false,
+			nbs:     2,
+			nrws:    2,
 		},
 		{
-			q:    `select ?p as ?p1, ?o as ?o1 from ?test where {/u<joe> ?p ?o};`,
-			err:  false,
-			nbs:  2,
-			nrws: 2,
+			q:       `select ?p as ?p1, ?o as ?o1 from ?test where {/u<joe> ?p ?o};`,
+			wantErr: false,
+			nbs:     2,
+			nrws:    2,
 		},
 		{
-			q:    `select ?s, ?p from ?test where {?s ?p /t<car>};`,
-			err:  false,
-			nbs:  2,
-			nrws: 4,
+			q:       `select ?s, ?p from ?test where {?s ?p /t<car>};`,
+			wantErr: false,
+			nbs:     2,
+			nrws:    4,
 		},
 		{
-			q:    `select ?s, ?o from ?test where {?s "parent_of"@[] ?o};`,
-			err:  false,
-			nbs:  2,
-			nrws: 4,
+			q:       `select ?s, ?o from ?test where {?s "parent_of"@[] ?o};`,
+			wantErr: false,
+			nbs:     2,
+			nrws:    4,
 		},
 		{
-			q:    `select ?s, ?p, ?o from ?test where {/u<joe> as ?s "parent_of"@[] as ?p /u<mary> as ?o};`,
-			err:  false,
-			nbs:  3,
-			nrws: 1,
+			q:       `select ?s, ?p, ?o from ?test where {/u<joe> as ?s "parent_of"@[] as ?p /u<mary> as ?o};`,
+			wantErr: false,
+			nbs:     3,
+			nrws:    1,
 		},
 		{
-			q:    `select ?s, ?p, ?o from ?test where {/u<unknown> as ?s "parent_of"@[] as ?p /u<mary> as ?o};`,
-			err:  false,
-			nbs:  3,
-			nrws: 0,
+			q:       `select ?s, ?p, ?o from ?test where {/u<unknown> as ?s "parent_of"@[] as ?p /u<mary> as ?o};`,
+			wantErr: false,
+			nbs:     3,
+			nrws:    0,
 		},
 		{
-			q:    `select ?o from ?test where {/u<joe> "parent_of"@[] ?o};`,
-			err:  false,
-			nbs:  1,
-			nrws: 2,
+			q:       `select ?o from ?test where {/u<joe> "parent_of"@[] ?o};`,
+			wantErr: false,
+			nbs:     1,
+			nrws:    2,
 		},
 		{
-			q:    `select ?p from ?test where {/u<joe> ?p /u<mary>};`,
-			err:  false,
-			nbs:  1,
-			nrws: 1,
+			q:       `select ?p from ?test where {/u<joe> ?p /u<mary>};`,
+			wantErr: false,
+			nbs:     1,
+			nrws:    1,
 		},
 		{
-			q:    `select ?s from ?test where {?s "is_a"@[] /t<car>};`,
-			err:  false,
-			nbs:  1,
-			nrws: 4,
+			q:       `select ?s from ?test where {?s "is_a"@[] /t<car>};`,
+			wantErr: false,
+			nbs:     1,
+			nrws:    4,
 		},
 		{
-			q:    `select ?s as ?s1 from ?test where {?s "is_a"@[] /t<car>};`,
-			err:  false,
-			nbs:  1,
-			nrws: 4,
+			q:       `select ?s as ?s1 from ?test where {?s "is_a"@[] /t<car>};`,
+			wantErr: false,
+			nbs:     1,
+			nrws:    4,
 		},
 		{
-			q:    `select ?o from ?test where {/u<joe> "parent_of"@[] ?o. ?o "parent_of"@[] /u<john>};`,
-			err:  false,
-			nbs:  1,
-			nrws: 1,
+			q:       `select ?o from ?test where {/u<joe> "parent_of"@[] ?o. ?o "parent_of"@[] /u<john>};`,
+			wantErr: false,
+			nbs:     1,
+			nrws:    1,
 		},
 		{
-			q:    `select ?s, ?o from ?test where {/u<joe> "parent_of"@[] ?o. ?o "parent_of"@[] ?s};`,
-			err:  false,
-			nbs:  2,
-			nrws: 2,
+			q:       `select ?s, ?o from ?test where {/u<joe> "parent_of"@[] ?o. ?o "parent_of"@[] ?s};`,
+			wantErr: false,
+			nbs:     2,
+			nrws:    2,
 		},
 		{
-			q:    `select ?s, ?p, ?o, ?k, ?l, ?m from ?test where {?s ?p ?o. ?k ?l ?m};`,
-			err:  false,
-			nbs:  6,
-			nrws: (len(strings.Split(testTriples, "\n")) - 1) * (len(strings.Split(testTriples, "\n")) - 1),
+			q:       `select ?s, ?p, ?o, ?k, ?l, ?m from ?test where {?s ?p ?o. ?k ?l ?m};`,
+			wantErr: false,
+			nbs:     6,
+			nrws:    (len(strings.Split(testTriples, "\n")) - 1) * (len(strings.Split(testTriples, "\n")) - 1),
 		},
 		{
-			q:    `select ?s, ?p, ?o, ?k, ?l from ?test where {?s ?p ?o. ?k ?l ?m};`,
-			err:  false,
-			nbs:  5,
-			nrws: (len(strings.Split(testTriples, "\n")) - 1) * (len(strings.Split(testTriples, "\n")) - 1),
+			q:       `select ?s, ?p, ?o, ?k, ?l from ?test where {?s ?p ?o. ?k ?l ?m};`,
+			wantErr: false,
+			nbs:     5,
+			nrws:    (len(strings.Split(testTriples, "\n")) - 1) * (len(strings.Split(testTriples, "\n")) - 1),
 		},
 		{
-			q:    `select ?s, ?p, ?o, ?k from ?test where {?s ?p ?o. ?k ?l ?m};`,
-			err:  false,
-			nbs:  4,
-			nrws: (len(strings.Split(testTriples, "\n")) - 1) * (len(strings.Split(testTriples, "\n")) - 1),
+			q:       `select ?s, ?p, ?o, ?k from ?test where {?s ?p ?o. ?k ?l ?m};`,
+			wantErr: false,
+			nbs:     4,
+			nrws:    (len(strings.Split(testTriples, "\n")) - 1) * (len(strings.Split(testTriples, "\n")) - 1),
 		},
 		{
-			q:    `select ?s, ?p, ?o from ?test where {?s ?p ?o. ?k ?l ?m};`,
-			err:  false,
-			nbs:  3,
-			nrws: (len(strings.Split(testTriples, "\n")) - 1) * (len(strings.Split(testTriples, "\n")) - 1),
+			q:       `select ?s, ?p, ?o from ?test where {?s ?p ?o. ?k ?l ?m};`,
+			wantErr: false,
+			nbs:     3,
+			nrws:    (len(strings.Split(testTriples, "\n")) - 1) * (len(strings.Split(testTriples, "\n")) - 1),
 		},
 		{
-			q:    `select ?s, ?p from ?test where {?s ?p ?o. ?k ?l ?m};`,
-			err:  false,
-			nbs:  2,
-			nrws: (len(strings.Split(testTriples, "\n")) - 1) * (len(strings.Split(testTriples, "\n")) - 1),
+			q:       `select ?s, ?p from ?test where {?s ?p ?o. ?k ?l ?m};`,
+			wantErr: false,
+			nbs:     2,
+			nrws:    (len(strings.Split(testTriples, "\n")) - 1) * (len(strings.Split(testTriples, "\n")) - 1),
 		},
 		{
-			q:    `select ?s from ?test where {?s ?p ?o. ?k ?l ?m};`,
-			err:  false,
-			nbs:  1,
-			nrws: (len(strings.Split(testTriples, "\n")) - 1) * (len(strings.Split(testTriples, "\n")) - 1),
+			q:       `select ?s from ?test where {?s ?p ?o. ?k ?l ?m};`,
+			wantErr: false,
+			nbs:     1,
+			nrws:    (len(strings.Split(testTriples, "\n")) - 1) * (len(strings.Split(testTriples, "\n")) - 1),
 		},
 		{
-			q:    `select ?o from ?test where {/u<peter> "bought"@[,] ?o};`,
-			err:  false,
-			nbs:  1,
-			nrws: 4,
+			q:       `select ?o from ?test where {/u<peter> "bought"@[,] ?o};`,
+			wantErr: false,
+			nbs:     1,
+			nrws:    4,
 		},
 		{
-			q:    `select ?o from ?test where {/u<peter> "bought"@[,2015-01-01T00:00:00-08:00] ?o};`,
-			err:  false,
-			nbs:  1,
-			nrws: 0,
+			q:       `select ?o from ?test where {/u<peter> "bought"@[,2015-01-01T00:00:00-08:00] ?o};`,
+			wantErr: false,
+			nbs:     1,
+			nrws:    0,
 		},
 		{
-			q:    `select ?o from ?test where {/u<peter> "bought"@[2017-01-01T00:00:00-08:00,] ?o};`,
-			err:  false,
-			nbs:  1,
-			nrws: 0,
+			q:       `select ?o from ?test where {/u<peter> "bought"@[2017-01-01T00:00:00-08:00,] ?o};`,
+			wantErr: false,
+			nbs:     1,
+			nrws:    0,
 		},
 		{
-			q:    `select ?o from ?test where {/u<peter> "bought"@[2015-01-01T00:00:00-08:00,2017-01-01T00:00:00-08:00] ?o};`,
-			err:  false,
-			nbs:  1,
-			nrws: 4,
+			q:       `select ?o from ?test where {/u<peter> "bought"@[2015-01-01T00:00:00-08:00,2017-01-01T00:00:00-08:00] ?o};`,
+			wantErr: false,
+			nbs:     1,
+			nrws:    4,
 		},
 		{
-			q:    `select ?o from ?test where {/l<barcelona> "predicate"@[] "turned"@[,] as ?o};`,
-			err:  false,
-			nbs:  1,
-			nrws: 4,
+			q:       `select ?o from ?test where {/l<barcelona> "predicate"@[] "turned"@[,] as ?o};`,
+			wantErr: false,
+			nbs:     1,
+			nrws:    4,
 		},
 		{
-			q:    `select ?o from ?test where {/l<barcelona> "predicate"@[] "turned"@[,2015-01-01T00:00:00-08:00] as ?o};`,
-			err:  false,
-			nbs:  1,
-			nrws: 0,
+			q:       `select ?o from ?test where {/l<barcelona> "predicate"@[] "turned"@[,2015-01-01T00:00:00-08:00] as ?o};`,
+			wantErr: false,
+			nbs:     1,
+			nrws:    0,
 		},
 		{
-			q:    `select ?o from ?test where {/l<barcelona> "predicate"@[] "turned"@[2017-01-01T00:00:00-08:00,] as ?o};`,
-			err:  false,
-			nbs:  1,
-			nrws: 0,
+			q:       `select ?o from ?test where {/l<barcelona> "predicate"@[] "turned"@[2017-01-01T00:00:00-08:00,] as ?o};`,
+			wantErr: false,
+			nbs:     1,
+			nrws:    0,
 		},
 		{
-			q:    `select ?o from ?test where {/l<barcelona> "predicate"@[] "turned"@[2015-01-01T00:00:00-08:00,2017-01-01T00:00:00-08:00] as ?o};`,
-			err:  false,
-			nbs:  1,
-			nrws: 4,
+			q:       `select ?o from ?test where {/l<barcelona> "predicate"@[] "turned"@[2015-01-01T00:00:00-08:00,2017-01-01T00:00:00-08:00] as ?o};`,
+			wantErr: false,
+			nbs:     1,
+			nrws:    4,
 		},
 		{
-			q:    `select ?grandparent, count(?name) as ?grandchildren from ?test where {/u<joe> as ?grandparent "parent_of"@[] ?offspring . ?offspring "parent_of"@[] ?name} group by ?grandparent;`,
-			err:  false,
-			nbs:  2,
-			nrws: 1,
+			q:       `select ?grandparent, count(?name) as ?grandchildren from ?test where {/u<joe> as ?grandparent "parent_of"@[] ?offspring . ?offspring "parent_of"@[] ?name} group by ?grandparent;`,
+			wantErr: false,
+			nbs:     2,
+			nrws:    1,
 		},
 		{
-			q:    `select ?grandparent, count(distinct ?name) as ?grandchildren from ?test where {/u<joe> as ?grandparent "parent_of"@[] ?offspring . ?offspring "parent_of"@[] ?name} group by ?grandparent;`,
-			err:  false,
-			nbs:  2,
-			nrws: 1,
+			q:       `select ?grandparent, count(distinct ?name) as ?grandchildren from ?test where {/u<joe> as ?grandparent "parent_of"@[] ?offspring . ?offspring "parent_of"@[] ?name} group by ?grandparent;`,
+			wantErr: false,
+			nbs:     2,
+			nrws:    1,
 		},
 		{
-			q:    `select ?s, ?p, ?o, ?k, ?l, ?m from ?test where {?s ?p ?o. ?k ?l ?m} order by ?s, ?p, ?o, ?k, ?l, ?m;`,
-			err:  false,
-			nbs:  6,
-			nrws: (len(strings.Split(testTriples, "\n")) - 1) * (len(strings.Split(testTriples, "\n")) - 1),
+			q:       `select ?s, ?p, ?o, ?k, ?l, ?m from ?test where {?s ?p ?o. ?k ?l ?m} order by ?s, ?p, ?o, ?k, ?l, ?m;`,
+			wantErr: false,
+			nbs:     6,
+			nrws:    (len(strings.Split(testTriples, "\n")) - 1) * (len(strings.Split(testTriples, "\n")) - 1),
 		},
 		{
-			q:    `select ?s, ?p, ?o, ?k, ?l, ?m from ?test where {?s ?p ?o. ?k ?l ?m} order by ?s, ?p, ?o, ?k, ?l, ?m  having not(?s = ?s);`,
-			err:  false,
-			nbs:  6,
-			nrws: 0,
+			q:       `select ?s, ?p, ?o, ?k, ?l, ?m from ?test where {?s ?p ?o. ?k ?l ?m} order by ?s, ?p, ?o, ?k, ?l, ?m  having not(?s = ?s);`,
+			wantErr: false,
+			nbs:     6,
+			nrws:    0,
 		},
 		{
-			q:    `select ?o from ?test where {/l<barcelona> "predicate"@[] "turned"@[2015-01-01T00:00:00-08:00,2017-01-01T00:00:00-08:00] as ?o} LIMIT "2"^^type:int64;`,
-			err:  false,
-			nbs:  1,
-			nrws: 2,
+			q:       `select ?o from ?test where {/l<barcelona> "predicate"@[] "turned"@[2015-01-01T00:00:00-08:00,2017-01-01T00:00:00-08:00] as ?o} LIMIT "2"^^type:int64;`,
+			wantErr: false,
+			nbs:     1,
+			nrws:    2,
 		},
 		{
-			q:    `select ?o from ?test where {/u<peter> "bought"@[2015-01-01T00:00:00-08:00,2017-01-01T00:00:00-08:00] ?o} before 2014-01-01T00:00:00-08:00;`,
-			err:  false,
-			nbs:  1,
-			nrws: 0,
+			q:       `select ?o from ?test where {/u<peter> "bought"@[2015-01-01T00:00:00-08:00,2017-01-01T00:00:00-08:00] ?o} before 2014-01-01T00:00:00-08:00;`,
+			wantErr: false,
+			nbs:     1,
+			nrws:    0,
 		},
 		{
-			q:    `select ?o from ?test where {/u<peter> "bought"@[2015-01-01T00:00:00-08:00,2017-01-01T00:00:00-08:00] ?o} after 2017-01-01T00:00:00-08:00;`,
-			err:  false,
-			nbs:  1,
-			nrws: 0,
+			q:       `select ?o from ?test where {/u<peter> "bought"@[2015-01-01T00:00:00-08:00,2017-01-01T00:00:00-08:00] ?o} after 2017-01-01T00:00:00-08:00;`,
+			wantErr: false,
+			nbs:     1,
+			nrws:    0,
 		},
 		{
-			q:    `select ?o from ?test where {/u<peter> "bought"@[2015-01-01T00:00:00-08:00,2017-01-01T00:00:00-08:00] ?o} between 2014-01-01T00:00:00-08:00, 2017-01-01T00:00:00-08:00;`,
-			err:  false,
-			nbs:  1,
-			nrws: 4,
+			q:       `select ?o from ?test where {/u<peter> "bought"@[2015-01-01T00:00:00-08:00,2017-01-01T00:00:00-08:00] ?o} between 2014-01-01T00:00:00-08:00, 2017-01-01T00:00:00-08:00;`,
+			wantErr: false,
+			nbs:     1,
+			nrws:    4,
 		},
 		{
-			q:    `SELECT ?grandparent, COUNT(?grandparent) AS ?number_of_grandchildren FROM ?test WHERE{ ?gp ID ?grandparent "parent_of"@[] ?c . ?c "parent_of"@[] ?gc ID ?gc } GROUP BY ?grandparent;`,
-			err:  false,
-			nbs:  2,
-			nrws: 1,
+			q:       `SELECT ?grandparent, COUNT(?grandparent) AS ?number_of_grandchildren FROM ?test WHERE{ ?gp ID ?grandparent "parent_of"@[] ?c . ?c "parent_of"@[] ?gc ID ?gc } GROUP BY ?grandparent;`,
+			wantErr: false,
+			nbs:     2,
+			nrws:    1,
 		},
 		{ // Issue 40 (https://github.com/google/badwolf/issues/40)
-			q:    `SELECT ?item, ?t FROM ?test WHERE {?item "in"@[?t] /room<Bedroom>};`,
-			err:  false,
-			nbs:  2,
-			nrws: 1,
+			q:       `SELECT ?item, ?t FROM ?test WHERE {?item "in"@[?t] /room<Bedroom>};`,
+			wantErr: false,
+			nbs:     2,
+			nrws:    1,
 		},
 		{
-			q:    `SHOW GRAPHS;`,
-			err:  false,
-			nbs:  1,
-			nrws: 1,
+			q:       `SHOW GRAPHS;`,
+			wantErr: false,
+			nbs:     1,
+			nrws:    1,
 		},
 		{
-			q:    `select ?s, ?o from ?test where {?s "tag"@[] ?o} having ?o = "abc"^^type:text;`,
-			err:  false,
-			nbs:  2,
-			nrws: 1,
+			q:       `select ?s, ?o from ?test where {?s "tag"@[] ?o} having ?o = "abc"^^type:text;`,
+			wantErr: false,
+			nbs:     2,
+			nrws:    1,
 		},
 		{
-			q:    `select ?s, ?height from ?test where {?s "height_cm"@[] ?height} having ?height > "0"^^type:int64;`,
-			err:  false,
-			nbs:  2,
-			nrws: 4,
+			q:       `select ?s, ?height from ?test where {?s "height_cm"@[] ?height} having ?height > "0"^^type:int64;`,
+			wantErr: false,
+			nbs:     2,
+			nrws:    4,
 		},
 		{
-			q:    `select ?s, ?height from ?test where {?s "height_cm"@[] ?height} having ?height > "160"^^type:int64;`,
-			err:  false,
-			nbs:  2,
-			nrws: 3,
+			q:       `select ?s, ?height from ?test where {?s "height_cm"@[] ?height} having ?height > "160"^^type:int64;`,
+			wantErr: false,
+			nbs:     2,
+			nrws:    3,
 		},
 		{
-			q:    `select ?s, ?height from ?test where {?s "height_cm"@[] ?height} having ?height = "151"^^type:int64;`,
-			err:  false,
-			nbs:  2,
-			nrws: 1,
+			q:       `select ?s, ?height from ?test where {?s "height_cm"@[] ?height} having ?height = "151"^^type:int64;`,
+			wantErr: false,
+			nbs:     2,
+			nrws:    1,
 		},
 		{
-			q:    `select ?s, ?height from ?test where {?s "height_cm"@[] ?height} having ?s > /u<zzzzz>;`,
-			err:  false,
-			nbs:  2,
-			nrws: 0,
+			q:       `select ?s, ?height from ?test where {?s "height_cm"@[] ?height} having ?s > /u<zzzzz>;`,
+			wantErr: false,
+			nbs:     2,
+			nrws:    0,
 		},
 		{
-			q:    `select ?s, ?height from ?test where {?s "height_cm"@[] ?height} having ?s > /u<alice>;`,
-			err:  false,
-			nbs:  2,
-			nrws: 3,
+			q:       `select ?s, ?height from ?test where {?s "height_cm"@[] ?height} having ?s > /u<alice>;`,
+			wantErr: false,
+			nbs:     2,
+			nrws:    3,
 		},
 		{
-			q:    `select ?s, ?height from ?test where {?s "height_cm"@[] ?height} having ?s > /u<bob>;`,
-			err:  false,
-			nbs:  2,
-			nrws: 2,
+			q:       `select ?s, ?height from ?test where {?s "height_cm"@[] ?height} having ?s > /u<bob>;`,
+			wantErr: false,
+			nbs:     2,
+			nrws:    2,
 		},
 		/*
 			/c<model s> "is_a"@[] /t<car>
@@ -560,10 +560,10 @@ func TestPlannerQuery(t *testing.T) {
 		*/
 		// OPTIONAL clauses.
 		{
-			q:    `SELECT ?car FROM ?test WHERE { ?car "is_a"@[] /t<car> };`,
-			err:  false,
-			nbs:  1,
-			nrws: 4,
+			q:       `SELECT ?car FROM ?test WHERE { ?car "is_a"@[] /t<car> };`,
+			wantErr: false,
+			nbs:     1,
+			nrws:    4,
 		},
 		{
 			q: `SELECT ?car
@@ -571,9 +571,9 @@ func TestPlannerQuery(t *testing.T) {
 			    WHERE {
 				   /c<model s> as ?car "is_a"@[] /t<car>
 				};`,
-			err:  false,
-			nbs:  1,
-			nrws: 1,
+			wantErr: false,
+			nbs:     1,
+			nrws:    1,
 		},
 		{
 			q: `SELECT ?car
@@ -582,9 +582,9 @@ func TestPlannerQuery(t *testing.T) {
 				   ?car "is_a"@[] /t<car> .
 				   /c<model z> as ?car "is_a"@[] /t<car>
 				};`,
-			err:  false,
-			nbs:  1,
-			nrws: 0,
+			wantErr: false,
+			nbs:     1,
+			nrws:    0,
 		},
 		{
 			q: `SELECT ?car
@@ -593,9 +593,9 @@ func TestPlannerQuery(t *testing.T) {
 					?car "is_a"@[] /t<car> .
 					OPTIONAL { /c<model O> "is_a"@[] /t<car> }
 				};`,
-			err:  false,
-			nbs:  1,
-			nrws: 4,
+			wantErr: false,
+			nbs:     1,
+			nrws:    4,
 		},
 		{
 			q: `SELECT ?car
@@ -604,9 +604,9 @@ func TestPlannerQuery(t *testing.T) {
 					?car "is_a"@[] /t<car> .
 					OPTIONAL { ?car "is_a"@[] /t<car> }
 				};`,
-			err:  false,
-			nbs:  1,
-			nrws: 4,
+			wantErr: false,
+			nbs:     1,
+			nrws:    4,
 		},
 		{
 			q: `SELECT ?cars, ?type
@@ -615,9 +615,9 @@ func TestPlannerQuery(t *testing.T) {
 					?cars "is_a"@[] /t<car> .
 					OPTIONAL { ?cars "is_a"@[] ?type }
 				};`,
-			err:  false,
-			nbs:  2,
-			nrws: 4,
+			wantErr: false,
+			nbs:     2,
+			nrws:    4,
 		},
 		{
 			q: `SELECT ?p, ?o
@@ -626,9 +626,9 @@ func TestPlannerQuery(t *testing.T) {
 					/c<mini> ?p ?o
 				}
 				HAVING ?o > "37"^^type:int64;`,
-			err:  false,
-			nbs:  2,
-			nrws: 0,
+			wantErr: false,
+			nbs:     2,
+			nrws:    0,
 		},
 		{
 			q: `SELECT ?o
@@ -637,9 +637,9 @@ func TestPlannerQuery(t *testing.T) {
 					/u<alice> "height_cm"@[] ?o
 				}
 				HAVING ?o = /u<peter>;`,
-			err:  false,
-			nbs:  1,
-			nrws: 0,
+			wantErr: false,
+			nbs:     1,
+			nrws:    0,
 		},
 		{
 			q: `SELECT ?s_id, ?height
@@ -648,9 +648,9 @@ func TestPlannerQuery(t *testing.T) {
 					?s ID ?s_id "height_cm"@[] ?height
 				}
 				HAVING ?s_id = "alice"^^type:text;`,
-			err:  false,
-			nbs:  2,
-			nrws: 1,
+			wantErr: false,
+			nbs:     2,
+			nrws:    1,
 		},
 		{
 			q: `SELECT ?s_id, ?height
@@ -659,9 +659,9 @@ func TestPlannerQuery(t *testing.T) {
 					?s ID ?s_id "height_cm"@[] ?height
 				}
 				HAVING ?s_id > "37"^^type:int64;`,
-			err:  true,
-			nbs:  2,
-			nrws: 1,
+			wantErr: true,
+			nbs:     2,
+			nrws:    1,
 		},
 		{
 			q: `SELECT ?s_id, ?height
@@ -670,9 +670,9 @@ func TestPlannerQuery(t *testing.T) {
 					?s ID ?s_id "height_cm"@[] ?height
 				}
 				HAVING ?s_id = /u<alice>;`,
-			err:  true,
-			nbs:  2,
-			nrws: 0,
+			wantErr: true,
+			nbs:     2,
+			nrws:    0,
 		},
 		{
 			q: `SELECT ?p_id, ?o
@@ -681,9 +681,9 @@ func TestPlannerQuery(t *testing.T) {
 					/u<peter> ?p ID ?p_id ?o
 				}
 				HAVING ?p_id < "parent_of"^^type:text;`,
-			err:  false,
-			nbs:  2,
-			nrws: 4,
+			wantErr: false,
+			nbs:     2,
+			nrws:    4,
 		},
 		{
 			q: `SELECT ?s, ?s_type
@@ -692,9 +692,9 @@ func TestPlannerQuery(t *testing.T) {
 					?s TYPE ?s_type ?p ?o
 				}
 				HAVING ?s_type = "/c"^^type:text;`,
-			err:  false,
-			nbs:  2,
-			nrws: 4,
+			wantErr: false,
+			nbs:     2,
+			nrws:    4,
 		},
 		{
 			q: `SELECT ?s, ?s_type
@@ -703,9 +703,9 @@ func TestPlannerQuery(t *testing.T) {
 					?s TYPE ?s_type ?p ?o
 				}
 				HAVING ?s_type < "/l"^^type:text;`,
-			err:  false,
-			nbs:  2,
-			nrws: 7,
+			wantErr: false,
+			nbs:     2,
+			nrws:    7,
 		},
 		{
 			q: `SELECT ?p, ?p_id, ?o
@@ -715,8 +715,9 @@ func TestPlannerQuery(t *testing.T) {
 				}
 				HAVING ?p_id = "bought"^^type:text
 				AFTER 2016-03-01T00:00:00-08:00;`,
-			nbs:  3,
-			nrws: 2,
+			wantErr: false,
+			nbs:     3,
+			nrws:    2,
 		},
 		{
 			q: `SELECT ?p, ?p_id, ?o
@@ -726,8 +727,9 @@ func TestPlannerQuery(t *testing.T) {
 				}
 				HAVING ?p_id < "parent_of"^^type:text
 				BEFORE 2016-03-01T00:00:00-08:00;`,
-			nbs:  3,
-			nrws: 3,
+			wantErr: false,
+			nbs:     3,
+			nrws:    3,
 		},
 		{
 			q: `SELECT ?p, ?p_id, ?o
@@ -737,8 +739,9 @@ func TestPlannerQuery(t *testing.T) {
 				}
 				HAVING ?p_id = "bought"^^type:text
 				BETWEEN 2016-02-01T00:00:00-08:00, 2016-03-01T00:00:00-08:00;`,
-			nbs:  3,
-			nrws: 2,
+			wantErr: false,
+			nbs:     3,
+			nrws:    2,
 		},
 		{
 			q: `SELECT ?p, ?p_id, ?o
@@ -748,8 +751,9 @@ func TestPlannerQuery(t *testing.T) {
 				}
 				HAVING ?p_id < "work_with"^^type:text
 				BEFORE 2016-02-01T00:00:00-08:00;`,
-			nbs:  3,
-			nrws: 4,
+			wantErr: false,
+			nbs:     3,
+			nrws:    4,
 		},
 	}
 
@@ -770,15 +774,15 @@ func TestPlannerQuery(t *testing.T) {
 			t.Errorf("planner.New failed to create a valid query plan with error: %v", err)
 		}
 		tbl, err := plnr.Execute(ctx)
-		if !entry.err && err != nil {
+		if !entry.wantErr && err != nil {
 			t.Errorf("planner.Execute failed for query %q with error: %v", entry.q, err)
 			continue
 		}
-		if entry.err && err == nil {
+		if entry.wantErr && err == nil {
 			t.Errorf("planner.Execute for query %q should have returned an error, but did not", entry.q)
 			continue
 		}
-		if entry.err {
+		if entry.wantErr {
 			// an error was expected and it was indeed caught above.
 			continue
 		}

--- a/bql/planner/planner_test.go
+++ b/bql/planner/planner_test.go
@@ -273,236 +273,283 @@ func populateStoreWithTriples(ctx context.Context, s storage.Store, gn string, t
 func TestPlannerQuery(t *testing.T) {
 	testTable := []struct {
 		q    string
+		err  bool
 		nbs  int
 		nrws int
 	}{
 		{
 			q:    `select ?s, ?p, ?o from ?test where {?s ?p ?o};`,
+			err:  false,
 			nbs:  3,
 			nrws: len(strings.Split(testTriples, "\n")) - 1,
 		},
 		{
 			q:    `select ?s as ?s1, ?p as ?p1, ?o as ?o1 from ?test where {?s ?p ?o};`,
+			err:  false,
 			nbs:  3,
 			nrws: len(strings.Split(testTriples, "\n")) - 1,
 		},
 		{
 			q:    `select ?p, ?o from ?test where {/u<joe> ?p ?o};`,
+			err:  false,
 			nbs:  2,
 			nrws: 2,
 		},
 		{
 			q:    `select ?p as ?p1, ?o as ?o1 from ?test where {/u<joe> ?p ?o};`,
+			err:  false,
 			nbs:  2,
 			nrws: 2,
 		},
 		{
 			q:    `select ?s, ?p from ?test where {?s ?p /t<car>};`,
+			err:  false,
 			nbs:  2,
 			nrws: 4,
 		},
 		{
 			q:    `select ?s, ?o from ?test where {?s "parent_of"@[] ?o};`,
+			err:  false,
 			nbs:  2,
 			nrws: 4,
 		},
 		{
 			q:    `select ?s, ?p, ?o from ?test where {/u<joe> as ?s "parent_of"@[] as ?p /u<mary> as ?o};`,
+			err:  false,
 			nbs:  3,
 			nrws: 1,
 		},
 		{
 			q:    `select ?s, ?p, ?o from ?test where {/u<unknown> as ?s "parent_of"@[] as ?p /u<mary> as ?o};`,
+			err:  false,
 			nbs:  3,
 			nrws: 0,
 		},
 		{
 			q:    `select ?o from ?test where {/u<joe> "parent_of"@[] ?o};`,
+			err:  false,
 			nbs:  1,
 			nrws: 2,
 		},
 		{
 			q:    `select ?p from ?test where {/u<joe> ?p /u<mary>};`,
+			err:  false,
 			nbs:  1,
 			nrws: 1,
 		},
 		{
 			q:    `select ?s from ?test where {?s "is_a"@[] /t<car>};`,
+			err:  false,
 			nbs:  1,
 			nrws: 4,
 		},
 		{
 			q:    `select ?s as ?s1 from ?test where {?s "is_a"@[] /t<car>};`,
+			err:  false,
 			nbs:  1,
 			nrws: 4,
 		},
 		{
 			q:    `select ?o from ?test where {/u<joe> "parent_of"@[] ?o. ?o "parent_of"@[] /u<john>};`,
+			err:  false,
 			nbs:  1,
 			nrws: 1,
 		},
 		{
 			q:    `select ?s, ?o from ?test where {/u<joe> "parent_of"@[] ?o. ?o "parent_of"@[] ?s};`,
+			err:  false,
 			nbs:  2,
 			nrws: 2,
 		},
 		{
 			q:    `select ?s, ?p, ?o, ?k, ?l, ?m from ?test where {?s ?p ?o. ?k ?l ?m};`,
+			err:  false,
 			nbs:  6,
 			nrws: (len(strings.Split(testTriples, "\n")) - 1) * (len(strings.Split(testTriples, "\n")) - 1),
 		},
 		{
 			q:    `select ?s, ?p, ?o, ?k, ?l from ?test where {?s ?p ?o. ?k ?l ?m};`,
+			err:  false,
 			nbs:  5,
 			nrws: (len(strings.Split(testTriples, "\n")) - 1) * (len(strings.Split(testTriples, "\n")) - 1),
 		},
 		{
 			q:    `select ?s, ?p, ?o, ?k from ?test where {?s ?p ?o. ?k ?l ?m};`,
+			err:  false,
 			nbs:  4,
 			nrws: (len(strings.Split(testTriples, "\n")) - 1) * (len(strings.Split(testTriples, "\n")) - 1),
 		},
 		{
 			q:    `select ?s, ?p, ?o from ?test where {?s ?p ?o. ?k ?l ?m};`,
+			err:  false,
 			nbs:  3,
 			nrws: (len(strings.Split(testTriples, "\n")) - 1) * (len(strings.Split(testTriples, "\n")) - 1),
 		},
 		{
 			q:    `select ?s, ?p from ?test where {?s ?p ?o. ?k ?l ?m};`,
+			err:  false,
 			nbs:  2,
 			nrws: (len(strings.Split(testTriples, "\n")) - 1) * (len(strings.Split(testTriples, "\n")) - 1),
 		},
 		{
 			q:    `select ?s from ?test where {?s ?p ?o. ?k ?l ?m};`,
+			err:  false,
 			nbs:  1,
 			nrws: (len(strings.Split(testTriples, "\n")) - 1) * (len(strings.Split(testTriples, "\n")) - 1),
 		},
 		{
 			q:    `select ?o from ?test where {/u<peter> "bought"@[,] ?o};`,
+			err:  false,
 			nbs:  1,
 			nrws: 4,
 		},
 		{
 			q:    `select ?o from ?test where {/u<peter> "bought"@[,2015-01-01T00:00:00-08:00] ?o};`,
+			err:  false,
 			nbs:  1,
 			nrws: 0,
 		},
 		{
 			q:    `select ?o from ?test where {/u<peter> "bought"@[2017-01-01T00:00:00-08:00,] ?o};`,
+			err:  false,
 			nbs:  1,
 			nrws: 0,
 		},
 		{
 			q:    `select ?o from ?test where {/u<peter> "bought"@[2015-01-01T00:00:00-08:00,2017-01-01T00:00:00-08:00] ?o};`,
+			err:  false,
 			nbs:  1,
 			nrws: 4,
 		},
 		{
 			q:    `select ?o from ?test where {/l<barcelona> "predicate"@[] "turned"@[,] as ?o};`,
+			err:  false,
 			nbs:  1,
 			nrws: 4,
 		},
 		{
 			q:    `select ?o from ?test where {/l<barcelona> "predicate"@[] "turned"@[,2015-01-01T00:00:00-08:00] as ?o};`,
+			err:  false,
 			nbs:  1,
 			nrws: 0,
 		},
 		{
 			q:    `select ?o from ?test where {/l<barcelona> "predicate"@[] "turned"@[2017-01-01T00:00:00-08:00,] as ?o};`,
+			err:  false,
 			nbs:  1,
 			nrws: 0,
 		},
 		{
 			q:    `select ?o from ?test where {/l<barcelona> "predicate"@[] "turned"@[2015-01-01T00:00:00-08:00,2017-01-01T00:00:00-08:00] as ?o};`,
+			err:  false,
 			nbs:  1,
 			nrws: 4,
 		},
 		{
 			q:    `select ?grandparent, count(?name) as ?grandchildren from ?test where {/u<joe> as ?grandparent "parent_of"@[] ?offspring . ?offspring "parent_of"@[] ?name} group by ?grandparent;`,
+			err:  false,
 			nbs:  2,
 			nrws: 1,
 		},
 		{
 			q:    `select ?grandparent, count(distinct ?name) as ?grandchildren from ?test where {/u<joe> as ?grandparent "parent_of"@[] ?offspring . ?offspring "parent_of"@[] ?name} group by ?grandparent;`,
+			err:  false,
 			nbs:  2,
 			nrws: 1,
 		},
 		{
 			q:    `select ?s, ?p, ?o, ?k, ?l, ?m from ?test where {?s ?p ?o. ?k ?l ?m} order by ?s, ?p, ?o, ?k, ?l, ?m;`,
+			err:  false,
 			nbs:  6,
 			nrws: (len(strings.Split(testTriples, "\n")) - 1) * (len(strings.Split(testTriples, "\n")) - 1),
 		},
 		{
 			q:    `select ?s, ?p, ?o, ?k, ?l, ?m from ?test where {?s ?p ?o. ?k ?l ?m} order by ?s, ?p, ?o, ?k, ?l, ?m  having not(?s = ?s);`,
+			err:  false,
 			nbs:  6,
 			nrws: 0,
 		},
 		{
 			q:    `select ?o from ?test where {/l<barcelona> "predicate"@[] "turned"@[2015-01-01T00:00:00-08:00,2017-01-01T00:00:00-08:00] as ?o} LIMIT "2"^^type:int64;`,
+			err:  false,
 			nbs:  1,
 			nrws: 2,
 		},
 		{
 			q:    `select ?o from ?test where {/u<peter> "bought"@[2015-01-01T00:00:00-08:00,2017-01-01T00:00:00-08:00] ?o} before 2014-01-01T00:00:00-08:00;`,
+			err:  false,
 			nbs:  1,
 			nrws: 0,
 		},
 		{
 			q:    `select ?o from ?test where {/u<peter> "bought"@[2015-01-01T00:00:00-08:00,2017-01-01T00:00:00-08:00] ?o} after 2017-01-01T00:00:00-08:00;`,
+			err:  false,
 			nbs:  1,
 			nrws: 0,
 		},
 		{
 			q:    `select ?o from ?test where {/u<peter> "bought"@[2015-01-01T00:00:00-08:00,2017-01-01T00:00:00-08:00] ?o} between 2014-01-01T00:00:00-08:00, 2017-01-01T00:00:00-08:00;`,
+			err:  false,
 			nbs:  1,
 			nrws: 4,
 		},
 		{
 			q:    `SELECT ?grandparent, COUNT(?grandparent) AS ?number_of_grandchildren FROM ?test WHERE{ ?gp ID ?grandparent "parent_of"@[] ?c . ?c "parent_of"@[] ?gc ID ?gc } GROUP BY ?grandparent;`,
+			err:  false,
 			nbs:  2,
 			nrws: 1,
 		},
 		{ // Issue 40 (https://github.com/google/badwolf/issues/40)
 			q:    `SELECT ?item, ?t FROM ?test WHERE {?item "in"@[?t] /room<Bedroom>};`,
+			err:  false,
 			nbs:  2,
 			nrws: 1,
 		},
 		{
 			q:    `SHOW GRAPHS;`,
+			err:  false,
 			nbs:  1,
 			nrws: 1,
 		},
 		{
 			q:    `select ?s, ?o from ?test where {?s "tag"@[] ?o} having ?o = "abc"^^type:text;`,
+			err:  false,
 			nbs:  2,
 			nrws: 1,
 		},
 		{
 			q:    `select ?s, ?height from ?test where {?s "height_cm"@[] ?height} having ?height > "0"^^type:int64;`,
+			err:  false,
 			nbs:  2,
 			nrws: 4,
 		},
 		{
 			q:    `select ?s, ?height from ?test where {?s "height_cm"@[] ?height} having ?height > "160"^^type:int64;`,
+			err:  false,
 			nbs:  2,
 			nrws: 3,
 		},
 		{
 			q:    `select ?s, ?height from ?test where {?s "height_cm"@[] ?height} having ?height = "151"^^type:int64;`,
+			err:  false,
 			nbs:  2,
 			nrws: 1,
 		},
 		{
 			q:    `select ?s, ?height from ?test where {?s "height_cm"@[] ?height} having ?s > /u<zzzzz>;`,
+			err:  false,
 			nbs:  2,
 			nrws: 0,
 		},
 		{
 			q:    `select ?s, ?height from ?test where {?s "height_cm"@[] ?height} having ?s > /u<alice>;`,
+			err:  false,
 			nbs:  2,
 			nrws: 3,
 		},
 		{
 			q:    `select ?s, ?height from ?test where {?s "height_cm"@[] ?height} having ?s > /u<bob>;`,
+			err:  false,
 			nbs:  2,
 			nrws: 2,
 		},
@@ -514,6 +561,7 @@ func TestPlannerQuery(t *testing.T) {
 		// OPTIONAL clauses.
 		{
 			q:    `SELECT ?car FROM ?test WHERE { ?car "is_a"@[] /t<car> };`,
+			err:  false,
 			nbs:  1,
 			nrws: 4,
 		},
@@ -523,6 +571,7 @@ func TestPlannerQuery(t *testing.T) {
 			    WHERE {
 				   /c<model s> as ?car "is_a"@[] /t<car>
 				};`,
+			err:  false,
 			nbs:  1,
 			nrws: 1,
 		},
@@ -533,6 +582,7 @@ func TestPlannerQuery(t *testing.T) {
 				   ?car "is_a"@[] /t<car> .
 				   /c<model z> as ?car "is_a"@[] /t<car>
 				};`,
+			err:  false,
 			nbs:  1,
 			nrws: 0,
 		},
@@ -543,6 +593,7 @@ func TestPlannerQuery(t *testing.T) {
 					?car "is_a"@[] /t<car> .
 					OPTIONAL { /c<model O> "is_a"@[] /t<car> }
 				};`,
+			err:  false,
 			nbs:  1,
 			nrws: 4,
 		},
@@ -553,6 +604,7 @@ func TestPlannerQuery(t *testing.T) {
 					?car "is_a"@[] /t<car> .
 					OPTIONAL { ?car "is_a"@[] /t<car> }
 				};`,
+			err:  false,
 			nbs:  1,
 			nrws: 4,
 		},
@@ -563,8 +615,31 @@ func TestPlannerQuery(t *testing.T) {
 					?cars "is_a"@[] /t<car> .
 					OPTIONAL { ?cars "is_a"@[] ?type }
 				};`,
+			err:  false,
 			nbs:  2,
 			nrws: 4,
+		},
+		{
+			q: `SELECT ?p, ?o
+				FROM ?test
+				WHERE {
+					/c<mini> ?p ?o
+				}
+				HAVING ?o > "37"^^type:int64;`,
+			err:  false,
+			nbs:  2,
+			nrws: 0,
+		},
+		{
+			q: `SELECT ?o
+				FROM ?test
+				WHERE {
+					/u<alice> "height_cm"@[] ?o
+				}
+				HAVING ?o = /u<peter>;`,
+			err:  false,
+			nbs:  1,
+			nrws: 0,
 		},
 		{
 			q: `SELECT ?s_id, ?height
@@ -573,8 +648,31 @@ func TestPlannerQuery(t *testing.T) {
 					?s ID ?s_id "height_cm"@[] ?height
 				}
 				HAVING ?s_id = "alice"^^type:text;`,
+			err:  false,
 			nbs:  2,
 			nrws: 1,
+		},
+		{
+			q: `SELECT ?s_id, ?height
+				FROM ?test
+				WHERE {
+					?s ID ?s_id "height_cm"@[] ?height
+				}
+				HAVING ?s_id > "37"^^type:int64;`,
+			err:  true,
+			nbs:  2,
+			nrws: 1,
+		},
+		{
+			q: `SELECT ?s_id, ?height
+				FROM ?test
+				WHERE {
+					?s ID ?s_id "height_cm"@[] ?height
+				}
+				HAVING ?s_id = /u<alice>;`,
+			err:  true,
+			nbs:  2,
+			nrws: 0,
 		},
 		{
 			q: `SELECT ?p_id, ?o
@@ -583,6 +681,7 @@ func TestPlannerQuery(t *testing.T) {
 					/u<peter> ?p ID ?p_id ?o
 				}
 				HAVING ?p_id < "parent_of"^^type:text;`,
+			err:  false,
 			nbs:  2,
 			nrws: 4,
 		},
@@ -592,20 +691,28 @@ func TestPlannerQuery(t *testing.T) {
 	populateStoreWithTriples(ctx, s, "?test", testTriples, t)
 	p, err := grammar.NewParser(grammar.SemanticBQL())
 	if err != nil {
-		t.Fatalf("grammar.NewParser: should have produced a valid BQL parser with error %v", err)
+		t.Fatalf("grammar.NewParser should have produced a valid BQL parser but got error: %v", err)
 	}
 	for _, entry := range testTable {
 		st := &semantic.Statement{}
 		if err := p.Parse(grammar.NewLLk(entry.q, 1), st); err != nil {
-			t.Errorf("Parser.consume: failed to parse query %q with error %v", entry.q, err)
+			t.Errorf("Parser.consume: failed to parse query %q with error: %v", entry.q, err)
 		}
 		plnr, err := New(ctx, s, st, 0, 10, nil)
 		if err != nil {
-			t.Errorf("planner.New failed to create a valid query plan with error %v", err)
+			t.Errorf("planner.New failed to create a valid query plan with error: %v", err)
 		}
 		tbl, err := plnr.Execute(ctx)
-		if err != nil {
-			t.Errorf("planner.Execute failed for query %q with error %v", entry.q, err)
+		if !entry.err && err != nil {
+			t.Errorf("planner.Execute failed for query %q with error: %v", entry.q, err)
+			continue
+		}
+		if entry.err && err == nil {
+			t.Errorf("planner.Execute for query %q should have returned an error, but did not", entry.q)
+			continue
+		}
+		if entry.err {
+			// an error was expected and it was indeed caught above.
 			continue
 		}
 		if got, want := len(tbl.Bindings()), entry.nbs; got != want {

--- a/bql/planner/planner_test.go
+++ b/bql/planner/planner_test.go
@@ -538,51 +538,51 @@ func TestPlannerQuery(t *testing.T) {
 		},
 		{
 			q: `SELECT ?car
-				    FROM ?test
-				    WHERE {
-					   ?car "is_a"@[] /t<car> .
-					   OPTIONAL { /c<model O> "is_a"@[] /t<car> }
-					};`,
+				FROM ?test
+				WHERE {
+					?car "is_a"@[] /t<car> .
+					OPTIONAL { /c<model O> "is_a"@[] /t<car> }
+				};`,
 			nbs:  1,
 			nrws: 4,
 		},
 		{
 			q: `SELECT ?car
-				    FROM ?test
-				    WHERE {
-					   ?car "is_a"@[] /t<car> .
-					   OPTIONAL { ?car "is_a"@[] /t<car> }
-					};`,
+				FROM ?test
+				WHERE {
+					?car "is_a"@[] /t<car> .
+					OPTIONAL { ?car "is_a"@[] /t<car> }
+				};`,
 			nbs:  1,
 			nrws: 4,
 		},
 		{
 			q: `SELECT ?cars, ?type
-				    FROM ?test
-				    WHERE {
-					   ?cars "is_a"@[] /t<car> .
-					   OPTIONAL { ?cars "is_a"@[] ?type }
-					};`,
+				FROM ?test
+				WHERE {
+					?cars "is_a"@[] /t<car> .
+					OPTIONAL { ?cars "is_a"@[] ?type }
+				};`,
 			nbs:  2,
 			nrws: 4,
 		},
 		{
 			q: `SELECT ?s_id, ?height
-					FROM ?test
-					WHERE {
-						?s ID ?s_id "height_cm"@[] ?height
-					}
-					HAVING ?s_id = "alice"^^type:text;`,
+				FROM ?test
+				WHERE {
+					?s ID ?s_id "height_cm"@[] ?height
+				}
+				HAVING ?s_id = "alice"^^type:text;`,
 			nbs:  2,
 			nrws: 1,
 		},
 		{
 			q: `SELECT ?p_id, ?o
-					FROM ?test
-					WHERE {
-						/u<peter> ?p ID ?p_id ?o
-					}
-					HAVING ?p_id < "parent_of"^^type:text;`,
+				FROM ?test
+				WHERE {
+					/u<peter> ?p ID ?p_id ?o
+				}
+				HAVING ?p_id < "parent_of"^^type:text;`,
 			nbs:  2,
 			nrws: 4,
 		},

--- a/bql/semantic/expression.go
+++ b/bql/semantic/expression.go
@@ -145,7 +145,7 @@ func (e *evaluationNode) Evaluate(r table.Row) (bool, error) {
 	case GT:
 		return csEL > csER, nil
 	default:
-		return false, fmt.Errorf("boolean evaluation requires a boolen operation; found %q instead", e.op)
+		return false, fmt.Errorf("boolean evaluation requires a boolean operation; found %q instead", e.op)
 	}
 }
 

--- a/bql/semantic/expression.go
+++ b/bql/semantic/expression.go
@@ -47,17 +47,17 @@ func (a *AlwaysReturn) Evaluate(r table.Row) (bool, error) {
 type OP int8
 
 const (
-	// LT represents '<'
+	// LT represents '<'.
 	LT OP = iota
-	// GT represents '>''
+	// GT represents '>'.
 	GT
-	// EQ represents '=''
+	// EQ represents '='.
 	EQ
-	// NOT represents 'not'
+	// NOT represents 'not'.
 	NOT
-	// AND represents 'and'
+	// AND represents 'and'.
 	AND
-	// OR represents 'or'
+	// OR represents 'or'.
 	OR
 )
 
@@ -81,7 +81,7 @@ func (o OP) String() string {
 	}
 }
 
-// formatCell formats a given cell into a trimmed comparable string
+// formatCell formats a given cell into a trimmed comparable string.
 func formatCell(c *table.Cell) (string, error) {
 	if c.L != nil {
 		return strings.TrimSpace(c.L.ToComparableString()), nil
@@ -98,15 +98,15 @@ func formatCell(c *table.Cell) (string, error) {
 
 // evaluationNode represents the internal representation of one expression.
 type evaluationNode struct {
-	op OP // operation
+	op OP // operation.
 
-	lB string // left binding
-	rB string // right binding
+	lB string // left binding.
+	rB string // right binding.
 }
 
 // Evaluate the expression.
 func (e *evaluationNode) Evaluate(r table.Row) (bool, error) {
-	// Binary evaluation
+	// Binary evaluation.
 	eval := func() (*table.Cell, *table.Cell, error) {
 		var (
 			eL, eR *table.Cell
@@ -149,7 +149,7 @@ func (e *evaluationNode) Evaluate(r table.Row) (bool, error) {
 	}
 }
 
-// cellFromRow retrives the value of a binding from a given row
+// cellFromRow retrives the value of a binding from a given row.
 func cellFromRow(binding string, r table.Row) (*table.Cell, error) {
 	var (
 		val *table.Cell
@@ -164,10 +164,10 @@ func cellFromRow(binding string, r table.Row) (*table.Cell, error) {
 
 // comparisonForLiteral represents the internal representation of an expression of comparison between a binding and a literal.
 type comparisonForLiteral struct {
-	op OP // operation
+	op OP // operation.
 
-	lS string // left string
-	rS string // right string
+	lS string // left string.
+	rS string // right string.
 }
 
 func (e *comparisonForLiteral) Evaluate(r table.Row) (bool, error) {
@@ -209,10 +209,10 @@ func (e *comparisonForLiteral) Evaluate(r table.Row) (bool, error) {
 
 // comparisonForNodeLiteral represents the internal representation of an expression of comparison between a binding and a node literal.
 type comparisonForNodeLiteral struct {
-	op OP // operation
+	op OP // operation.
 
-	lB  string // left binding
-	rNL string // right node literal
+	lB  string // left binding.
+	rNL string // right node literal.
 }
 
 func (e *comparisonForNodeLiteral) Evaluate(r table.Row) (bool, error) {
@@ -311,7 +311,7 @@ type booleanNode struct {
 
 // Evaluate the expression.
 func (e *booleanNode) Evaluate(r table.Row) (bool, error) {
-	// Binary evaluation
+	// Binary evaluation.
 	eval := func(binary bool) (bool, bool, error) {
 		var (
 			eL, eR     bool
@@ -412,7 +412,7 @@ func internalNewEvaluator(ce []ConsumedElement) (Evaluator, []ConsumedElement, e
 	head, tail := ce[0], ce[1:]
 	tkn := head.Token()
 
-	// Not token
+	// Not token.
 	if tkn.Type == lexer.ItemNot {
 		tailEval, tailCEs, err := internalNewEvaluator(tail)
 		if err != nil {
@@ -425,7 +425,7 @@ func internalNewEvaluator(ce []ConsumedElement) (Evaluator, []ConsumedElement, e
 		return e, tailCEs, nil
 	}
 
-	// Binding token
+	// Binding token.
 	if tkn.Type == lexer.ItemBinding {
 		if len(tail) < 2 {
 			return nil, nil, fmt.Errorf("cannot create a binary evaluation operand for %v", ce)
@@ -482,7 +482,7 @@ func internalNewEvaluator(ce []ConsumedElement) (Evaluator, []ConsumedElement, e
 		return nil, nil, fmt.Errorf("cannot build a binary evaluation operand with right operand %v", bndTkn)
 	}
 
-	// LPar Token
+	// LPar Token.
 	if tkn.Type == lexer.ItemLPar {
 		tailEval, ce, err := internalNewEvaluator(tail)
 		if err != nil {

--- a/bql/semantic/expression.go
+++ b/bql/semantic/expression.go
@@ -89,7 +89,7 @@ func formatCell(c *table.Cell) (string, error) {
 	if c.S != nil {
 		formatted, err := literal.DefaultBuilder().Build(literal.Text, *c.S)
 		if err != nil {
-			return "", fmt.Errorf("could not build a literal from string while trying to formatCell, got error: %v", err)
+			return "", fmt.Errorf("formatCell failed, could not build a text literal from the string %q, got error: %v", *c.S, err)
 		}
 		return strings.TrimSpace(formatted.ToComparableString()), nil
 	}
@@ -130,11 +130,11 @@ func (e *evaluationNode) Evaluate(r table.Row) (bool, error) {
 
 	csEL, err := formatCell(eL)
 	if err != nil {
-		return false, fmt.Errorf("in evaluationNode.Evaluate got error: %v", err)
+		return false, fmt.Errorf("evaluationNode.Evaluate failed, the call for formatCell(%s) returned error: %v", eL, err)
 	}
 	csER, err := formatCell(eR)
 	if err != nil {
-		return false, fmt.Errorf("in evaluationNode.Evaluate got error: %v", err)
+		return false, fmt.Errorf("evaluationNode.Evaluate failed, the call for formatCell(%s) returned error: %v", eR, err)
 	}
 
 	switch e.op {
@@ -173,7 +173,7 @@ type comparisonForLiteral struct {
 func (e *comparisonForLiteral) Evaluate(r table.Row) (bool, error) {
 	leftCell, err := cellFromRow(e.lS, r)
 	if err != nil {
-		return false, fmt.Errorf("in comparisonForLiteral.Evaluate got error: %v", err)
+		return false, fmt.Errorf("comparisonForLiteral.Evaluate failed, the call for cellFromRow(%v, %v) returned error: %v", e.lS, r, err)
 	}
 	if leftCell.L == nil && leftCell.S == nil {
 		return false, nil
@@ -181,7 +181,7 @@ func (e *comparisonForLiteral) Evaluate(r table.Row) (bool, error) {
 
 	rightLiteral, err := literal.DefaultBuilder().Parse(e.rS)
 	if err != nil {
-		return false, fmt.Errorf("in comparisonForLiteral.Evaluate got error: %v", err)
+		return false, fmt.Errorf("comparisonForLiteral.Evaluate failed, could not parse literal from the string %q, got error: %v", e.rS, err)
 	}
 	if leftCell.S != nil && rightLiteral.Type() != literal.Text {
 		return false, fmt.Errorf("a string binding can only be compared with a literal of type text, got literal %q instead", rightLiteral.String())
@@ -195,7 +195,7 @@ func (e *comparisonForLiteral) Evaluate(r table.Row) (bool, error) {
 	var csEL, csER string
 	csEL, err = formatCell(leftCell)
 	if err != nil {
-		return false, fmt.Errorf("in comparisonForLiteral.Evaluate got error: %v", err)
+		return false, fmt.Errorf("comparisonForLiteral.Evaluate failed, the call for formatCell(%s) returned error: %v", leftCell, err)
 	}
 	csER = rightLiteral.ToComparableString()
 
@@ -222,7 +222,7 @@ type comparisonForNodeLiteral struct {
 func (e *comparisonForNodeLiteral) Evaluate(r table.Row) (bool, error) {
 	eL, err := cellFromRow(e.lB, r)
 	if err != nil {
-		return false, fmt.Errorf("in comparisonForNodeLiteral.Evaluate got error: %v", err)
+		return false, fmt.Errorf("comparisonForNodeLiteral.Evaluate failed, the call for cellFromRow(%v, %v) returned error: %v", e.lB, r, err)
 	}
 	if eL.S != nil {
 		return false, fmt.Errorf("a string binding can only be compared with a literal of type text, got literal %q instead", strings.TrimSpace(e.rNL))
@@ -233,7 +233,7 @@ func (e *comparisonForNodeLiteral) Evaluate(r table.Row) (bool, error) {
 
 	csEL, err := formatCell(eL)
 	if err != nil {
-		return false, fmt.Errorf("in comparisonForNodeLiteral.Evaluate got error: %v", err)
+		return false, fmt.Errorf("comparisonForNodeLiteral.Evaluate failed, the call for formatCell(%s) returned error: %v", eL, err)
 	}
 	csER := strings.TrimSpace(e.rNL)
 

--- a/bql/semantic/expression.go
+++ b/bql/semantic/expression.go
@@ -114,11 +114,11 @@ func (e *evaluationNode) Evaluate(r table.Row) (bool, error) {
 		)
 		eL, ok = r[e.lB]
 		if !ok {
-			return nil, nil, fmt.Errorf("comparison operation requires the binding value for %q for row %q to exist", e.lB, r)
+			return nil, nil, fmt.Errorf("comparison operation requires the binding value for %q for row %v to exist", e.lB, r)
 		}
 		eR, ok = r[e.rB]
 		if !ok {
-			return nil, nil, fmt.Errorf("comparison operation requires the binding value for %q for row %q to exist", e.rB, r)
+			return nil, nil, fmt.Errorf("comparison operation requires the binding value for %q for row %v to exist", e.rB, r)
 		}
 		return eL, eR, nil
 	}
@@ -145,7 +145,7 @@ func (e *evaluationNode) Evaluate(r table.Row) (bool, error) {
 	case GT:
 		return csEL > csER, nil
 	default:
-		return false, fmt.Errorf("boolean evaluation requires a boolean operation; found %q instead", e.op)
+		return false, fmt.Errorf("boolean evaluation requires a boolean operation; found %q instead", e.op.String())
 	}
 }
 
@@ -157,7 +157,7 @@ func cellFromRow(binding string, r table.Row) (*table.Cell, error) {
 	)
 	val, ok = r[binding]
 	if !ok {
-		return nil, fmt.Errorf("comparison operation requires the binding value for %q for row %q to exist", binding, r)
+		return nil, fmt.Errorf("comparison operation requires the binding value for %q for row %v to exist", binding, r)
 	}
 	return val, nil
 }
@@ -207,7 +207,7 @@ func (e *comparisonForLiteral) Evaluate(r table.Row) (bool, error) {
 	case GT:
 		return csEL > csER, nil
 	default:
-		return false, fmt.Errorf("boolean evaluation requires a boolean operation; found %q instead", e.op)
+		return false, fmt.Errorf("boolean evaluation requires a boolean operation; found %q instead", e.op.String())
 	}
 }
 
@@ -245,7 +245,7 @@ func (e *comparisonForNodeLiteral) Evaluate(r table.Row) (bool, error) {
 	case GT:
 		return csEL > csER, nil
 	default:
-		return false, fmt.Errorf("boolean evaluation requires a boolean operation; found %q instead", e.op)
+		return false, fmt.Errorf("boolean evaluation requires a boolean operation; found %q instead", e.op.String())
 	}
 }
 
@@ -322,7 +322,7 @@ func (e *booleanNode) Evaluate(r table.Row) (bool, error) {
 			errL, errR error
 		)
 		if !e.lS {
-			return false, false, fmt.Errorf("boolean operations require a left operator; found (%q, %q) instead", e.lE, e.rE)
+			return false, false, fmt.Errorf(`boolean operations require a left operator; found "(%v, %v)" instead`, e.lE, e.rE)
 		}
 		eL, errL = e.lE.Evaluate(r)
 		if errL != nil {
@@ -330,7 +330,7 @@ func (e *booleanNode) Evaluate(r table.Row) (bool, error) {
 		}
 		if binary {
 			if !e.rS {
-				return false, false, fmt.Errorf("boolean operations require a left operator; found (%q, %q) instead", e.lE, e.rE)
+				return false, false, fmt.Errorf(`boolean operations require a right operator; found "(%v, %v)" instead`, e.lE, e.rE)
 			}
 			eR, errR = e.rE.Evaluate(r)
 			if errR != nil {
@@ -360,7 +360,7 @@ func (e *booleanNode) Evaluate(r table.Row) (bool, error) {
 		}
 		return !eL, nil
 	default:
-		return false, fmt.Errorf("boolean evaluation requires a boolen operation; found %q instead", e.op)
+		return false, fmt.Errorf("boolean evaluation requires a boolen operation; found %q instead", e.op.String())
 	}
 }
 
@@ -526,7 +526,7 @@ func internalNewEvaluator(ce []ConsumedElement) (Evaluator, []ConsumedElement, e
 
 	var tkns []string
 	for _, e := range ce {
-		tkns = append(tkns, fmt.Sprintf("%q", e.token.Type))
+		tkns = append(tkns, fmt.Sprintf("%q", e.token.Type.String()))
 	}
 	return nil, nil, fmt.Errorf("could not create an evaluator for condition {%s}", strings.Join(tkns, ","))
 }

--- a/bql/semantic/expression.go
+++ b/bql/semantic/expression.go
@@ -89,7 +89,7 @@ func formatCell(c *table.Cell) (string, error) {
 	if c.S != nil {
 		formatted, err := literal.DefaultBuilder().Build(literal.Text, *c.S)
 		if err != nil {
-			return "", fmt.Errorf("in formatCell, could not build literal from string - received error: %v", err)
+			return "", fmt.Errorf("could not build a literal from string while trying to formatCell, got error: %v", err)
 		}
 		return strings.TrimSpace(formatted.ToComparableString()), nil
 	}
@@ -187,9 +187,8 @@ func (e *comparisonForLiteral) Evaluate(r table.Row) (bool, error) {
 		return false, fmt.Errorf("a string binding can only be compared with a literal of type text, got literal %v instead", lit.String())
 	}
 
-	var (
-		csEL, csER string // comparable string expressions left and right
-	)
+	// comparable string expressions for left and right tokens.
+	var csEL, csER string
 	csEL, err = formatCell(leftCell)
 	if err != nil {
 		return false, fmt.Errorf("in comparisonForLiteral.Evaluate got error: %v", err)

--- a/bql/semantic/expression.go
+++ b/bql/semantic/expression.go
@@ -179,12 +179,16 @@ func (e *comparisonForLiteral) Evaluate(r table.Row) (bool, error) {
 		return false, nil
 	}
 
-	lit, err := literal.DefaultBuilder().Parse(e.rS)
+	rightLiteral, err := literal.DefaultBuilder().Parse(e.rS)
 	if err != nil {
 		return false, fmt.Errorf("in comparisonForLiteral.Evaluate got error: %v", err)
 	}
-	if leftCell.S != nil && lit.Type() != literal.Text {
-		return false, fmt.Errorf("a string binding can only be compared with a literal of type text, got literal %q instead", lit.String())
+	if leftCell.S != nil && rightLiteral.Type() != literal.Text {
+		return false, fmt.Errorf("a string binding can only be compared with a literal of type text, got literal %q instead", rightLiteral.String())
+	}
+
+	if leftCell.L != nil && leftCell.L.Type() != rightLiteral.Type() && !(leftCell.L.IsNumber() && rightLiteral.IsNumber()) {
+		return false, nil
 	}
 
 	// comparable string expressions for left and right tokens.
@@ -193,7 +197,7 @@ func (e *comparisonForLiteral) Evaluate(r table.Row) (bool, error) {
 	if err != nil {
 		return false, fmt.Errorf("in comparisonForLiteral.Evaluate got error: %v", err)
 	}
-	csER = lit.ToComparableString()
+	csER = rightLiteral.ToComparableString()
 
 	switch e.op {
 	case EQ:

--- a/bql/semantic/expression.go
+++ b/bql/semantic/expression.go
@@ -187,7 +187,7 @@ func (e *comparisonForLiteral) Evaluate(r table.Row) (bool, error) {
 		return false, fmt.Errorf("a string binding can only be compared with a literal of type text, got literal %q instead", rightLiteral.String())
 	}
 
-	if leftCell.L != nil && leftCell.L.Type() != rightLiteral.Type() && !(leftCell.L.IsNumber() && rightLiteral.IsNumber()) {
+	if leftCell.L != nil && leftCell.L.Type() != rightLiteral.Type() {
 		return false, nil
 	}
 

--- a/bql/semantic/expression.go
+++ b/bql/semantic/expression.go
@@ -184,7 +184,7 @@ func (e *comparisonForLiteral) Evaluate(r table.Row) (bool, error) {
 		return false, fmt.Errorf("in comparisonForLiteral.Evaluate got error: %v", err)
 	}
 	if leftCell.S != nil && lit.Type() != literal.Text {
-		return false, fmt.Errorf("a string binding can only be compared with a literal of type text, got literal %v instead", lit.String())
+		return false, fmt.Errorf("a string binding can only be compared with a literal of type text, got literal %q instead", lit.String())
 	}
 
 	// comparable string expressions for left and right tokens.

--- a/bql/semantic/expression_test.go
+++ b/bql/semantic/expression_test.go
@@ -192,7 +192,7 @@ func TestBooleanEvaluationNode(t *testing.T) {
 func buildLiteralOrDie(textLiteral string) *literal.Literal {
 	lit, err := literal.DefaultBuilder().Parse(textLiteral)
 	if err != nil {
-		panic("Could not parse text literal got err: " + err.Error())
+		panic(fmt.Sprintf("Could not parse text literal got err: %v", err.Error()))
 	}
 	return lit
 }
@@ -575,6 +575,48 @@ func TestNewEvaluator(t *testing.T) {
 			},
 			err:  false,
 			want: true,
+		},
+		{
+			id: `?o > "37"^^type:int64`,
+			in: []ConsumedElement{
+				NewConsumedToken(&lexer.Token{
+					Type: lexer.ItemBinding,
+					Text: "?o",
+				}),
+				NewConsumedToken(&lexer.Token{
+					Type: lexer.ItemGT,
+				}),
+				NewConsumedToken(&lexer.Token{
+					Type: lexer.ItemLiteral,
+					Text: `"37"^^type:int64`,
+				}),
+			},
+			r: table.Row{
+				"?o": &table.Cell{N: newNodeFromStringOrDie("/u", "paul")},
+			},
+			err:  false,
+			want: false,
+		},
+		{
+			id: `?o = /u<peter>`,
+			in: []ConsumedElement{
+				NewConsumedToken(&lexer.Token{
+					Type: lexer.ItemBinding,
+					Text: "?o",
+				}),
+				NewConsumedToken(&lexer.Token{
+					Type: lexer.ItemEQ,
+				}),
+				NewConsumedToken(&lexer.Token{
+					Type: lexer.ItemNode,
+					Text: "/u<peter>",
+				}),
+			},
+			r: table.Row{
+				"?o": &table.Cell{L: buildLiteralOrDie(`"73"^^type:int64`)},
+			},
+			err:  false,
+			want: false,
 		},
 		{
 			id: `?s ID ?id > "37"^^type:int64`,

--- a/bql/semantic/expression_test.go
+++ b/bql/semantic/expression_test.go
@@ -702,27 +702,6 @@ func TestNewEvaluator(t *testing.T) {
 			err:  false,
 			want: false,
 		},
-		{
-			id: `?foo > "10"^^type:int64`,
-			in: []ConsumedElement{
-				NewConsumedToken(&lexer.Token{
-					Type: lexer.ItemBinding,
-					Text: "?foo",
-				}),
-				NewConsumedToken(&lexer.Token{
-					Type: lexer.ItemGT,
-				}),
-				NewConsumedToken(&lexer.Token{
-					Type: lexer.ItemLiteral,
-					Text: `"10"^^type:int64`,
-				}),
-			},
-			r: table.Row{
-				"?foo": &table.Cell{L: mustBuildLiteral(`"100.0"^^type:float64`)},
-			},
-			err:  false,
-			want: true,
-		},
 	}
 	for _, entry := range testTable {
 		eval, err := NewEvaluator(entry.in)

--- a/bql/semantic/expression_test.go
+++ b/bql/semantic/expression_test.go
@@ -493,6 +493,27 @@ func TestNewEvaluator(t *testing.T) {
 			want: false,
 		},
 		{
+			id: `?s TYPE ?s_type = "/u"^^type:text`,
+			in: []ConsumedElement{
+				NewConsumedToken(&lexer.Token{
+					Type: lexer.ItemBinding,
+					Text: "?s_type",
+				}),
+				NewConsumedToken(&lexer.Token{
+					Type: lexer.ItemEQ,
+				}),
+				NewConsumedToken(&lexer.Token{
+					Type: lexer.ItemLiteral,
+					Text: `"/u"^^type:text`,
+				}),
+			},
+			r: table.Row{
+				"?s_type": &table.Cell{S: table.CellString("/u")},
+			},
+			err:  false,
+			want: true,
+		},
+		{
 			id: `?foo = "99.0"^^type:float64`,
 			in: []ConsumedElement{
 				NewConsumedToken(&lexer.Token{

--- a/bql/semantic/expression_test.go
+++ b/bql/semantic/expression_test.go
@@ -189,18 +189,18 @@ func TestBooleanEvaluationNode(t *testing.T) {
 	}
 }
 
-func buildLiteralOrDie(textLiteral string) *literal.Literal {
+func mustBuildLiteral(textLiteral string) *literal.Literal {
 	lit, err := literal.DefaultBuilder().Parse(textLiteral)
 	if err != nil {
-		panic(fmt.Sprintf("Could not parse text literal got err: %v", err.Error()))
+		panic(fmt.Sprintf("could not parse text literal %q, got error: %v", textLiteral, err))
 	}
 	return lit
 }
 
-func newNodeFromStringOrDie(nodeType, nodeID string) *node.Node {
+func mustBuildNodeFromStrings(nodeType, nodeID string) *node.Node {
 	n, err := node.NewNodeFromStrings(nodeType, nodeID)
 	if err != nil {
-		panic(fmt.Sprintf("Could not build node from type %q and value %q", nodeType, nodeID))
+		panic(fmt.Sprintf("could not build node from type %q and ID %q, got error: %v", nodeType, nodeID, err))
 	}
 	return n
 }
@@ -423,7 +423,7 @@ func TestNewEvaluator(t *testing.T) {
 			},
 			r: table.Row{
 				"?foo": &table.Cell{
-					L: buildLiteralOrDie(`"abc"^^type:text`),
+					L: mustBuildLiteral(`"abc"^^type:text`),
 				},
 			},
 			err:  false,
@@ -529,7 +529,7 @@ func TestNewEvaluator(t *testing.T) {
 				}),
 			},
 			r: table.Row{
-				"?foo": &table.Cell{L: buildLiteralOrDie(`"99.0"^^type:float64`)},
+				"?foo": &table.Cell{L: mustBuildLiteral(`"99.0"^^type:float64`)},
 			},
 			err:  false,
 			want: true,
@@ -550,7 +550,7 @@ func TestNewEvaluator(t *testing.T) {
 				}),
 			},
 			r: table.Row{
-				"?foo": &table.Cell{L: buildLiteralOrDie(`"100"^^type:int64`)},
+				"?foo": &table.Cell{L: mustBuildLiteral(`"100"^^type:int64`)},
 			},
 			err:  false,
 			want: true,
@@ -571,7 +571,7 @@ func TestNewEvaluator(t *testing.T) {
 				}),
 			},
 			r: table.Row{
-				"?foo": &table.Cell{L: buildLiteralOrDie(`"100"^^type:int64`)},
+				"?foo": &table.Cell{L: mustBuildLiteral(`"100"^^type:int64`)},
 			},
 			err:  false,
 			want: false,
@@ -592,7 +592,7 @@ func TestNewEvaluator(t *testing.T) {
 				}),
 			},
 			r: table.Row{
-				"?foo": &table.Cell{N: newNodeFromStringOrDie("/_", "meowth")},
+				"?foo": &table.Cell{N: mustBuildNodeFromStrings("/_", "meowth")},
 			},
 			err:  false,
 			want: true,
@@ -613,7 +613,7 @@ func TestNewEvaluator(t *testing.T) {
 				}),
 			},
 			r: table.Row{
-				"?o": &table.Cell{N: newNodeFromStringOrDie("/u", "paul")},
+				"?o": &table.Cell{N: mustBuildNodeFromStrings("/u", "paul")},
 			},
 			err:  false,
 			want: false,
@@ -634,7 +634,7 @@ func TestNewEvaluator(t *testing.T) {
 				}),
 			},
 			r: table.Row{
-				"?o": &table.Cell{L: buildLiteralOrDie(`"73"^^type:int64`)},
+				"?o": &table.Cell{L: mustBuildLiteral(`"73"^^type:int64`)},
 			},
 			err:  false,
 			want: false,
@@ -697,7 +697,7 @@ func TestNewEvaluator(t *testing.T) {
 				}),
 			},
 			r: table.Row{
-				"?foo": &table.Cell{L: buildLiteralOrDie(`"10"^^type:int64`)},
+				"?foo": &table.Cell{L: mustBuildLiteral(`"10"^^type:int64`)},
 			},
 			err:  false,
 			want: false,
@@ -718,7 +718,7 @@ func TestNewEvaluator(t *testing.T) {
 				}),
 			},
 			r: table.Row{
-				"?foo": &table.Cell{L: buildLiteralOrDie(`"100.0"^^type:float64`)},
+				"?foo": &table.Cell{L: mustBuildLiteral(`"100.0"^^type:float64`)},
 			},
 			err:  false,
 			want: true,

--- a/bql/semantic/expression_test.go
+++ b/bql/semantic/expression_test.go
@@ -98,7 +98,7 @@ func TestEvaluationNode(t *testing.T) {
 	for _, entry := range testTable {
 		got, err := entry.eval.Evaluate(entry.r)
 		if !entry.err && err != nil {
-			t.Errorf("failed to evaluate op %q for %v on row %v with error %v", entry.eval.(*evaluationNode).op.String(), entry.eval, entry.r, err)
+			t.Errorf("failed to evaluate op %q for %v on row %v with error: %v", entry.eval.(*evaluationNode).op.String(), entry.eval, entry.r, err)
 		}
 		if want := entry.want; got != want {
 			t.Errorf("failed to evaluate op %q for %v on row %v; got %v, want %v", entry.eval.(*evaluationNode).op.String(), entry.eval, entry.r, got, want)
@@ -181,7 +181,7 @@ func TestBooleanEvaluationNode(t *testing.T) {
 	for _, entry := range testTable {
 		got, err := entry.eval.Evaluate(table.Row{})
 		if !entry.err && err != nil {
-			t.Errorf("failed to evaluate op %q for %v with error %v", entry.eval.(*booleanNode).op.String(), entry.eval, err)
+			t.Errorf("failed to evaluate op %q for %v with error: %v", entry.eval.(*booleanNode).op.String(), entry.eval, err)
 		}
 		if want := entry.want; got != want {
 			t.Errorf("failed to evaluate op %q for %v; got %v, want %v", entry.eval.(*booleanNode).op.String(), entry.eval, got, want)
@@ -727,18 +727,18 @@ func TestNewEvaluator(t *testing.T) {
 	for _, entry := range testTable {
 		eval, err := NewEvaluator(entry.in)
 		if err != nil {
-			t.Fatalf("test %q should have never failed to process %v with error: %v", entry.id, entry.in, err)
+			t.Fatalf("test %q should have never failed when creating a new evaluator from %v, got error: %v", entry.id, entry.in, err)
 		}
 
 		got, err := eval.Evaluate(entry.r)
 		if !entry.err && err != nil {
-			t.Errorf("test %q the created evaluator failed to evaluate row %v with error: %v", entry.id, entry.r, err)
+			t.Errorf("%s: eval.Evaluate(%v) = _, %v; want nil error", entry.id, entry.r, err)
 		}
 		if entry.err && err == nil {
-			t.Errorf("test %q the created evaluator should have returned an error when evaluating row %v", entry.id, entry.r)
+			t.Errorf("%s: eval.Evaluate(%v) = _, nil; want non-nil error", entry.id, entry.r)
 		}
 		if want := entry.want; got != want {
-			t.Errorf("test %q failed to evaluate the proper value; got %v, want %v", entry.id, got, want)
+			t.Errorf("%s: eval.Evaluate(%v) = %v, _; want %v, _", entry.id, entry.r, got, want)
 		}
 	}
 }

--- a/bql/semantic/expression_test.go
+++ b/bql/semantic/expression_test.go
@@ -660,6 +660,48 @@ func TestNewEvaluator(t *testing.T) {
 			err:  true,
 			want: false,
 		},
+		{
+			id: `?foo = "10"^^type:text`,
+			in: []ConsumedElement{
+				NewConsumedToken(&lexer.Token{
+					Type: lexer.ItemBinding,
+					Text: "?foo",
+				}),
+				NewConsumedToken(&lexer.Token{
+					Type: lexer.ItemEQ,
+				}),
+				NewConsumedToken(&lexer.Token{
+					Type: lexer.ItemLiteral,
+					Text: `"10"^^type:text`,
+				}),
+			},
+			r: table.Row{
+				"?foo": &table.Cell{L: buildLiteralOrDie(`"10"^^type:int64`)},
+			},
+			err:  false,
+			want: false,
+		},
+		{
+			id: `?foo > "10"^^type:int64`,
+			in: []ConsumedElement{
+				NewConsumedToken(&lexer.Token{
+					Type: lexer.ItemBinding,
+					Text: "?foo",
+				}),
+				NewConsumedToken(&lexer.Token{
+					Type: lexer.ItemGT,
+				}),
+				NewConsumedToken(&lexer.Token{
+					Type: lexer.ItemLiteral,
+					Text: `"10"^^type:int64`,
+				}),
+			},
+			r: table.Row{
+				"?foo": &table.Cell{L: buildLiteralOrDie(`"100.0"^^type:float64`)},
+			},
+			err:  false,
+			want: true,
+		},
 	}
 	for _, entry := range testTable {
 		eval, err := NewEvaluator(entry.in)

--- a/bql/semantic/expression_test.go
+++ b/bql/semantic/expression_test.go
@@ -200,7 +200,7 @@ func buildLiteralOrDie(textLiteral string) *literal.Literal {
 func newNodeFromStringOrDie(nodeType, nodeID string) *node.Node {
 	n, err := node.NewNodeFromStrings(nodeType, nodeID)
 	if err != nil {
-		panic(fmt.Sprintf("Could not build node from type %s and value %s", nodeType, nodeID))
+		panic(fmt.Sprintf("Could not build node from type %q and value %q", nodeType, nodeID))
 	}
 	return n
 }

--- a/bql/semantic/expression_test.go
+++ b/bql/semantic/expression_test.go
@@ -98,10 +98,10 @@ func TestEvaluationNode(t *testing.T) {
 	for _, entry := range testTable {
 		got, err := entry.eval.Evaluate(entry.r)
 		if !entry.err && err != nil {
-			t.Errorf("failed to evaluate op %q for %v on row %v with error %v", entry.eval.(*evaluationNode).op, entry.eval, entry.r, err)
+			t.Errorf("failed to evaluate op %q for %v on row %v with error %v", entry.eval.(*evaluationNode).op.String(), entry.eval, entry.r, err)
 		}
 		if want := entry.want; got != want {
-			t.Errorf("failed to evaluate op %q for %v on row %v; got %v, want %v", entry.eval.(*evaluationNode).op, entry.eval, entry.r, got, want)
+			t.Errorf("failed to evaluate op %q for %v on row %v; got %v, want %v", entry.eval.(*evaluationNode).op.String(), entry.eval, entry.r, got, want)
 		}
 	}
 }
@@ -181,10 +181,10 @@ func TestBooleanEvaluationNode(t *testing.T) {
 	for _, entry := range testTable {
 		got, err := entry.eval.Evaluate(table.Row{})
 		if !entry.err && err != nil {
-			t.Errorf("failed to evaluate op %q for %v with error %v", entry.eval.(*booleanNode).op, entry.eval, err)
+			t.Errorf("failed to evaluate op %q for %v with error %v", entry.eval.(*booleanNode).op.String(), entry.eval, err)
 		}
 		if want := entry.want; got != want {
-			t.Errorf("failed to evaluate op %q for %v; got %v, want %v", entry.eval.(*booleanNode).op, entry.eval, got, want)
+			t.Errorf("failed to evaluate op %q for %v; got %v, want %v", entry.eval.(*booleanNode).op.String(), entry.eval, got, want)
 		}
 	}
 }

--- a/bql/semantic/expression_test.go
+++ b/bql/semantic/expression_test.go
@@ -24,14 +24,6 @@ import (
 	"github.com/google/badwolf/triple/node"
 )
 
-func buildLiteral(l string) string {
-	p, err := literal.DefaultBuilder().Parse(l)
-	if err != nil {
-		return ""
-	}
-	return p.ToComparableString()
-}
-
 func TestEvaluationNode(t *testing.T) {
 	testTable := []struct {
 		eval Evaluator
@@ -415,7 +407,7 @@ func TestNewEvaluator(t *testing.T) {
 			want: false,
 		},
 		{
-			id: "?foo = \"abc\"^^type:text",
+			id: `?foo = "abc"^^type:text`,
 			in: []ConsumedElement{
 				NewConsumedToken(&lexer.Token{
 					Type: lexer.ItemBinding,
@@ -426,7 +418,7 @@ func TestNewEvaluator(t *testing.T) {
 				}),
 				NewConsumedToken(&lexer.Token{
 					Type: lexer.ItemLiteral,
-					Text: "\"abc\"^^type:text",
+					Text: `"abc"^^type:text`,
 				}),
 			},
 			r: table.Row{
@@ -438,7 +430,7 @@ func TestNewEvaluator(t *testing.T) {
 			want: true,
 		},
 		{
-			id: "?s ID ?id = \"abc\"^^type:text",
+			id: `?s ID ?id = "abc"^^type:text`,
 			in: []ConsumedElement{
 				NewConsumedToken(&lexer.Token{
 					Type: lexer.ItemBinding,
@@ -449,7 +441,7 @@ func TestNewEvaluator(t *testing.T) {
 				}),
 				NewConsumedToken(&lexer.Token{
 					Type: lexer.ItemLiteral,
-					Text: "\"abc\"^^type:text",
+					Text: `"abc"^^type:text`,
 				}),
 			},
 			r: table.Row{
@@ -459,7 +451,7 @@ func TestNewEvaluator(t *testing.T) {
 			want: true,
 		},
 		{
-			id: "?s ID ?id < \"bbb\"^^type:text",
+			id: `?s ID ?id < "bbb"^^type:text`,
 			in: []ConsumedElement{
 				NewConsumedToken(&lexer.Token{
 					Type: lexer.ItemBinding,
@@ -470,7 +462,7 @@ func TestNewEvaluator(t *testing.T) {
 				}),
 				NewConsumedToken(&lexer.Token{
 					Type: lexer.ItemLiteral,
-					Text: "\"bbb\"^^type:text",
+					Text: `"bbb"^^type:text`,
 				}),
 			},
 			r: table.Row{
@@ -480,7 +472,7 @@ func TestNewEvaluator(t *testing.T) {
 			want: true,
 		},
 		{
-			id: "?s ID ?id > \"ccc\"^^type:text",
+			id: `?s ID ?id > "ccc"^^type:text`,
 			in: []ConsumedElement{
 				NewConsumedToken(&lexer.Token{
 					Type: lexer.ItemBinding,
@@ -491,7 +483,7 @@ func TestNewEvaluator(t *testing.T) {
 				}),
 				NewConsumedToken(&lexer.Token{
 					Type: lexer.ItemLiteral,
-					Text: "\"ccc\"^^type:text",
+					Text: `"ccc"^^type:text`,
 				}),
 			},
 			r: table.Row{
@@ -501,7 +493,7 @@ func TestNewEvaluator(t *testing.T) {
 			want: false,
 		},
 		{
-			id: "?foo = \"99.0\"^^type:float64",
+			id: `?foo = "99.0"^^type:float64`,
 			in: []ConsumedElement{
 				NewConsumedToken(&lexer.Token{
 					Type: lexer.ItemBinding,
@@ -512,7 +504,7 @@ func TestNewEvaluator(t *testing.T) {
 				}),
 				NewConsumedToken(&lexer.Token{
 					Type: lexer.ItemLiteral,
-					Text: "\"99.0\"^^type:float64",
+					Text: `"99.0"^^type:float64`,
 				}),
 			},
 			r: table.Row{
@@ -522,7 +514,7 @@ func TestNewEvaluator(t *testing.T) {
 			want: true,
 		},
 		{
-			id: "?foo > \"10\"^^type:int64",
+			id: `?foo > "10"^^type:int64`,
 			in: []ConsumedElement{
 				NewConsumedToken(&lexer.Token{
 					Type: lexer.ItemBinding,
@@ -533,7 +525,7 @@ func TestNewEvaluator(t *testing.T) {
 				}),
 				NewConsumedToken(&lexer.Token{
 					Type: lexer.ItemLiteral,
-					Text: "\"10\"^^type:int64",
+					Text: `"10"^^type:int64`,
 				}),
 			},
 			r: table.Row{
@@ -543,7 +535,7 @@ func TestNewEvaluator(t *testing.T) {
 			want: true,
 		},
 		{
-			id: "?foo < \"10\"^^type:int64",
+			id: `?foo < "10"^^type:int64`,
 			in: []ConsumedElement{
 				NewConsumedToken(&lexer.Token{
 					Type: lexer.ItemBinding,
@@ -554,11 +546,11 @@ func TestNewEvaluator(t *testing.T) {
 				}),
 				NewConsumedToken(&lexer.Token{
 					Type: lexer.ItemLiteral,
-					Text: "\"10\"^^type:int64",
+					Text: `"10"^^type:int64`,
 				}),
 			},
 			r: table.Row{
-				"?foo": &table.Cell{L: buildLiteralOrDie("\"100\"^^type:int64")},
+				"?foo": &table.Cell{L: buildLiteralOrDie(`"100"^^type:int64`)},
 			},
 			err:  false,
 			want: false,

--- a/bql/semantic/expression_test.go
+++ b/bql/semantic/expression_test.go
@@ -622,12 +622,12 @@ func TestNewEvaluator(t *testing.T) {
 	for _, entry := range testTable {
 		eval, err := NewEvaluator(entry.in)
 		if err != nil {
-			t.Fatalf("test %q should have never failed to process %v with error %v", entry.id, entry.in, err)
+			t.Fatalf("test %q should have never failed to process %v with error: %v", entry.id, entry.in, err)
 		}
 
 		got, err := eval.Evaluate(entry.r)
 		if !entry.err && err != nil {
-			t.Errorf("test %q the created evaluator failed to evaluate row %v with error %v", entry.id, entry.r, err)
+			t.Errorf("test %q the created evaluator failed to evaluate row %v with error: %v", entry.id, entry.r, err)
 		}
 		if entry.err && err == nil {
 			t.Errorf("test %q the created evaluator should have returned an error when evaluating row %v", entry.id, entry.r)

--- a/docs/bql.md
+++ b/docs/bql.md
@@ -407,7 +407,7 @@ that would require multiple clauses and extra bindings:
 ```
 
 Note that the intervals defined by `before`, `after`, and `between` are always closed (the 
-limits of the intervals are included). You can then understand the `after` as a '>=', the 
+limits of the intervals are included). You can then understand the `after` as a `>=`, the 
 `before` as a `<=` and the `between` as a combination of them.
 
 Also, remember that bindings may take time anchor values so you could also query

--- a/triple/literal/literal.go
+++ b/triple/literal/literal.go
@@ -90,11 +90,6 @@ func (l *Literal) ToComparableString() string {
 	return s
 }
 
-// IsNumber returns if the literal is indeed a number (Int64 or Float64).
-func (l *Literal) IsNumber() bool {
-	return l.Type() == Int64 || l.Type() == Float64
-}
-
 // Bool returns the value of a literal as a boolean.
 func (l *Literal) Bool() (bool, error) {
 	if l.t != Bool {

--- a/triple/literal/literal.go
+++ b/triple/literal/literal.go
@@ -90,6 +90,11 @@ func (l *Literal) ToComparableString() string {
 	return s
 }
 
+// IsNumber returns if the literal is indeed a number (Int64 or Float64).
+func (l *Literal) IsNumber() bool {
+	return l.Type() == Int64 || l.Type() == Float64
+}
+
 // Bool returns the value of a literal as a boolean.
 func (l *Literal) Bool() (bool, error) {
 	if l.t != Bool {


### PR DESCRIPTION
Previously, comparisons between ID bindings and text literals inside HAVING clauses (such as below) were not effective:

```
SELECT ?s, ?predID, ?o
FROM ?family
WHERE {
  ?s ?p ID ?predID ?o
}
HAVING ?predID < "parent_of"^^type:text;
```

Now, they are fully supported (`<`, `>` and `=`), proceeding as a lexicographical comparison between the ID binding and the text literal that follows.

The same is now supported for bindings created using the TYPE keyword too.

Error handling for comparison expressions were also improved.