### PR TITLE
Fix bug of TYPE bindings with non-node objects and AT bindings with immutable triples (Issue #113)

### DIFF
--- a/bql/planner/data_access.go
+++ b/bql/planner/data_access.go
@@ -570,7 +570,8 @@ func tripleToRow(t *triple.Triple, cls *semantic.GraphClause) (table.Row, error)
 	}
 	if cls.PAnchorBinding != "" {
 		if p.Type() != predicate.Temporal {
-			return nil, fmt.Errorf("cannot retrieve the time anchor value for non temporal predicate %q in binding %q", p, cls.PAnchorBinding)
+			// in the case of time anchor binding (eg: "bought"@[?time]) for an immutable predicate we just want (for now) to skip this triple and proceed to the next one, not returning any errors.
+			return nil, nil
 		}
 		t, err := p.TimeAnchor()
 		if err != nil {

--- a/bql/planner/data_access.go
+++ b/bql/planner/data_access.go
@@ -567,7 +567,7 @@ func tripleToRow(t *triple.Triple, cls *semantic.GraphClause) (table.Row, error)
 	}
 	if cls.PAnchorBinding != "" {
 		if p.Type() != predicate.Temporal {
-			// in the case of time anchor binding (eg: "bought"@[?time]) for an immutable predicate we just want (for now) to skip this triple and proceed to the next one, not returning any errors.
+			// in the case of time anchor binding (eg: "bought"@[?time]) for an immutable predicate we just want to skip this triple and proceed to the next one, not returning any errors.
 			return nil, nil
 		}
 		t, err := p.TimeAnchor()
@@ -582,7 +582,7 @@ func tripleToRow(t *triple.Triple, cls *semantic.GraphClause) (table.Row, error)
 	}
 	if cls.PAnchorAlias != "" {
 		if p.Type() != predicate.Temporal {
-			// in the case of AT binding for an immutable predicate we just want (for now) to skip this triple and proceed to the next one, not returning any errors.
+			// in the case of AT binding for an immutable predicate we just want to skip this triple and proceed to the next one, not returning any errors.
 			return nil, nil
 		}
 		t, err := p.TimeAnchor()
@@ -622,7 +622,7 @@ func tripleToRow(t *triple.Triple, cls *semantic.GraphClause) (table.Row, error)
 	if cls.OTypeAlias != "" {
 		n, err := o.Node()
 		if err != nil {
-			// in the case of TYPE binding for a non-node object we just want (for now) to skip this triple and proceed to the next one, not returning any errors.
+			// in the case of TYPE binding for a non-node object we just want to skip this triple and proceed to the next one, not returning any errors.
 			return nil, nil
 		}
 		c := &table.Cell{S: table.CellString(n.Type().String())}

--- a/bql/planner/data_access.go
+++ b/bql/planner/data_access.go
@@ -624,7 +624,8 @@ func tripleToRow(t *triple.Triple, cls *semantic.GraphClause) (table.Row, error)
 	if cls.OTypeAlias != "" {
 		n, err := o.Node()
 		if err != nil {
-			return nil, err
+			// in the case of TYPE binding for a non-node object we just want (for now) to skip this triple and proceed to the next one, not returning any errors.
+			return nil, nil
 		}
 		c := &table.Cell{S: table.CellString(n.Type().String())}
 		r[cls.OTypeAlias] = c

--- a/bql/planner/data_access.go
+++ b/bql/planner/data_access.go
@@ -582,10 +582,10 @@ func tripleToRow(t *triple.Triple, cls *semantic.GraphClause) (table.Row, error)
 			return nil, nil
 		}
 	}
-
 	if cls.PAnchorAlias != "" {
 		if p.Type() != predicate.Temporal {
-			return nil, fmt.Errorf("cannot retrieve the time anchor value for non temporal predicate %q in binding %q", p, cls.PAnchorAlias)
+			// in the case of AT binding for an immutable predicate we just want (for now) to skip this triple and proceed to the next one, not returning any errors.
+			return nil, nil
 		}
 		t, err := p.TimeAnchor()
 		if err != nil {

--- a/bql/planner/data_access.go
+++ b/bql/planner/data_access.go
@@ -475,9 +475,10 @@ func addTriples(ts <-chan *triple.Triple, cls *semantic.GraphClause, tbl *table.
 		if err != nil {
 			break
 		}
-		if r != nil {
-			tbl.AddRow(r)
+		if r == nil {
+			continue
 		}
+		tbl.AddRow(r)
 	}
 	// Drain the channel to avoid leaking goroutines in the case the loop above was interrupted by an error.
 	for range ts {

--- a/bql/planner/data_access.go
+++ b/bql/planner/data_access.go
@@ -472,11 +472,8 @@ func addTriples(ts <-chan *triple.Triple, cls *semantic.GraphClause, tbl *table.
 			tbl.AddRow(r)
 		}
 	}
-	if lastErr != nil {
-		return lastErr
-	}
 
-	return nil
+	return lastErr
 }
 
 // objectToCell returns a cell containing the data boxed in the object.

--- a/bql/planner/planner_test.go
+++ b/bql/planner/planner_test.go
@@ -689,6 +689,15 @@ func TestPlannerQuery(t *testing.T) {
 			nBindings: 3,
 			nRows:     4,
 		},
+		{
+			q: `SELECT ?s, ?time, ?o
+				FROM ?test
+				WHERE {
+					?s "parent_of"@[?time] ?o
+				};`,
+			nBindings: 3,
+			nRows:     0,
+		},
 	}
 
 	s, ctx := memory.NewStore(), context.Background()

--- a/bql/planner/planner_test.go
+++ b/bql/planner/planner_test.go
@@ -680,6 +680,15 @@ func TestPlannerQuery(t *testing.T) {
 			nBindings: 2,
 			nRows:     2,
 		},
+		{
+			q: `SELECT ?p, ?time, ?o
+				FROM ?test
+				WHERE {
+					/u<peter> ?p AT ?time ?o
+				};`,
+			nBindings: 3,
+			nRows:     4,
+		},
 	}
 
 	s, ctx := memory.NewStore(), context.Background()

--- a/bql/planner/planner_test.go
+++ b/bql/planner/planner_test.go
@@ -670,6 +670,16 @@ func TestPlannerQuery(t *testing.T) {
 			nBindings: 3,
 			nRows:     4,
 		},
+		{
+			q: `SELECT ?o, ?o_type
+				FROM ?test
+				WHERE {
+					?s ?p ?o TYPE ?o_type
+				}
+				HAVING (?s = /u<joe>) OR (?s = /l<barcelona>) OR (?s = /u<alice>);`,
+			nBindings: 2,
+			nRows:     2,
+		},
 	}
 
 	s, ctx := memory.NewStore(), context.Background()


### PR DESCRIPTION
Previously, when extracting the TYPE of an object through a TYPE binding, you would find a **deadlock** and the program would freeze if you had objects that were not nodes in your graph. 

For example, in the graph `?family` with the following triples:

```
INSERT DATA INTO ?family {
  /u<peter> "height_cm"@[2006-01-02T15:04:05.999999999Z] "172"^^type:int64 .
  /u<joe> "height_cm"@[2006-01-02T15:04:05.999999999Z] "174"^^type:int64 .
  /u<joe> "parent_of"@[] /u<peter>
};
```

If you executed the following query:

```
SELECT ?o_type
FROM ?family
WHERE {
 /u<joe> ?p ?o TYPE ?o_type
};
```

You would have a deadlock due to the fact that your query would try to extract the TYPE from a literal object (eg: `"174"^^type:int64` here), that does not have a TYPE as in the case of a node object. It would also happen if you had objects that were predicates in your graph (like in the case of a reification). 

This PR comes to fix this problem.

It also fixes the problem of a deadlock when your query tries to extract the time anchor through AT bindings and you have immutable triples in your graph. This later problem with AT bindings and immutable triples is detailed in the issue https://github.com/google/badwolf/issues/113.