### PR TITLE
Fixing grammar for navigability

### DIFF
--- a/bql/grammar/grammar.go
+++ b/bql/grammar/grammar.go
@@ -25,980 +25,1050 @@ import (
 	"github.com/google/badwolf/bql/semantic"
 )
 
+var (
+	startClauses = []*Clause{
+		{
+			Elements: []Element{
+				NewTokenType(lexer.ItemQuery),
+				NewSymbol("VARS"),
+				NewTokenType(lexer.ItemFrom),
+				NewSymbol("INPUT_GRAPHS"),
+				NewSymbol("WHERE"),
+				NewSymbol("GROUP_BY"),
+				NewSymbol("ORDER_BY"),
+				NewSymbol("HAVING"),
+				NewSymbol("GLOBAL_TIME_BOUND"),
+				NewSymbol("LIMIT"),
+				NewTokenType(lexer.ItemSemicolon),
+			},
+		},
+		{
+			Elements: []Element{
+				NewTokenType(lexer.ItemInsert),
+				NewTokenType(lexer.ItemData),
+				NewTokenType(lexer.ItemInto),
+				NewSymbol("OUTPUT_GRAPHS"),
+				NewTokenType(lexer.ItemLBracket),
+				NewTokenType(lexer.ItemNode),
+				NewTokenType(lexer.ItemPredicate),
+				NewSymbol("INSERT_OBJECT"),
+				NewSymbol("INSERT_DATA"),
+				NewTokenType(lexer.ItemRBracket),
+				NewTokenType(lexer.ItemSemicolon),
+			},
+		},
+		{
+			Elements: []Element{
+				NewTokenType(lexer.ItemDelete),
+				NewTokenType(lexer.ItemData),
+				NewTokenType(lexer.ItemFrom),
+				NewSymbol("INPUT_GRAPHS"),
+				NewTokenType(lexer.ItemLBracket),
+				NewTokenType(lexer.ItemNode),
+				NewTokenType(lexer.ItemPredicate),
+				NewSymbol("DELETE_OBJECT"),
+				NewSymbol("DELETE_DATA"),
+				NewTokenType(lexer.ItemRBracket),
+				NewTokenType(lexer.ItemSemicolon),
+			},
+		},
+		{
+			Elements: []Element{
+				NewTokenType(lexer.ItemCreate),
+				NewSymbol("CREATE_GRAPHS"),
+				NewTokenType(lexer.ItemSemicolon),
+			},
+		},
+		{
+			Elements: []Element{
+				NewTokenType(lexer.ItemDrop),
+				NewSymbol("DROP_GRAPHS"),
+				NewTokenType(lexer.ItemSemicolon),
+			},
+		},
+		{
+			Elements: []Element{
+				NewTokenType(lexer.ItemConstruct),
+				NewSymbol("CONSTRUCT_FACTS"),
+				NewTokenType(lexer.ItemInto),
+				NewSymbol("OUTPUT_GRAPHS"),
+				NewTokenType(lexer.ItemFrom),
+				NewSymbol("INPUT_GRAPHS"),
+				NewSymbol("WHERE"),
+				NewSymbol("HAVING"),
+				NewTokenType(lexer.ItemSemicolon),
+			},
+		},
+		{
+			Elements: []Element{
+				NewTokenType(lexer.ItemDeconstruct),
+				NewSymbol("DECONSTRUCT_FACTS"),
+				NewTokenType(lexer.ItemIn),
+				NewSymbol("OUTPUT_GRAPHS"),
+				NewTokenType(lexer.ItemFrom),
+				NewSymbol("INPUT_GRAPHS"),
+				NewSymbol("WHERE"),
+				NewSymbol("HAVING"),
+				NewTokenType(lexer.ItemSemicolon),
+			},
+		},
+		{
+			Elements: []Element{
+				NewTokenType(lexer.ItemShow),
+				NewSymbol("GRAPH_SHOW"),
+				NewTokenType(lexer.ItemSemicolon),
+			},
+		},
+	}
+	createGraphClauses = []*Clause{
+		{
+			Elements: []Element{
+				NewTokenType(lexer.ItemGraph),
+				NewSymbol("GRAPHS"),
+			},
+		},
+	}
+	dropGraphClauses = []*Clause{
+		{
+			Elements: []Element{
+				NewTokenType(lexer.ItemGraph),
+				NewSymbol("GRAPHS"),
+			},
+		},
+	}
+	varsClauses = []*Clause{
+		{
+			Elements: []Element{
+				NewTokenType(lexer.ItemBinding),
+				NewSymbol("VARS_AS"),
+				NewSymbol("MORE_VARS"),
+			},
+		},
+		{
+			Elements: []Element{
+				NewTokenType(lexer.ItemCount),
+				NewTokenType(lexer.ItemLPar),
+				NewSymbol("COUNT_DISTINCT"),
+				NewTokenType(lexer.ItemBinding),
+				NewTokenType(lexer.ItemRPar),
+				NewTokenType(lexer.ItemAs),
+				NewTokenType(lexer.ItemBinding),
+				NewSymbol("MORE_VARS"),
+			},
+		},
+		{
+			Elements: []Element{
+				NewTokenType(lexer.ItemSum),
+				NewTokenType(lexer.ItemLPar),
+				NewTokenType(lexer.ItemBinding),
+				NewTokenType(lexer.ItemRPar),
+				NewTokenType(lexer.ItemAs),
+				NewTokenType(lexer.ItemBinding),
+				NewSymbol("MORE_VARS"),
+			},
+		},
+	}
+	countDistinctClauses = []*Clause{
+		{
+			Elements: []Element{
+				NewTokenType(lexer.ItemDistinct),
+			},
+		},
+		{},
+	}
+	varsAsClauses = []*Clause{
+		{
+			Elements: []Element{
+				NewTokenType(lexer.ItemAs),
+				NewTokenType(lexer.ItemBinding),
+			},
+		},
+		{},
+	}
+	moreVarsClauses = []*Clause{
+		{
+			Elements: []Element{
+				NewTokenType(lexer.ItemComma),
+				NewSymbol("VARS"),
+			},
+		},
+		{},
+	}
+	graphsClauses = []*Clause{
+		{
+			Elements: []Element{
+				NewTokenType(lexer.ItemBinding),
+				NewSymbol("MORE_GRAPHS"),
+			},
+		},
+	}
+	moreGraphsClauses = []*Clause{
+		{
+			Elements: []Element{
+				NewTokenType(lexer.ItemComma),
+				NewTokenType(lexer.ItemBinding),
+				NewSymbol("MORE_GRAPHS"),
+			},
+		},
+		{},
+	}
+	inputGraphClauses = []*Clause{
+		{
+			Elements: []Element{
+				NewTokenType(lexer.ItemBinding),
+				NewSymbol("MORE_INPUT_GRAPHS"),
+			},
+		},
+	}
+	moreInputGraphClauses = []*Clause{
+		{
+			Elements: []Element{
+				NewTokenType(lexer.ItemComma),
+				NewTokenType(lexer.ItemBinding),
+				NewSymbol("MORE_INPUT_GRAPHS"),
+			},
+		},
+		{},
+	}
+	outputGraphClauses = []*Clause{
+		{
+			Elements: []Element{
+				NewTokenType(lexer.ItemBinding),
+				NewSymbol("MORE_OUTPUT_GRAPHS"),
+			},
+		},
+	}
+	moreOutputGraphClauses = []*Clause{
+		{
+			Elements: []Element{
+				NewTokenType(lexer.ItemComma),
+				NewTokenType(lexer.ItemBinding),
+				NewSymbol("MORE_OUTPUT_GRAPHS"),
+			},
+		},
+		{},
+	}
+	whereClauses = []*Clause{
+		{
+			Elements: []Element{
+				NewTokenType(lexer.ItemWhere),
+				NewTokenType(lexer.ItemLBracket),
+				NewSymbol("FIRST_CLAUSE"),
+				NewTokenType(lexer.ItemRBracket),
+			},
+		},
+	}
+	firstClauses = []*Clause{
+		{
+			Elements: []Element{
+				NewTokenType(lexer.ItemNode),
+				NewSymbol("SUBJECT_EXTRACT"),
+				NewSymbol("PREDICATE"),
+				NewSymbol("OBJECT"),
+				NewSymbol("MORE_CLAUSES"),
+			},
+		},
+		{
+			Elements: []Element{
+				NewTokenType(lexer.ItemBinding),
+				NewSymbol("SUBJECT_EXTRACT"),
+				NewSymbol("PREDICATE"),
+				NewSymbol("OBJECT"),
+				NewSymbol("MORE_CLAUSES"),
+			},
+		},
+	}
+	moreClauses = []*Clause{
+		{
+			Elements: []Element{
+				NewTokenType(lexer.ItemDot),
+				NewSymbol("CLAUSES"),
+			},
+		},
+		{},
+	}
+	clauses = []*Clause{
+		{
+			Elements: []Element{
+				NewTokenType(lexer.ItemOptional),
+				NewTokenType(lexer.ItemLBracket),
+				NewSymbol("OPTIONAL_CLAUSE"),
+				NewTokenType(lexer.ItemRBracket),
+				NewSymbol("MORE_CLAUSES"),
+			},
+		},
+		{
+			Elements: []Element{
+				NewTokenType(lexer.ItemNode),
+				NewSymbol("SUBJECT_EXTRACT"),
+				NewSymbol("PREDICATE"),
+				NewSymbol("OBJECT"),
+				NewSymbol("MORE_CLAUSES"),
+			},
+		},
+		{
+			Elements: []Element{
+				NewTokenType(lexer.ItemBinding),
+				NewSymbol("SUBJECT_EXTRACT"),
+				NewSymbol("PREDICATE"),
+				NewSymbol("OBJECT"),
+				NewSymbol("MORE_CLAUSES"),
+			},
+		},
+	}
+	optionalClauses = []*Clause{
+		{
+			Elements: []Element{
+				NewTokenType(lexer.ItemNode),
+				NewSymbol("SUBJECT_EXTRACT"),
+				NewSymbol("PREDICATE"),
+				NewSymbol("OBJECT"),
+			},
+		},
+		{
+			Elements: []Element{
+				NewTokenType(lexer.ItemBinding),
+				NewSymbol("SUBJECT_EXTRACT"),
+				NewSymbol("PREDICATE"),
+				NewSymbol("OBJECT"),
+			},
+		},
+	}
+	subjectExtractClauses = []*Clause{
+		{
+			Elements: []Element{
+				NewTokenType(lexer.ItemAs),
+				NewTokenType(lexer.ItemBinding),
+				NewSymbol("SUBJECT_TYPE"),
+				NewSymbol("SUBJECT_ID"),
+			},
+		},
+		{
+			Elements: []Element{
+				NewTokenType(lexer.ItemType),
+				NewTokenType(lexer.ItemBinding),
+				NewSymbol("SUBJECT_ID"),
+			},
+		},
+		{
+			Elements: []Element{
+				NewTokenType(lexer.ItemID),
+				NewTokenType(lexer.ItemBinding),
+			},
+		},
+		{},
+	}
+	subjectTypeClauses = []*Clause{
+		{
+			Elements: []Element{
+				NewTokenType(lexer.ItemType),
+				NewTokenType(lexer.ItemBinding),
+			},
+		},
+		{},
+	}
+	subjectIDClauses = []*Clause{
+		{
+			Elements: []Element{
+				NewTokenType(lexer.ItemID),
+				NewTokenType(lexer.ItemBinding),
+			},
+		},
+		{},
+	}
+	predicateClauses = []*Clause{
+		{
+			Elements: []Element{
+				NewTokenType(lexer.ItemPredicate),
+				NewSymbol("PREDICATE_AS"),
+				NewSymbol("PREDICATE_ID"),
+				NewSymbol("PREDICATE_AT"),
+			},
+		},
+		{
+			Elements: []Element{
+				NewTokenType(lexer.ItemPredicateBound),
+				NewSymbol("PREDICATE_AS"),
+				NewSymbol("PREDICATE_ID"),
+				NewSymbol("PREDICATE_BOUND_AT"),
+			},
+		},
+		{
+			Elements: []Element{
+				NewTokenType(lexer.ItemBinding),
+				NewSymbol("PREDICATE_AS"),
+				NewSymbol("PREDICATE_ID"),
+				NewSymbol("PREDICATE_AT"),
+			},
+		},
+	}
+	predicateAsClauses = []*Clause{
+		{
+			Elements: []Element{
+				NewTokenType(lexer.ItemAs),
+				NewTokenType(lexer.ItemBinding),
+			},
+		},
+		{},
+	}
+	predicateIDClauses = []*Clause{
+		{
+			Elements: []Element{
+				NewTokenType(lexer.ItemID),
+				NewTokenType(lexer.ItemBinding),
+			},
+		},
+		{},
+	}
+	predicateAtClauses = []*Clause{
+		{
+			Elements: []Element{
+				NewTokenType(lexer.ItemAt),
+				NewTokenType(lexer.ItemBinding),
+			},
+		},
+		{},
+	}
+	predicateBoundAtClauses = []*Clause{
+		{
+			Elements: []Element{
+				NewTokenType(lexer.ItemAt),
+				NewSymbol("PREDICATE_BOUND_AT_BINDINGS"),
+			},
+		},
+		{},
+	}
+	predicateBoundAtBindingsClauses = []*Clause{
+		{
+			Elements: []Element{
+				NewTokenType(lexer.ItemBinding),
+				NewSymbol("PREDICATE_BOUND_AT_BINDINGS_END"),
+			},
+		},
+		{},
+	}
+	predicateBoundAtBindingsEndClauses = []*Clause{
+		{
+			Elements: []Element{
+				NewTokenType(lexer.ItemComma),
+				NewTokenType(lexer.ItemBinding),
+			},
+		},
+		{},
+	}
+	objectClauses = []*Clause{
+		{
+			Elements: []Element{
+				NewTokenType(lexer.ItemLiteral),
+				NewSymbol("OBJECT_LITERAL_AS"),
+			},
+		},
+		{
+			Elements: []Element{
+				NewTokenType(lexer.ItemNode),
+				NewSymbol("OBJECT_SUBJECT_EXTRACT"),
+			},
+		},
+		{
+			Elements: []Element{
+				NewTokenType(lexer.ItemPredicate),
+				NewSymbol("OBJECT_PREDICATE_AS"),
+				NewSymbol("OBJECT_PREDICATE_ID"),
+				NewSymbol("OBJECT_PREDICATE_AT"),
+			},
+		},
+		{
+			Elements: []Element{
+				NewTokenType(lexer.ItemPredicateBound),
+				NewSymbol("OBJECT_PREDICATE_AS"),
+				NewSymbol("OBJECT_PREDICATE_ID"),
+				NewSymbol("OBJECT_PREDICATE_BOUND_AT"),
+			},
+		},
+		{
+			Elements: []Element{
+				NewTokenType(lexer.ItemBinding),
+				NewSymbol("OBJECT_LITERAL_BINDING_AS"),
+				NewSymbol("OBJECT_LITERAL_BINDING_TYPE"),
+				NewSymbol("OBJECT_LITERAL_BINDING_ID"),
+				NewSymbol("OBJECT_LITERAL_BINDING_AT"),
+			},
+		},
+	}
+	objectSubjectExtractClauses = []*Clause{
+		{
+			Elements: []Element{
+				NewTokenType(lexer.ItemAs),
+				NewTokenType(lexer.ItemBinding),
+				NewSymbol("OBJECT_SUBJECT_TYPE"),
+				NewSymbol("OBJECT_SUBJECT_ID"),
+			},
+		},
+		{
+			Elements: []Element{
+				NewTokenType(lexer.ItemType),
+				NewTokenType(lexer.ItemBinding),
+				NewSymbol("OBJECT_SUBJECT_ID"),
+			},
+		},
+		{
+			Elements: []Element{
+				NewTokenType(lexer.ItemID),
+				NewTokenType(lexer.ItemBinding),
+			},
+		},
+		{},
+	}
+	objectSubjectTypeClauses = []*Clause{
+		{
+			Elements: []Element{
+				NewTokenType(lexer.ItemType),
+				NewTokenType(lexer.ItemBinding),
+			},
+		},
+		{},
+	}
+	objectSubjectIDClauses = []*Clause{
+		{
+			Elements: []Element{
+				NewTokenType(lexer.ItemID),
+				NewTokenType(lexer.ItemBinding),
+			},
+		},
+		{},
+	}
+	objectPredicateAsClauses = []*Clause{
+		{
+			Elements: []Element{
+				NewTokenType(lexer.ItemAs),
+				NewTokenType(lexer.ItemBinding),
+			},
+		},
+		{},
+	}
+	objectPredicateIDClauses = []*Clause{
+		{
+			Elements: []Element{
+				NewTokenType(lexer.ItemID),
+				NewTokenType(lexer.ItemBinding),
+			},
+		},
+		{},
+	}
+	objectPredicateAtClauses = []*Clause{
+		{
+			Elements: []Element{
+				NewTokenType(lexer.ItemAt),
+				NewTokenType(lexer.ItemBinding),
+			},
+		},
+		{},
+	}
+	objectPredicateBoundAtClauses = []*Clause{
+		{
+			Elements: []Element{
+				NewTokenType(lexer.ItemAt),
+				NewSymbol("OBJECT_PREDICATE_BOUND_AT_BINDINGS"),
+			},
+		},
+		{},
+	}
+	objectPredicateBoundAtBindingsClauses = []*Clause{
+		{
+			Elements: []Element{
+				NewTokenType(lexer.ItemBinding),
+				NewSymbol("OBJECT_PREDICATE_BOUND_AT_BINDINGS_END"),
+			},
+		},
+		{},
+	}
+	objectPredicateBoundAtBindingsEndClauses = []*Clause{
+		{
+			Elements: []Element{
+				NewTokenType(lexer.ItemComma),
+				NewTokenType(lexer.ItemBinding),
+			},
+		},
+		{},
+	}
+	objectLiteralAsClauses = []*Clause{
+		{
+			Elements: []Element{
+				NewTokenType(lexer.ItemAs),
+				NewTokenType(lexer.ItemBinding),
+			},
+		},
+		{},
+	}
+	objectLiteralBindingAsClauses = []*Clause{
+		{
+			Elements: []Element{
+				NewTokenType(lexer.ItemAs),
+				NewTokenType(lexer.ItemBinding),
+			},
+		},
+		{},
+	}
+	objectLiteralBindingTypeClauses = []*Clause{
+		{
+			Elements: []Element{
+				NewTokenType(lexer.ItemType),
+				NewTokenType(lexer.ItemBinding),
+			},
+		},
+		{},
+	}
+	objectLiteralBindingIDClauses = []*Clause{
+		{
+			Elements: []Element{
+				NewTokenType(lexer.ItemID),
+				NewTokenType(lexer.ItemBinding),
+			},
+		},
+		{},
+	}
+	objectLiteralBindingAtClauses = []*Clause{
+		{
+			Elements: []Element{
+				NewTokenType(lexer.ItemAt),
+				NewTokenType(lexer.ItemBinding),
+			},
+		},
+		{},
+	}
+	groupByClauses = []*Clause{
+		{
+			Elements: []Element{
+				NewTokenType(lexer.ItemGroup),
+				NewTokenType(lexer.ItemBy),
+				NewTokenType(lexer.ItemBinding),
+				NewSymbol("GROUP_BY_BINDINGS"),
+			},
+		},
+		{},
+	}
+	groupByBindingsClauses = []*Clause{
+		{
+			Elements: []Element{
+				NewTokenType(lexer.ItemComma),
+				NewTokenType(lexer.ItemBinding),
+				NewSymbol("GROUP_BY_BINDINGS"),
+			},
+		},
+		{},
+	}
+	orderByClauses = []*Clause{
+		{
+			Elements: []Element{
+				NewTokenType(lexer.ItemOrder),
+				NewTokenType(lexer.ItemBy),
+				NewTokenType(lexer.ItemBinding),
+				NewSymbol("ORDER_BY_DIRECTION"),
+				NewSymbol("ORDER_BY_BINDINGS"),
+			},
+		},
+		{},
+	}
+	orderByDirectionClauses = []*Clause{
+		{
+			Elements: []Element{
+				NewTokenType(lexer.ItemAsc),
+			},
+		},
+		{
+			Elements: []Element{
+				NewTokenType(lexer.ItemDesc),
+			},
+		},
+		{},
+	}
+	orderByBindingsClauses = []*Clause{
+		{
+			Elements: []Element{
+				NewTokenType(lexer.ItemComma),
+				NewTokenType(lexer.ItemBinding),
+				NewSymbol("ORDER_BY_DIRECTION"),
+				NewSymbol("ORDER_BY_BINDINGS"),
+			},
+		},
+		{},
+	}
+	topHavingClauses = []*Clause{
+		{
+			Elements: []Element{
+				NewTokenType(lexer.ItemHaving),
+				NewSymbol("HAVING_CLAUSE"),
+			},
+		},
+		{},
+	}
+	havingClauses = []*Clause{
+		{
+			Elements: []Element{
+				NewTokenType(lexer.ItemBinding),
+				NewSymbol("HAVING_CLAUSE_BINARY_COMPOSITE"),
+			},
+		},
+		{
+			Elements: []Element{
+				NewTokenType(lexer.ItemNode),
+				NewSymbol("HAVING_CLAUSE_BINARY_COMPOSITE"),
+			},
+		},
+		{
+			Elements: []Element{
+				NewTokenType(lexer.ItemLiteral),
+				NewSymbol("HAVING_CLAUSE_BINARY_COMPOSITE"),
+			},
+		},
+		{
+			Elements: []Element{
+				NewTokenType(lexer.ItemNot),
+				NewSymbol("HAVING_CLAUSE"),
+			},
+		},
+		{
+			Elements: []Element{
+				NewTokenType(lexer.ItemLPar),
+				NewSymbol("HAVING_CLAUSE"),
+				NewTokenType(lexer.ItemRPar),
+				NewSymbol("HAVING_CLAUSE_BINARY_COMPOSITE"),
+			},
+		},
+	}
+	havingClausesBinaryCompositeClauses = []*Clause{
+		{
+			Elements: []Element{
+				NewTokenType(lexer.ItemAnd),
+				NewSymbol("HAVING_CLAUSE"),
+			},
+		},
+		{
+			Elements: []Element{
+				NewTokenType(lexer.ItemOr),
+				NewSymbol("HAVING_CLAUSE"),
+			},
+		},
+		{
+			Elements: []Element{
+				NewTokenType(lexer.ItemEQ),
+				NewSymbol("HAVING_CLAUSE"),
+			},
+		},
+		{
+			Elements: []Element{
+				NewTokenType(lexer.ItemLT),
+				NewSymbol("HAVING_CLAUSE"),
+			},
+		},
+		{
+			Elements: []Element{
+				NewTokenType(lexer.ItemGT),
+				NewSymbol("HAVING_CLAUSE"),
+			},
+		},
+		{},
+	}
+	globalTimeBoundClauses = []*Clause{
+		{
+			Elements: []Element{
+				NewTokenType(lexer.ItemBefore),
+				NewTokenType(lexer.ItemPredicate),
+			},
+		},
+		{
+			Elements: []Element{
+				NewTokenType(lexer.ItemAfter),
+				NewTokenType(lexer.ItemPredicate),
+			},
+		},
+		{
+			Elements: []Element{
+				NewTokenType(lexer.ItemBetween),
+				NewTokenType(lexer.ItemPredicateBound),
+			},
+		},
+		{},
+	}
+	limitClauses = []*Clause{
+		{
+			Elements: []Element{
+				NewTokenType(lexer.ItemLimit),
+				NewTokenType(lexer.ItemLiteral),
+			},
+		},
+		{},
+	}
+	insertObjectClauses = []*Clause{
+		{
+			Elements: []Element{
+				NewTokenType(lexer.ItemNode),
+			},
+		},
+		{
+			Elements: []Element{
+				NewTokenType(lexer.ItemPredicate),
+			},
+		},
+		{
+			Elements: []Element{
+				NewTokenType(lexer.ItemLiteral),
+			},
+		},
+	}
+	insertDataClauses = []*Clause{
+		{
+			Elements: []Element{
+				NewTokenType(lexer.ItemDot),
+				NewTokenType(lexer.ItemNode),
+				NewTokenType(lexer.ItemPredicate),
+				NewSymbol("INSERT_OBJECT"),
+				NewSymbol("INSERT_DATA"),
+			},
+		},
+		{},
+	}
+	deleteObjectClauses = []*Clause{
+		{
+			Elements: []Element{
+				NewTokenType(lexer.ItemNode),
+			},
+		},
+		{
+			Elements: []Element{
+				NewTokenType(lexer.ItemPredicate),
+			},
+		},
+		{
+			Elements: []Element{
+				NewTokenType(lexer.ItemLiteral),
+			},
+		},
+	}
+	deleteDataClauses = []*Clause{
+		{
+			Elements: []Element{
+				NewTokenType(lexer.ItemDot),
+				NewTokenType(lexer.ItemNode),
+				NewTokenType(lexer.ItemPredicate),
+				NewSymbol("DELETE_OBJECT"),
+				NewSymbol("DELETE_DATA"),
+			},
+		},
+		{},
+	}
+	constructFactsClauses = []*Clause{
+		{
+			Elements: []Element{
+				NewTokenType(lexer.ItemLBracket),
+				NewSymbol("CONSTRUCT_TRIPLES"),
+				NewTokenType(lexer.ItemRBracket),
+			},
+		},
+	}
+	constructTriplesClauses = []*Clause{
+		{
+			Elements: []Element{
+				NewTokenType(lexer.ItemNode),
+				NewSymbol("CONSTRUCT_PREDICATE"),
+				NewSymbol("CONSTRUCT_OBJECT"),
+				NewSymbol("MORE_CONSTRUCT_PREDICATE_OBJECT_PAIRS"),
+				NewSymbol("MORE_CONSTRUCT_TRIPLES"),
+			},
+		},
+		{
+			Elements: []Element{
+				NewTokenType(lexer.ItemBlankNode),
+				NewSymbol("CONSTRUCT_PREDICATE"),
+				NewSymbol("CONSTRUCT_OBJECT"),
+				NewSymbol("MORE_CONSTRUCT_PREDICATE_OBJECT_PAIRS"),
+				NewSymbol("MORE_CONSTRUCT_TRIPLES"),
+			},
+		},
+		{
+			Elements: []Element{
+				NewTokenType(lexer.ItemBinding),
+				NewSymbol("CONSTRUCT_PREDICATE"),
+				NewSymbol("CONSTRUCT_OBJECT"),
+				NewSymbol("MORE_CONSTRUCT_PREDICATE_OBJECT_PAIRS"),
+				NewSymbol("MORE_CONSTRUCT_TRIPLES"),
+			},
+		},
+	}
+	constructPredicateClauses = []*Clause{
+		{
+			Elements: []Element{
+				NewTokenType(lexer.ItemPredicate),
+			},
+		},
+		{
+			Elements: []Element{
+				NewTokenType(lexer.ItemBinding),
+			},
+		},
+	}
+	constructObjectClauses = []*Clause{
+		{
+			Elements: []Element{
+				NewTokenType(lexer.ItemNode),
+			},
+		},
+		{
+			Elements: []Element{
+				NewTokenType(lexer.ItemBlankNode),
+			},
+		},
+		{
+			Elements: []Element{
+				NewTokenType(lexer.ItemPredicate),
+			},
+		},
+		{
+			Elements: []Element{
+				NewTokenType(lexer.ItemLiteral),
+			},
+		},
+		{
+			Elements: []Element{
+				NewTokenType(lexer.ItemBinding),
+			},
+		},
+	}
+	moreConstructPredicateObjectPairsClauses = []*Clause{
+		{
+			Elements: []Element{
+				NewTokenType(lexer.ItemSemicolon),
+				NewSymbol("CONSTRUCT_PREDICATE"),
+				NewSymbol("CONSTRUCT_OBJECT"),
+				NewSymbol("MORE_CONSTRUCT_PREDICATE_OBJECT_PAIRS"),
+			},
+		},
+		{},
+	}
+	moreConstructTriplesClauses = []*Clause{
+		{
+			Elements: []Element{
+				NewTokenType(lexer.ItemDot),
+				NewSymbol("CONSTRUCT_TRIPLES"),
+			},
+		},
+		{},
+	}
+	deconstructFactsClauses = []*Clause{
+		{
+			Elements: []Element{
+				NewTokenType(lexer.ItemLBracket),
+				NewSymbol("DECONSTRUCT_TRIPLES"),
+				NewTokenType(lexer.ItemRBracket),
+			},
+		},
+	}
+	deconstructTriplesClauses = []*Clause{
+		{
+			Elements: []Element{
+				NewTokenType(lexer.ItemNode),
+				NewSymbol("CONSTRUCT_PREDICATE"),
+				NewSymbol("CONSTRUCT_OBJECT"),
+				NewSymbol("MORE_DECONSTRUCT_TRIPLES"),
+			},
+		},
+		{
+			Elements: []Element{
+				NewTokenType(lexer.ItemBinding),
+				NewSymbol("CONSTRUCT_PREDICATE"),
+				NewSymbol("CONSTRUCT_OBJECT"),
+				NewSymbol("MORE_DECONSTRUCT_TRIPLES"),
+			},
+		},
+	}
+	moreDeconstructTriplesClauses = []*Clause{
+		{
+			Elements: []Element{
+				NewTokenType(lexer.ItemDot),
+				NewSymbol("DECONSTRUCT_TRIPLES"),
+			},
+		},
+		{},
+	}
+	graphShowClauses = []*Clause{
+		{
+			Elements: []Element{
+				NewTokenType(lexer.ItemGraphs),
+			},
+		},
+	}
+)
+
 // BQL LL1 grammar.
 func BQL() *Grammar {
 	return &Grammar{
-		"START": []*Clause{
-			{
-				Elements: []Element{
-					NewTokenType(lexer.ItemQuery),
-					NewSymbol("VARS"),
-					NewTokenType(lexer.ItemFrom),
-					NewSymbol("INPUT_GRAPHS"),
-					NewSymbol("WHERE"),
-					NewSymbol("GROUP_BY"),
-					NewSymbol("ORDER_BY"),
-					NewSymbol("HAVING"),
-					NewSymbol("GLOBAL_TIME_BOUND"),
-					NewSymbol("LIMIT"),
-					NewTokenType(lexer.ItemSemicolon),
-				},
-			},
-			{
-				Elements: []Element{
-					NewTokenType(lexer.ItemInsert),
-					NewTokenType(lexer.ItemData),
-					NewTokenType(lexer.ItemInto),
-					NewSymbol("OUTPUT_GRAPHS"),
-					NewTokenType(lexer.ItemLBracket),
-					NewTokenType(lexer.ItemNode),
-					NewTokenType(lexer.ItemPredicate),
-					NewSymbol("INSERT_OBJECT"),
-					NewSymbol("INSERT_DATA"),
-					NewTokenType(lexer.ItemRBracket),
-					NewTokenType(lexer.ItemSemicolon),
-				},
-			},
-			{
-				Elements: []Element{
-					NewTokenType(lexer.ItemDelete),
-					NewTokenType(lexer.ItemData),
-					NewTokenType(lexer.ItemFrom),
-					NewSymbol("INPUT_GRAPHS"),
-					NewTokenType(lexer.ItemLBracket),
-					NewTokenType(lexer.ItemNode),
-					NewTokenType(lexer.ItemPredicate),
-					NewSymbol("DELETE_OBJECT"),
-					NewSymbol("DELETE_DATA"),
-					NewTokenType(lexer.ItemRBracket),
-					NewTokenType(lexer.ItemSemicolon),
-				},
-			},
-			{
-				Elements: []Element{
-					NewTokenType(lexer.ItemCreate),
-					NewSymbol("CREATE_GRAPHS"),
-					NewTokenType(lexer.ItemSemicolon),
-				},
-			},
-			{
-				Elements: []Element{
-					NewTokenType(lexer.ItemDrop),
-					NewSymbol("DROP_GRAPHS"),
-					NewTokenType(lexer.ItemSemicolon),
-				},
-			},
-			{
-				Elements: []Element{
-					NewTokenType(lexer.ItemConstruct),
-					NewSymbol("CONSTRUCT_FACTS"),
-					NewTokenType(lexer.ItemInto),
-					NewSymbol("OUTPUT_GRAPHS"),
-					NewTokenType(lexer.ItemFrom),
-					NewSymbol("INPUT_GRAPHS"),
-					NewSymbol("WHERE"),
-					NewSymbol("HAVING"),
-					NewTokenType(lexer.ItemSemicolon),
-				},
-			},
-			{
-				Elements: []Element{
-					NewTokenType(lexer.ItemDeconstruct),
-					NewSymbol("DECONSTRUCT_FACTS"),
-					NewTokenType(lexer.ItemIn),
-					NewSymbol("OUTPUT_GRAPHS"),
-					NewTokenType(lexer.ItemFrom),
-					NewSymbol("INPUT_GRAPHS"),
-					NewSymbol("WHERE"),
-					NewSymbol("HAVING"),
-					NewTokenType(lexer.ItemSemicolon),
-				},
-			},
-			{
-				Elements: []Element{
-					NewTokenType(lexer.ItemShow),
-					NewSymbol("GRAPH_SHOW"),
-					NewTokenType(lexer.ItemSemicolon),
-				},
-			},
-		},
-		"CREATE_GRAPHS": []*Clause{
-			{
-				Elements: []Element{
-					NewTokenType(lexer.ItemGraph),
-					NewSymbol("GRAPHS"),
-				},
-			},
-		},
-		"DROP_GRAPHS": []*Clause{
-			{
-				Elements: []Element{
-					NewTokenType(lexer.ItemGraph),
-					NewSymbol("GRAPHS"),
-				},
-			},
-		},
-		"VARS": []*Clause{
-			{
-				Elements: []Element{
-					NewTokenType(lexer.ItemBinding),
-					NewSymbol("VARS_AS"),
-					NewSymbol("MORE_VARS"),
-				},
-			},
-			{
-				Elements: []Element{
-					NewTokenType(lexer.ItemCount),
-					NewTokenType(lexer.ItemLPar),
-					NewSymbol("COUNT_DISTINCT"),
-					NewTokenType(lexer.ItemBinding),
-					NewTokenType(lexer.ItemRPar),
-					NewTokenType(lexer.ItemAs),
-					NewTokenType(lexer.ItemBinding),
-					NewSymbol("MORE_VARS"),
-				},
-			},
-			{
-				Elements: []Element{
-					NewTokenType(lexer.ItemSum),
-					NewTokenType(lexer.ItemLPar),
-					NewTokenType(lexer.ItemBinding),
-					NewTokenType(lexer.ItemRPar),
-					NewTokenType(lexer.ItemAs),
-					NewTokenType(lexer.ItemBinding),
-					NewSymbol("MORE_VARS"),
-				},
-			},
-		},
-		"COUNT_DISTINCT": []*Clause{
-			{
-				Elements: []Element{
-					NewTokenType(lexer.ItemDistinct),
-				},
-			},
-			{},
-		},
-		"VARS_AS": []*Clause{
-			{
-				Elements: []Element{
-					NewTokenType(lexer.ItemAs),
-					NewTokenType(lexer.ItemBinding),
-				},
-			},
-			{},
-		},
-		"MORE_VARS": []*Clause{
-			{
-				Elements: []Element{
-					NewTokenType(lexer.ItemComma),
-					NewSymbol("VARS"),
-				},
-			},
-			{},
-		},
-		"GRAPHS": []*Clause{
-			{
-				Elements: []Element{
-					NewTokenType(lexer.ItemBinding),
-					NewSymbol("MORE_GRAPHS"),
-				},
-			},
-		},
-		"MORE_GRAPHS": []*Clause{
-			{
-				Elements: []Element{
-					NewTokenType(lexer.ItemComma),
-					NewTokenType(lexer.ItemBinding),
-					NewSymbol("MORE_GRAPHS"),
-				},
-			},
-			{},
-		},
-		"INPUT_GRAPHS": []*Clause{
-			{
-				Elements: []Element{
-					NewTokenType(lexer.ItemBinding),
-					NewSymbol("MORE_INPUT_GRAPHS"),
-				},
-			},
-		},
-		"MORE_INPUT_GRAPHS": []*Clause{
-			{
-				Elements: []Element{
-					NewTokenType(lexer.ItemComma),
-					NewTokenType(lexer.ItemBinding),
-					NewSymbol("MORE_INPUT_GRAPHS"),
-				},
-			},
-			{},
-		},
-		"OUTPUT_GRAPHS": []*Clause{
-			{
-				Elements: []Element{
-					NewTokenType(lexer.ItemBinding),
-					NewSymbol("MORE_OUTPUT_GRAPHS"),
-				},
-			},
-		},
-		"MORE_OUTPUT_GRAPHS": []*Clause{
-			{
-				Elements: []Element{
-					NewTokenType(lexer.ItemComma),
-					NewTokenType(lexer.ItemBinding),
-					NewSymbol("MORE_OUTPUT_GRAPHS"),
-				},
-			},
-			{},
-		},
-		"WHERE": []*Clause{
-			{
-				Elements: []Element{
-					NewTokenType(lexer.ItemWhere),
-					NewTokenType(lexer.ItemLBracket),
-					NewSymbol("FIRST_CLAUSE"),
-					NewTokenType(lexer.ItemRBracket),
-				},
-			},
-		},
-		"FIRST_CLAUSE": []*Clause{
-			{
-				Elements: []Element{
-					NewTokenType(lexer.ItemNode),
-					NewSymbol("SUBJECT_EXTRACT"),
-					NewSymbol("PREDICATE"),
-					NewSymbol("OBJECT"),
-					NewSymbol("MORE_CLAUSES"),
-				},
-			},
-			{
-				Elements: []Element{
-					NewTokenType(lexer.ItemBinding),
-					NewSymbol("SUBJECT_EXTRACT"),
-					NewSymbol("PREDICATE"),
-					NewSymbol("OBJECT"),
-					NewSymbol("MORE_CLAUSES"),
-				},
-			},
-		},
-		"MORE_CLAUSES": []*Clause{
-			{
-				Elements: []Element{
-					NewTokenType(lexer.ItemDot),
-					NewSymbol("CLAUSES"),
-				},
-			},
-			{},
-		},
-		"CLAUSES": []*Clause{
-			{
-				Elements: []Element{
-					NewTokenType(lexer.ItemOptional),
-					NewTokenType(lexer.ItemLBracket),
-					NewSymbol("OPTIONAL_CLAUSE"),
-					NewTokenType(lexer.ItemRBracket),
-					NewSymbol("MORE_CLAUSES"),
-				},
-			},
-			{
-				Elements: []Element{
-					NewTokenType(lexer.ItemNode),
-					NewSymbol("SUBJECT_EXTRACT"),
-					NewSymbol("PREDICATE"),
-					NewSymbol("OBJECT"),
-					NewSymbol("MORE_CLAUSES"),
-				},
-			},
-			{
-				Elements: []Element{
-					NewTokenType(lexer.ItemBinding),
-					NewSymbol("SUBJECT_EXTRACT"),
-					NewSymbol("PREDICATE"),
-					NewSymbol("OBJECT"),
-					NewSymbol("MORE_CLAUSES"),
-				},
-			},
-		},
-		"OPTIONAL_CLAUSE": []*Clause{
-			{
-				Elements: []Element{
-					NewTokenType(lexer.ItemNode),
-					NewSymbol("SUBJECT_EXTRACT"),
-					NewSymbol("PREDICATE"),
-					NewSymbol("OBJECT"),
-				},
-			},
-			{
-				Elements: []Element{
-					NewTokenType(lexer.ItemBinding),
-					NewSymbol("SUBJECT_EXTRACT"),
-					NewSymbol("PREDICATE"),
-					NewSymbol("OBJECT"),
-				},
-			},
-		},
-		"SUBJECT_EXTRACT": []*Clause{
-			{
-				Elements: []Element{
-					NewTokenType(lexer.ItemAs),
-					NewTokenType(lexer.ItemBinding),
-					NewSymbol("SUBJECT_TYPE"),
-					NewSymbol("SUBJECT_ID"),
-				},
-			},
-			{
-				Elements: []Element{
-					NewTokenType(lexer.ItemType),
-					NewTokenType(lexer.ItemBinding),
-					NewSymbol("SUBJECT_ID"),
-				},
-			},
-			{
-				Elements: []Element{
-					NewTokenType(lexer.ItemID),
-					NewTokenType(lexer.ItemBinding),
-				},
-			},
-			{},
-		},
-		"SUBJECT_TYPE": []*Clause{
-			{
-				Elements: []Element{
-					NewTokenType(lexer.ItemType),
-					NewTokenType(lexer.ItemBinding),
-				},
-			},
-			{},
-		},
-		"SUBJECT_ID": []*Clause{
-			{
-				Elements: []Element{
-					NewTokenType(lexer.ItemID),
-					NewTokenType(lexer.ItemBinding),
-				},
-			},
-			{},
-		},
-		"PREDICATE": []*Clause{
-			{
-				Elements: []Element{
-					NewTokenType(lexer.ItemPredicate),
-					NewSymbol("PREDICATE_AS"),
-					NewSymbol("PREDICATE_ID"),
-					NewSymbol("PREDICATE_AT"),
-				},
-			},
-			{
-				Elements: []Element{
-					NewTokenType(lexer.ItemPredicateBound),
-					NewSymbol("PREDICATE_AS"),
-					NewSymbol("PREDICATE_ID"),
-					NewSymbol("PREDICATE_BOUND_AT"),
-				},
-			},
-			{
-				Elements: []Element{
-					NewTokenType(lexer.ItemBinding),
-					NewSymbol("PREDICATE_AS"),
-					NewSymbol("PREDICATE_ID"),
-					NewSymbol("PREDICATE_AT"),
-				},
-			},
-		},
-		"PREDICATE_AS": []*Clause{
-			{
-				Elements: []Element{
-					NewTokenType(lexer.ItemAs),
-					NewTokenType(lexer.ItemBinding),
-				},
-			},
-			{},
-		},
-		"PREDICATE_ID": []*Clause{
-			{
-				Elements: []Element{
-					NewTokenType(lexer.ItemID),
-					NewTokenType(lexer.ItemBinding),
-				},
-			},
-			{},
-		},
-		"PREDICATE_AT": []*Clause{
-			{
-				Elements: []Element{
-					NewTokenType(lexer.ItemAt),
-					NewTokenType(lexer.ItemBinding),
-				},
-			},
-			{},
-		},
-		"PREDICATE_BOUND_AT": []*Clause{
-			{
-				Elements: []Element{
-					NewTokenType(lexer.ItemAt),
-					NewSymbol("PREDICATE_BOUND_AT_BINDINGS"),
-				},
-			},
-			{},
-		},
-		"PREDICATE_BOUND_AT_BINDINGS": []*Clause{
-			{
-				Elements: []Element{
-					NewTokenType(lexer.ItemBinding),
-					NewSymbol("PREDICATE_BOUND_AT_BINDINGS_END"),
-				},
-			},
-			{},
-		},
-		"PREDICATE_BOUND_AT_BINDINGS_END": []*Clause{
-			{
-				Elements: []Element{
-					NewTokenType(lexer.ItemComma),
-					NewTokenType(lexer.ItemBinding),
-				},
-			},
-			{},
-		},
-		"OBJECT": []*Clause{
-			{
-				Elements: []Element{
-					NewTokenType(lexer.ItemLiteral),
-					NewSymbol("OBJECT_LITERAL_AS"),
-				},
-			},
-			{
-				Elements: []Element{
-					NewTokenType(lexer.ItemNode),
-					NewSymbol("OBJECT_SUBJECT_EXTRACT"),
-				},
-			},
-			{
-				Elements: []Element{
-					NewTokenType(lexer.ItemPredicate),
-					NewSymbol("OBJECT_PREDICATE_AS"),
-					NewSymbol("OBJECT_PREDICATE_ID"),
-					NewSymbol("OBJECT_PREDICATE_AT"),
-				},
-			},
-			{
-				Elements: []Element{
-					NewTokenType(lexer.ItemPredicateBound),
-					NewSymbol("OBJECT_PREDICATE_AS"),
-					NewSymbol("OBJECT_PREDICATE_ID"),
-					NewSymbol("OBJECT_PREDICATE_BOUND_AT"),
-				},
-			},
-			{
-				Elements: []Element{
-					NewTokenType(lexer.ItemBinding),
-					NewSymbol("OBJECT_LITERAL_BINDING_AS"),
-					NewSymbol("OBJECT_LITERAL_BINDING_TYPE"),
-					NewSymbol("OBJECT_LITERAL_BINDING_ID"),
-					NewSymbol("OBJECT_LITERAL_BINDING_AT"),
-				},
-			},
-		},
-		"OBJECT_SUBJECT_EXTRACT": []*Clause{
-			{
-				Elements: []Element{
-					NewTokenType(lexer.ItemAs),
-					NewTokenType(lexer.ItemBinding),
-					NewSymbol("OBJECT_SUBJECT_TYPE"),
-					NewSymbol("OBJECT_SUBJECT_ID"),
-				},
-			},
-			{
-				Elements: []Element{
-					NewTokenType(lexer.ItemType),
-					NewTokenType(lexer.ItemBinding),
-					NewSymbol("OBJECT_SUBJECT_ID"),
-				},
-			},
-			{
-				Elements: []Element{
-					NewTokenType(lexer.ItemID),
-					NewTokenType(lexer.ItemBinding),
-				},
-			},
-			{},
-		},
-		"OBJECT_SUBJECT_TYPE": []*Clause{
-			{
-				Elements: []Element{
-					NewTokenType(lexer.ItemType),
-					NewTokenType(lexer.ItemBinding),
-				},
-			},
-			{},
-		},
-		"OBJECT_SUBJECT_ID": []*Clause{
-			{
-				Elements: []Element{
-					NewTokenType(lexer.ItemID),
-					NewTokenType(lexer.ItemBinding),
-				},
-			},
-			{},
-		},
-		"OBJECT_PREDICATE_AS": []*Clause{
-			{
-				Elements: []Element{
-					NewTokenType(lexer.ItemAs),
-					NewTokenType(lexer.ItemBinding),
-				},
-			},
-			{},
-		},
-		"OBJECT_PREDICATE_ID": []*Clause{
-			{
-				Elements: []Element{
-					NewTokenType(lexer.ItemID),
-					NewTokenType(lexer.ItemBinding),
-				},
-			},
-			{},
-		},
-		"OBJECT_PREDICATE_AT": []*Clause{
-			{
-				Elements: []Element{
-					NewTokenType(lexer.ItemAt),
-					NewTokenType(lexer.ItemBinding),
-				},
-			},
-			{},
-		},
-		"OBJECT_PREDICATE_BOUND_AT": []*Clause{
-			{
-				Elements: []Element{
-					NewTokenType(lexer.ItemAt),
-					NewSymbol("OBJECT_PREDICATE_BOUND_AT_BINDINGS"),
-				},
-			},
-			{},
-		},
-		"OBJECT_PREDICATE_BOUND_AT_BINDINGS": []*Clause{
-			{
-				Elements: []Element{
-					NewTokenType(lexer.ItemBinding),
-					NewSymbol("OBJECT_PREDICATE_BOUND_AT_BINDINGS_END"),
-				},
-			},
-			{},
-		},
-		"OBJECT_PREDICATE_BOUND_AT_BINDINGS_END": []*Clause{
-			{
-				Elements: []Element{
-					NewTokenType(lexer.ItemComma),
-					NewTokenType(lexer.ItemBinding),
-				},
-			},
-			{},
-		},
-		"OBJECT_LITERAL_AS": []*Clause{
-			{
-				Elements: []Element{
-					NewTokenType(lexer.ItemAs),
-					NewTokenType(lexer.ItemBinding),
-				},
-			},
-			{},
-		},
-		"OBJECT_LITERAL_BINDING_AS": []*Clause{
-			{
-				Elements: []Element{
-					NewTokenType(lexer.ItemAs),
-					NewTokenType(lexer.ItemBinding),
-				},
-			},
-			{},
-		},
-		"OBJECT_LITERAL_BINDING_TYPE": []*Clause{
-			{
-				Elements: []Element{
-					NewTokenType(lexer.ItemType),
-					NewTokenType(lexer.ItemBinding),
-				},
-			},
-			{},
-		},
-		"OBJECT_LITERAL_BINDING_ID": []*Clause{
-			{
-				Elements: []Element{
-					NewTokenType(lexer.ItemID),
-					NewTokenType(lexer.ItemBinding),
-				},
-			},
-			{},
-		},
-		"OBJECT_LITERAL_BINDING_AT": []*Clause{
-			{
-				Elements: []Element{
-					NewTokenType(lexer.ItemAt),
-					NewTokenType(lexer.ItemBinding),
-				},
-			},
-			{},
-		},
-		"GROUP_BY": []*Clause{
-			{
-				Elements: []Element{
-					NewTokenType(lexer.ItemGroup),
-					NewTokenType(lexer.ItemBy),
-					NewTokenType(lexer.ItemBinding),
-					NewSymbol("GROUP_BY_BINDINGS"),
-				},
-			},
-			{},
-		},
-		"GROUP_BY_BINDINGS": []*Clause{
-			{
-				Elements: []Element{
-					NewTokenType(lexer.ItemComma),
-					NewTokenType(lexer.ItemBinding),
-					NewSymbol("GROUP_BY_BINDINGS"),
-				},
-			},
-			{},
-		},
-		"ORDER_BY": []*Clause{
-			{
-				Elements: []Element{
-					NewTokenType(lexer.ItemOrder),
-					NewTokenType(lexer.ItemBy),
-					NewTokenType(lexer.ItemBinding),
-					NewSymbol("ORDER_BY_DIRECTION"),
-					NewSymbol("ORDER_BY_BINDINGS"),
-				},
-			},
-			{},
-		},
-		"ORDER_BY_DIRECTION": []*Clause{
-			{
-				Elements: []Element{
-					NewTokenType(lexer.ItemAsc),
-				},
-			},
-			{
-				Elements: []Element{
-					NewTokenType(lexer.ItemDesc),
-				},
-			},
-			{},
-		},
-		"ORDER_BY_BINDINGS": []*Clause{
-			{
-				Elements: []Element{
-					NewTokenType(lexer.ItemComma),
-					NewTokenType(lexer.ItemBinding),
-					NewSymbol("ORDER_BY_DIRECTION"),
-					NewSymbol("ORDER_BY_BINDINGS"),
-				},
-			},
-			{},
-		},
-		"HAVING": []*Clause{
-			{
-				Elements: []Element{
-					NewTokenType(lexer.ItemHaving),
-					NewSymbol("HAVING_CLAUSE"),
-				},
-			},
-			{},
-		},
-		"HAVING_CLAUSE": []*Clause{
-			{
-				Elements: []Element{
-					NewTokenType(lexer.ItemBinding),
-					NewSymbol("HAVING_CLAUSE_BINARY_COMPOSITE"),
-				},
-			},
-			{
-				Elements: []Element{
-					NewTokenType(lexer.ItemNode),
-					NewSymbol("HAVING_CLAUSE_BINARY_COMPOSITE"),
-				},
-			},
-			{
-				Elements: []Element{
-					NewTokenType(lexer.ItemLiteral),
-					NewSymbol("HAVING_CLAUSE_BINARY_COMPOSITE"),
-				},
-			},
-			{
-				Elements: []Element{
-					NewTokenType(lexer.ItemNot),
-					NewSymbol("HAVING_CLAUSE"),
-				},
-			},
-			{
-				Elements: []Element{
-					NewTokenType(lexer.ItemLPar),
-					NewSymbol("HAVING_CLAUSE"),
-					NewTokenType(lexer.ItemRPar),
-					NewSymbol("HAVING_CLAUSE_BINARY_COMPOSITE"),
-				},
-			},
-		},
-		"HAVING_CLAUSE_BINARY_COMPOSITE": []*Clause{
-			{
-				Elements: []Element{
-					NewTokenType(lexer.ItemAnd),
-					NewSymbol("HAVING_CLAUSE"),
-				},
-			},
-			{
-				Elements: []Element{
-					NewTokenType(lexer.ItemOr),
-					NewSymbol("HAVING_CLAUSE"),
-				},
-			},
-			{
-				Elements: []Element{
-					NewTokenType(lexer.ItemEQ),
-					NewSymbol("HAVING_CLAUSE"),
-				},
-			},
-			{
-				Elements: []Element{
-					NewTokenType(lexer.ItemLT),
-					NewSymbol("HAVING_CLAUSE"),
-				},
-			},
-			{
-				Elements: []Element{
-					NewTokenType(lexer.ItemGT),
-					NewSymbol("HAVING_CLAUSE"),
-				},
-			},
-			{},
-		},
-		"GLOBAL_TIME_BOUND": []*Clause{
-			{
-				Elements: []Element{
-					NewTokenType(lexer.ItemBefore),
-					NewTokenType(lexer.ItemPredicate),
-				},
-			},
-			{
-				Elements: []Element{
-					NewTokenType(lexer.ItemAfter),
-					NewTokenType(lexer.ItemPredicate),
-				},
-			},
-			{
-				Elements: []Element{
-					NewTokenType(lexer.ItemBetween),
-					NewTokenType(lexer.ItemPredicateBound),
-				},
-			},
-			{},
-		},
-		"LIMIT": []*Clause{
-			{
-				Elements: []Element{
-					NewTokenType(lexer.ItemLimit),
-					NewTokenType(lexer.ItemLiteral),
-				},
-			},
-			{},
-		},
-		"INSERT_OBJECT": []*Clause{
-			{
-				Elements: []Element{
-					NewTokenType(lexer.ItemNode),
-				},
-			},
-			{
-				Elements: []Element{
-					NewTokenType(lexer.ItemPredicate),
-				},
-			},
-			{
-				Elements: []Element{
-					NewTokenType(lexer.ItemLiteral),
-				},
-			},
-		},
-		"INSERT_DATA": []*Clause{
-			{
-				Elements: []Element{
-					NewTokenType(lexer.ItemDot),
-					NewTokenType(lexer.ItemNode),
-					NewTokenType(lexer.ItemPredicate),
-					NewSymbol("INSERT_OBJECT"),
-					NewSymbol("INSERT_DATA"),
-				},
-			},
-			{},
-		},
-		"DELETE_OBJECT": []*Clause{
-			{
-				Elements: []Element{
-					NewTokenType(lexer.ItemNode),
-				},
-			},
-			{
-				Elements: []Element{
-					NewTokenType(lexer.ItemPredicate),
-				},
-			},
-			{
-				Elements: []Element{
-					NewTokenType(lexer.ItemLiteral),
-				},
-			},
-		},
-		"DELETE_DATA": []*Clause{
-			{
-				Elements: []Element{
-					NewTokenType(lexer.ItemDot),
-					NewTokenType(lexer.ItemNode),
-					NewTokenType(lexer.ItemPredicate),
-					NewSymbol("DELETE_OBJECT"),
-					NewSymbol("DELETE_DATA"),
-				},
-			},
-			{},
-		},
-		"CONSTRUCT_FACTS": []*Clause{
-			{
-				Elements: []Element{
-					NewTokenType(lexer.ItemLBracket),
-					NewSymbol("CONSTRUCT_TRIPLES"),
-					NewTokenType(lexer.ItemRBracket),
-				},
-			},
-		},
-		"CONSTRUCT_TRIPLES": []*Clause{
-			{
-				Elements: []Element{
-					NewTokenType(lexer.ItemNode),
-					NewSymbol("CONSTRUCT_PREDICATE"),
-					NewSymbol("CONSTRUCT_OBJECT"),
-					NewSymbol("MORE_CONSTRUCT_PREDICATE_OBJECT_PAIRS"),
-					NewSymbol("MORE_CONSTRUCT_TRIPLES"),
-				},
-			},
-			{
-				Elements: []Element{
-					NewTokenType(lexer.ItemBlankNode),
-					NewSymbol("CONSTRUCT_PREDICATE"),
-					NewSymbol("CONSTRUCT_OBJECT"),
-					NewSymbol("MORE_CONSTRUCT_PREDICATE_OBJECT_PAIRS"),
-					NewSymbol("MORE_CONSTRUCT_TRIPLES"),
-				},
-			},
-			{
-				Elements: []Element{
-					NewTokenType(lexer.ItemBinding),
-					NewSymbol("CONSTRUCT_PREDICATE"),
-					NewSymbol("CONSTRUCT_OBJECT"),
-					NewSymbol("MORE_CONSTRUCT_PREDICATE_OBJECT_PAIRS"),
-					NewSymbol("MORE_CONSTRUCT_TRIPLES"),
-				},
-			},
-		},
-		"CONSTRUCT_PREDICATE": []*Clause{
-			{
-				Elements: []Element{
-					NewTokenType(lexer.ItemPredicate),
-				},
-			},
-			{
-				Elements: []Element{
-					NewTokenType(lexer.ItemBinding),
-				},
-			},
-		},
-		"CONSTRUCT_OBJECT": []*Clause{
-			{
-				Elements: []Element{
-					NewTokenType(lexer.ItemNode),
-				},
-			},
-			{
-				Elements: []Element{
-					NewTokenType(lexer.ItemBlankNode),
-				},
-			},
-			{
-				Elements: []Element{
-					NewTokenType(lexer.ItemPredicate),
-				},
-			},
-			{
-				Elements: []Element{
-					NewTokenType(lexer.ItemLiteral),
-				},
-			},
-			{
-				Elements: []Element{
-					NewTokenType(lexer.ItemBinding),
-				},
-			},
-		},
-		"MORE_CONSTRUCT_PREDICATE_OBJECT_PAIRS": []*Clause{
-			{
-				Elements: []Element{
-					NewTokenType(lexer.ItemSemicolon),
-					NewSymbol("CONSTRUCT_PREDICATE"),
-					NewSymbol("CONSTRUCT_OBJECT"),
-					NewSymbol("MORE_CONSTRUCT_PREDICATE_OBJECT_PAIRS"),
-				},
-			},
-			{},
-		},
-		"MORE_CONSTRUCT_TRIPLES": []*Clause{
-			{
-				Elements: []Element{
-					NewTokenType(lexer.ItemDot),
-					NewSymbol("CONSTRUCT_TRIPLES"),
-				},
-			},
-			{},
-		},
-		"DECONSTRUCT_FACTS": []*Clause{
-			{
-				Elements: []Element{
-					NewTokenType(lexer.ItemLBracket),
-					NewSymbol("DECONSTRUCT_TRIPLES"),
-					NewTokenType(lexer.ItemRBracket),
-				},
-			},
-		},
-		"DECONSTRUCT_TRIPLES": []*Clause{
-			{
-				Elements: []Element{
-					NewTokenType(lexer.ItemNode),
-					NewSymbol("CONSTRUCT_PREDICATE"),
-					NewSymbol("CONSTRUCT_OBJECT"),
-					NewSymbol("MORE_DECONSTRUCT_TRIPLES"),
-				},
-			},
-			{
-				Elements: []Element{
-					NewTokenType(lexer.ItemBinding),
-					NewSymbol("CONSTRUCT_PREDICATE"),
-					NewSymbol("CONSTRUCT_OBJECT"),
-					NewSymbol("MORE_DECONSTRUCT_TRIPLES"),
-				},
-			},
-		},
-		"MORE_DECONSTRUCT_TRIPLES": []*Clause{
-			{
-				Elements: []Element{
-					NewTokenType(lexer.ItemDot),
-					NewSymbol("DECONSTRUCT_TRIPLES"),
-				},
-			},
-			{},
-		},
-		"GRAPH_SHOW": []*Clause{
-			{
-				Elements: []Element{
-					NewTokenType(lexer.ItemGraphs),
-				},
-			},
-		},
+		"START":                                  startClauses,
+		"CREATE_GRAPHS":                          createGraphClauses,
+		"DROP_GRAPHS":                            dropGraphClauses,
+		"VARS":                                   varsClauses,
+		"COUNT_DISTINCT":                         countDistinctClauses,
+		"VARS_AS":                                varsAsClauses,
+		"MORE_VARS":                              moreVarsClauses,
+		"GRAPHS":                                 graphsClauses,
+		"MORE_GRAPHS":                            moreGraphsClauses,
+		"INPUT_GRAPHS":                           inputGraphClauses,
+		"MORE_INPUT_GRAPHS":                      moreInputGraphClauses,
+		"OUTPUT_GRAPHS":                          outputGraphClauses,
+		"MORE_OUTPUT_GRAPHS":                     moreOutputGraphClauses,
+		"WHERE":                                  whereClauses,
+		"FIRST_CLAUSE":                           firstClauses,
+		"MORE_CLAUSES":                           moreClauses,
+		"CLAUSES":                                clauses,
+		"OPTIONAL_CLAUSE":                        optionalClauses,
+		"SUBJECT_EXTRACT":                        subjectExtractClauses,
+		"SUBJECT_TYPE":                           subjectTypeClauses,
+		"SUBJECT_ID":                             subjectIDClauses,
+		"PREDICATE":                              predicateClauses,
+		"PREDICATE_AS":                           predicateAsClauses,
+		"PREDICATE_ID":                           predicateIDClauses,
+		"PREDICATE_AT":                           predicateAtClauses,
+		"PREDICATE_BOUND_AT":                     predicateBoundAtClauses,
+		"PREDICATE_BOUND_AT_BINDINGS":            predicateBoundAtBindingsClauses,
+		"PREDICATE_BOUND_AT_BINDINGS_END":        predicateBoundAtBindingsEndClauses,
+		"OBJECT":                                 objectClauses,
+		"OBJECT_SUBJECT_EXTRACT":                 objectSubjectExtractClauses,
+		"OBJECT_SUBJECT_TYPE":                    objectSubjectTypeClauses,
+		"OBJECT_SUBJECT_ID":                      objectSubjectIDClauses,
+		"OBJECT_PREDICATE_AS":                    objectPredicateAsClauses,
+		"OBJECT_PREDICATE_ID":                    objectPredicateIDClauses,
+		"OBJECT_PREDICATE_AT":                    objectPredicateAtClauses,
+		"OBJECT_PREDICATE_BOUND_AT":              objectPredicateBoundAtClauses,
+		"OBJECT_PREDICATE_BOUND_AT_BINDINGS":     objectPredicateBoundAtBindingsClauses,
+		"OBJECT_PREDICATE_BOUND_AT_BINDINGS_END": objectPredicateBoundAtBindingsEndClauses,
+		"OBJECT_LITERAL_AS":                      objectLiteralAsClauses,
+		"OBJECT_LITERAL_BINDING_AS":              objectLiteralBindingAsClauses,
+		"OBJECT_LITERAL_BINDING_TYPE":            objectLiteralBindingTypeClauses,
+		"OBJECT_LITERAL_BINDING_ID":              objectLiteralBindingIDClauses,
+		"OBJECT_LITERAL_BINDING_AT":              objectLiteralBindingAtClauses,
+		"GROUP_BY":                               groupByClauses,
+		"GROUP_BY_BINDINGS":                      groupByBindingsClauses,
+		"ORDER_BY":                               orderByClauses,
+		"ORDER_BY_DIRECTION":                     orderByDirectionClauses,
+		"ORDER_BY_BINDINGS":                      orderByBindingsClauses,
+		"HAVING":                                 topHavingClauses,
+		"HAVING_CLAUSE":                          havingClauses,
+		"HAVING_CLAUSE_BINARY_COMPOSITE":         havingClausesBinaryCompositeClauses,
+		"GLOBAL_TIME_BOUND":                      globalTimeBoundClauses,
+		"LIMIT":                                  limitClauses,
+		"INSERT_OBJECT":                          insertObjectClauses,
+		"INSERT_DATA":                            insertDataClauses,
+		"DELETE_OBJECT":                          deleteObjectClauses,
+		"DELETE_DATA":                            deleteDataClauses,
+		"CONSTRUCT_FACTS":                        constructFactsClauses,
+		"CONSTRUCT_TRIPLES":                      constructTriplesClauses,
+		"CONSTRUCT_PREDICATE":                    constructPredicateClauses,
+		"CONSTRUCT_OBJECT":                       constructObjectClauses,
+		"MORE_CONSTRUCT_PREDICATE_OBJECT_PAIRS":  moreConstructPredicateObjectPairsClauses,
+		"MORE_CONSTRUCT_TRIPLES":                 moreConstructTriplesClauses,
+		"DECONSTRUCT_FACTS":                      deconstructFactsClauses,
+		"DECONSTRUCT_TRIPLES":                    deconstructTriplesClauses,
+		"MORE_DECONSTRUCT_TRIPLES":               moreDeconstructTriplesClauses,
+		"GRAPH_SHOW":                             graphShowClauses,
 	}
 }
 

--- a/bql/grammar/grammar.go
+++ b/bql/grammar/grammar.go
@@ -24,6 +24,7 @@ import (
 	"github.com/google/badwolf/bql/lexer"
 	"github.com/google/badwolf/bql/semantic"
 )
+
 func startClauses() []*Clause {
 	return []*Clause{
 		{
@@ -1352,4 +1353,3 @@ func SemanticBQL() *Grammar {
 
 	return semanticBQL
 }
-

--- a/bql/grammar/grammar.go
+++ b/bql/grammar/grammar.go
@@ -24,9 +24,8 @@ import (
 	"github.com/google/badwolf/bql/lexer"
 	"github.com/google/badwolf/bql/semantic"
 )
-
-var (
-	startClauses = []*Clause{
+func startClauses() []*Clause {
+	return []*Clause{
 		{
 			Elements: []Element{
 				NewTokenType(lexer.ItemQuery),
@@ -120,7 +119,10 @@ var (
 			},
 		},
 	}
-	createGraphClauses = []*Clause{
+}
+
+func createGraphClauses() []*Clause {
+	return []*Clause{
 		{
 			Elements: []Element{
 				NewTokenType(lexer.ItemGraph),
@@ -128,7 +130,10 @@ var (
 			},
 		},
 	}
-	dropGraphClauses = []*Clause{
+}
+
+func dropGraphClauses() []*Clause {
+	return []*Clause{
 		{
 			Elements: []Element{
 				NewTokenType(lexer.ItemGraph),
@@ -136,7 +141,10 @@ var (
 			},
 		},
 	}
-	varsClauses = []*Clause{
+}
+
+func varsClauses() []*Clause {
+	return []*Clause{
 		{
 			Elements: []Element{
 				NewTokenType(lexer.ItemBinding),
@@ -168,7 +176,10 @@ var (
 			},
 		},
 	}
-	countDistinctClauses = []*Clause{
+}
+
+func countDistinctClauses() []*Clause {
+	return []*Clause{
 		{
 			Elements: []Element{
 				NewTokenType(lexer.ItemDistinct),
@@ -176,7 +187,10 @@ var (
 		},
 		{},
 	}
-	varsAsClauses = []*Clause{
+}
+
+func varsAsClauses() []*Clause {
+	return []*Clause{
 		{
 			Elements: []Element{
 				NewTokenType(lexer.ItemAs),
@@ -185,7 +199,10 @@ var (
 		},
 		{},
 	}
-	moreVarsClauses = []*Clause{
+}
+
+func moreVarsClauses() []*Clause {
+	return []*Clause{
 		{
 			Elements: []Element{
 				NewTokenType(lexer.ItemComma),
@@ -194,7 +211,10 @@ var (
 		},
 		{},
 	}
-	graphsClauses = []*Clause{
+}
+
+func graphsClauses() []*Clause {
+	return []*Clause{
 		{
 			Elements: []Element{
 				NewTokenType(lexer.ItemBinding),
@@ -202,7 +222,10 @@ var (
 			},
 		},
 	}
-	moreGraphsClauses = []*Clause{
+}
+
+func moreGraphsClauses() []*Clause {
+	return []*Clause{
 		{
 			Elements: []Element{
 				NewTokenType(lexer.ItemComma),
@@ -212,7 +235,10 @@ var (
 		},
 		{},
 	}
-	inputGraphClauses = []*Clause{
+}
+
+func inputGraphClauses() []*Clause {
+	return []*Clause{
 		{
 			Elements: []Element{
 				NewTokenType(lexer.ItemBinding),
@@ -220,7 +246,10 @@ var (
 			},
 		},
 	}
-	moreInputGraphClauses = []*Clause{
+}
+
+func moreInputGraphClauses() []*Clause {
+	return []*Clause{
 		{
 			Elements: []Element{
 				NewTokenType(lexer.ItemComma),
@@ -230,7 +259,10 @@ var (
 		},
 		{},
 	}
-	outputGraphClauses = []*Clause{
+}
+
+func outputGraphClauses() []*Clause {
+	return []*Clause{
 		{
 			Elements: []Element{
 				NewTokenType(lexer.ItemBinding),
@@ -238,7 +270,10 @@ var (
 			},
 		},
 	}
-	moreOutputGraphClauses = []*Clause{
+}
+
+func moreOutputGraphClauses() []*Clause {
+	return []*Clause{
 		{
 			Elements: []Element{
 				NewTokenType(lexer.ItemComma),
@@ -248,7 +283,10 @@ var (
 		},
 		{},
 	}
-	whereClauses = []*Clause{
+}
+
+func whereClauses() []*Clause {
+	return []*Clause{
 		{
 			Elements: []Element{
 				NewTokenType(lexer.ItemWhere),
@@ -258,7 +296,10 @@ var (
 			},
 		},
 	}
-	firstClauses = []*Clause{
+}
+
+func firstClauses() []*Clause {
+	return []*Clause{
 		{
 			Elements: []Element{
 				NewTokenType(lexer.ItemNode),
@@ -278,7 +319,9 @@ var (
 			},
 		},
 	}
-	moreClauses = []*Clause{
+}
+func moreClauses() []*Clause {
+	return []*Clause{
 		{
 			Elements: []Element{
 				NewTokenType(lexer.ItemDot),
@@ -287,7 +330,9 @@ var (
 		},
 		{},
 	}
-	clauses = []*Clause{
+}
+func clauses() []*Clause {
+	return []*Clause{
 		{
 			Elements: []Element{
 				NewTokenType(lexer.ItemOptional),
@@ -316,7 +361,10 @@ var (
 			},
 		},
 	}
-	optionalClauses = []*Clause{
+}
+
+func optionalClauses() []*Clause {
+	return []*Clause{
 		{
 			Elements: []Element{
 				NewTokenType(lexer.ItemNode),
@@ -334,7 +382,10 @@ var (
 			},
 		},
 	}
-	subjectExtractClauses = []*Clause{
+}
+
+func subjectExtractClauses() []*Clause {
+	return []*Clause{
 		{
 			Elements: []Element{
 				NewTokenType(lexer.ItemAs),
@@ -358,7 +409,10 @@ var (
 		},
 		{},
 	}
-	subjectTypeClauses = []*Clause{
+}
+
+func subjectTypeClauses() []*Clause {
+	return []*Clause{
 		{
 			Elements: []Element{
 				NewTokenType(lexer.ItemType),
@@ -367,7 +421,10 @@ var (
 		},
 		{},
 	}
-	subjectIDClauses = []*Clause{
+}
+
+func subjectIDClauses() []*Clause {
+	return []*Clause{
 		{
 			Elements: []Element{
 				NewTokenType(lexer.ItemID),
@@ -376,7 +433,10 @@ var (
 		},
 		{},
 	}
-	predicateClauses = []*Clause{
+}
+
+func predicateClauses() []*Clause {
+	return []*Clause{
 		{
 			Elements: []Element{
 				NewTokenType(lexer.ItemPredicate),
@@ -402,7 +462,10 @@ var (
 			},
 		},
 	}
-	predicateAsClauses = []*Clause{
+}
+
+func predicateAsClauses() []*Clause {
+	return []*Clause{
 		{
 			Elements: []Element{
 				NewTokenType(lexer.ItemAs),
@@ -411,7 +474,10 @@ var (
 		},
 		{},
 	}
-	predicateIDClauses = []*Clause{
+}
+
+func predicateIDClauses() []*Clause {
+	return []*Clause{
 		{
 			Elements: []Element{
 				NewTokenType(lexer.ItemID),
@@ -420,7 +486,10 @@ var (
 		},
 		{},
 	}
-	predicateAtClauses = []*Clause{
+}
+
+func predicateAtClauses() []*Clause {
+	return []*Clause{
 		{
 			Elements: []Element{
 				NewTokenType(lexer.ItemAt),
@@ -429,7 +498,10 @@ var (
 		},
 		{},
 	}
-	predicateBoundAtClauses = []*Clause{
+}
+
+func predicateBoundAtClauses() []*Clause {
+	return []*Clause{
 		{
 			Elements: []Element{
 				NewTokenType(lexer.ItemAt),
@@ -438,7 +510,10 @@ var (
 		},
 		{},
 	}
-	predicateBoundAtBindingsClauses = []*Clause{
+}
+
+func predicateBoundAtBindingsClauses() []*Clause {
+	return []*Clause{
 		{
 			Elements: []Element{
 				NewTokenType(lexer.ItemBinding),
@@ -447,16 +522,21 @@ var (
 		},
 		{},
 	}
-	predicateBoundAtBindingsEndClauses = []*Clause{
-		{
-			Elements: []Element{
-				NewTokenType(lexer.ItemComma),
-				NewTokenType(lexer.ItemBinding),
-			},
+}
+
+func predicateBoundAtBindingsEndClauses() []*Clause {
+	return []*Clause{{
+		Elements: []Element{
+			NewTokenType(lexer.ItemComma),
+			NewTokenType(lexer.ItemBinding),
 		},
+	},
 		{},
 	}
-	objectClauses = []*Clause{
+}
+
+func objectClauses() []*Clause {
+	return []*Clause{
 		{
 			Elements: []Element{
 				NewTokenType(lexer.ItemLiteral),
@@ -495,31 +575,36 @@ var (
 			},
 		},
 	}
-	objectSubjectExtractClauses = []*Clause{
+}
+
+func objectSubjectExtractClauses() []*Clause {
+	return []*Clause{{
+		Elements: []Element{
+			NewTokenType(lexer.ItemAs),
+			NewTokenType(lexer.ItemBinding),
+			NewSymbol("OBJECT_SUBJECT_TYPE"),
+			NewSymbol("OBJECT_SUBJECT_ID"),
+		},
+	},
 		{
 			Elements: []Element{
-				NewTokenType(lexer.ItemAs),
+				NewTokenType(lexer.ItemType),
 				NewTokenType(lexer.ItemBinding),
-				NewSymbol("OBJECT_SUBJECT_TYPE"),
 				NewSymbol("OBJECT_SUBJECT_ID"),
 			},
 		},
 		{
 			Elements: []Element{
-				NewTokenType(lexer.ItemType),
-				NewTokenType(lexer.ItemBinding),
-				NewSymbol("OBJECT_SUBJECT_ID"),
-			},
-		},
-		{
-			Elements: []Element{
 				NewTokenType(lexer.ItemID),
 				NewTokenType(lexer.ItemBinding),
 			},
 		},
 		{},
 	}
-	objectSubjectTypeClauses = []*Clause{
+}
+
+func objectSubjectTypeClauses() []*Clause {
+	return []*Clause{
 		{
 			Elements: []Element{
 				NewTokenType(lexer.ItemType),
@@ -528,7 +613,10 @@ var (
 		},
 		{},
 	}
-	objectSubjectIDClauses = []*Clause{
+}
+
+func objectSubjectIDClauses() []*Clause {
+	return []*Clause{
 		{
 			Elements: []Element{
 				NewTokenType(lexer.ItemID),
@@ -537,7 +625,10 @@ var (
 		},
 		{},
 	}
-	objectPredicateAsClauses = []*Clause{
+}
+
+func objectPredicateAsClauses() []*Clause {
+	return []*Clause{
 		{
 			Elements: []Element{
 				NewTokenType(lexer.ItemAs),
@@ -546,7 +637,10 @@ var (
 		},
 		{},
 	}
-	objectPredicateIDClauses = []*Clause{
+}
+
+func objectPredicateIDClauses() []*Clause {
+	return []*Clause{
 		{
 			Elements: []Element{
 				NewTokenType(lexer.ItemID),
@@ -555,7 +649,10 @@ var (
 		},
 		{},
 	}
-	objectPredicateAtClauses = []*Clause{
+}
+
+func objectPredicateAtClauses() []*Clause {
+	return []*Clause{
 		{
 			Elements: []Element{
 				NewTokenType(lexer.ItemAt),
@@ -564,7 +661,10 @@ var (
 		},
 		{},
 	}
-	objectPredicateBoundAtClauses = []*Clause{
+}
+
+func objectPredicateBoundAtClauses() []*Clause {
+	return []*Clause{
 		{
 			Elements: []Element{
 				NewTokenType(lexer.ItemAt),
@@ -573,52 +673,64 @@ var (
 		},
 		{},
 	}
-	objectPredicateBoundAtBindingsClauses = []*Clause{
-		{
-			Elements: []Element{
-				NewTokenType(lexer.ItemBinding),
-				NewSymbol("OBJECT_PREDICATE_BOUND_AT_BINDINGS_END"),
-			},
+}
+
+func objectPredicateBoundAtBindingsClauses() []*Clause {
+	return []*Clause{{
+		Elements: []Element{
+			NewTokenType(lexer.ItemBinding),
+			NewSymbol("OBJECT_PREDICATE_BOUND_AT_BINDINGS_END"),
 		},
+	},
 		{},
 	}
-	objectPredicateBoundAtBindingsEndClauses = []*Clause{
-		{
-			Elements: []Element{
-				NewTokenType(lexer.ItemComma),
-				NewTokenType(lexer.ItemBinding),
-			},
+}
+
+func objectPredicateBoundAtBindingsEndClauses() []*Clause {
+	return []*Clause{{
+		Elements: []Element{
+			NewTokenType(lexer.ItemComma),
+			NewTokenType(lexer.ItemBinding),
 		},
+	},
 		{},
 	}
-	objectLiteralAsClauses = []*Clause{
-		{
-			Elements: []Element{
-				NewTokenType(lexer.ItemAs),
-				NewTokenType(lexer.ItemBinding),
-			},
+}
+
+func objectLiteralAsClauses() []*Clause {
+	return []*Clause{{
+		Elements: []Element{
+			NewTokenType(lexer.ItemAs),
+			NewTokenType(lexer.ItemBinding),
 		},
+	},
 		{},
 	}
-	objectLiteralBindingAsClauses = []*Clause{
-		{
-			Elements: []Element{
-				NewTokenType(lexer.ItemAs),
-				NewTokenType(lexer.ItemBinding),
-			},
+}
+
+func objectLiteralBindingAsClauses() []*Clause {
+	return []*Clause{{
+		Elements: []Element{
+			NewTokenType(lexer.ItemAs),
+			NewTokenType(lexer.ItemBinding),
 		},
+	},
 		{},
 	}
-	objectLiteralBindingTypeClauses = []*Clause{
-		{
-			Elements: []Element{
-				NewTokenType(lexer.ItemType),
-				NewTokenType(lexer.ItemBinding),
-			},
+}
+func objectLiteralBindingTypeClauses() []*Clause {
+	return []*Clause{{
+		Elements: []Element{
+			NewTokenType(lexer.ItemType),
+			NewTokenType(lexer.ItemBinding),
 		},
+	},
 		{},
 	}
-	objectLiteralBindingIDClauses = []*Clause{
+}
+
+func objectLiteralBindingIDClauses() []*Clause {
+	return []*Clause{
 		{
 			Elements: []Element{
 				NewTokenType(lexer.ItemID),
@@ -627,16 +739,21 @@ var (
 		},
 		{},
 	}
-	objectLiteralBindingAtClauses = []*Clause{
-		{
-			Elements: []Element{
-				NewTokenType(lexer.ItemAt),
-				NewTokenType(lexer.ItemBinding),
-			},
+}
+
+func objectLiteralBindingAtClauses() []*Clause {
+	return []*Clause{{
+		Elements: []Element{
+			NewTokenType(lexer.ItemAt),
+			NewTokenType(lexer.ItemBinding),
 		},
+	},
 		{},
 	}
-	groupByClauses = []*Clause{
+}
+
+func groupByClauses() []*Clause {
+	return []*Clause{
 		{
 			Elements: []Element{
 				NewTokenType(lexer.ItemGroup),
@@ -647,34 +764,38 @@ var (
 		},
 		{},
 	}
-	groupByBindingsClauses = []*Clause{
-		{
-			Elements: []Element{
-				NewTokenType(lexer.ItemComma),
-				NewTokenType(lexer.ItemBinding),
-				NewSymbol("GROUP_BY_BINDINGS"),
-			},
+}
+
+func groupByBindingsClauses() []*Clause {
+	return []*Clause{{
+		Elements: []Element{
+			NewTokenType(lexer.ItemComma),
+			NewTokenType(lexer.ItemBinding),
+			NewSymbol("GROUP_BY_BINDINGS"),
 		},
+	},
 		{},
 	}
-	orderByClauses = []*Clause{
-		{
-			Elements: []Element{
-				NewTokenType(lexer.ItemOrder),
-				NewTokenType(lexer.ItemBy),
-				NewTokenType(lexer.ItemBinding),
-				NewSymbol("ORDER_BY_DIRECTION"),
-				NewSymbol("ORDER_BY_BINDINGS"),
-			},
+}
+func orderByClauses() []*Clause {
+	return []*Clause{{
+		Elements: []Element{
+			NewTokenType(lexer.ItemOrder),
+			NewTokenType(lexer.ItemBy),
+			NewTokenType(lexer.ItemBinding),
+			NewSymbol("ORDER_BY_DIRECTION"),
+			NewSymbol("ORDER_BY_BINDINGS"),
 		},
+	},
 		{},
 	}
-	orderByDirectionClauses = []*Clause{
-		{
-			Elements: []Element{
-				NewTokenType(lexer.ItemAsc),
-			},
+}
+func orderByDirectionClauses() []*Clause {
+	return []*Clause{{
+		Elements: []Element{
+			NewTokenType(lexer.ItemAsc),
 		},
+	},
 		{
 			Elements: []Element{
 				NewTokenType(lexer.ItemDesc),
@@ -682,33 +803,36 @@ var (
 		},
 		{},
 	}
-	orderByBindingsClauses = []*Clause{
-		{
-			Elements: []Element{
-				NewTokenType(lexer.ItemComma),
-				NewTokenType(lexer.ItemBinding),
-				NewSymbol("ORDER_BY_DIRECTION"),
-				NewSymbol("ORDER_BY_BINDINGS"),
-			},
+}
+func orderByBindingsClauses() []*Clause {
+	return []*Clause{{
+		Elements: []Element{
+			NewTokenType(lexer.ItemComma),
+			NewTokenType(lexer.ItemBinding),
+			NewSymbol("ORDER_BY_DIRECTION"),
+			NewSymbol("ORDER_BY_BINDINGS"),
 		},
+	},
 		{},
 	}
-	topHavingClauses = []*Clause{
-		{
-			Elements: []Element{
-				NewTokenType(lexer.ItemHaving),
-				NewSymbol("HAVING_CLAUSE"),
-			},
+}
+func topHavingClauses() []*Clause {
+	return []*Clause{{
+		Elements: []Element{
+			NewTokenType(lexer.ItemHaving),
+			NewSymbol("HAVING_CLAUSE"),
 		},
+	},
 		{},
 	}
-	havingClauses = []*Clause{
-		{
-			Elements: []Element{
-				NewTokenType(lexer.ItemBinding),
-				NewSymbol("HAVING_CLAUSE_BINARY_COMPOSITE"),
-			},
+}
+func havingClauses() []*Clause {
+	return []*Clause{{
+		Elements: []Element{
+			NewTokenType(lexer.ItemBinding),
+			NewSymbol("HAVING_CLAUSE_BINARY_COMPOSITE"),
 		},
+	},
 		{
 			Elements: []Element{
 				NewTokenType(lexer.ItemNode),
@@ -736,13 +860,14 @@ var (
 			},
 		},
 	}
-	havingClausesBinaryCompositeClauses = []*Clause{
-		{
-			Elements: []Element{
-				NewTokenType(lexer.ItemAnd),
-				NewSymbol("HAVING_CLAUSE"),
-			},
+}
+func havingClausesBinaryCompositeClauses() []*Clause {
+	return []*Clause{{
+		Elements: []Element{
+			NewTokenType(lexer.ItemAnd),
+			NewSymbol("HAVING_CLAUSE"),
 		},
+	},
 		{
 			Elements: []Element{
 				NewTokenType(lexer.ItemOr),
@@ -769,13 +894,14 @@ var (
 		},
 		{},
 	}
-	globalTimeBoundClauses = []*Clause{
-		{
-			Elements: []Element{
-				NewTokenType(lexer.ItemBefore),
-				NewTokenType(lexer.ItemPredicate),
-			},
+}
+func globalTimeBoundClauses() []*Clause {
+	return []*Clause{{
+		Elements: []Element{
+			NewTokenType(lexer.ItemBefore),
+			NewTokenType(lexer.ItemPredicate),
 		},
+	},
 		{
 			Elements: []Element{
 				NewTokenType(lexer.ItemAfter),
@@ -790,50 +916,23 @@ var (
 		},
 		{},
 	}
-	limitClauses = []*Clause{
-		{
-			Elements: []Element{
-				NewTokenType(lexer.ItemLimit),
-				NewTokenType(lexer.ItemLiteral),
-			},
+}
+func limitClauses() []*Clause {
+	return []*Clause{{
+		Elements: []Element{
+			NewTokenType(lexer.ItemLimit),
+			NewTokenType(lexer.ItemLiteral),
 		},
+	},
 		{},
 	}
-	insertObjectClauses = []*Clause{
-		{
-			Elements: []Element{
-				NewTokenType(lexer.ItemNode),
-			},
+}
+func insertObjectClauses() []*Clause {
+	return []*Clause{{
+		Elements: []Element{
+			NewTokenType(lexer.ItemNode),
 		},
-		{
-			Elements: []Element{
-				NewTokenType(lexer.ItemPredicate),
-			},
-		},
-		{
-			Elements: []Element{
-				NewTokenType(lexer.ItemLiteral),
-			},
-		},
-	}
-	insertDataClauses = []*Clause{
-		{
-			Elements: []Element{
-				NewTokenType(lexer.ItemDot),
-				NewTokenType(lexer.ItemNode),
-				NewTokenType(lexer.ItemPredicate),
-				NewSymbol("INSERT_OBJECT"),
-				NewSymbol("INSERT_DATA"),
-			},
-		},
-		{},
-	}
-	deleteObjectClauses = []*Clause{
-		{
-			Elements: []Element{
-				NewTokenType(lexer.ItemNode),
-			},
-		},
+	},
 		{
 			Elements: []Element{
 				NewTokenType(lexer.ItemPredicate),
@@ -845,37 +944,71 @@ var (
 			},
 		},
 	}
-	deleteDataClauses = []*Clause{
-		{
-			Elements: []Element{
-				NewTokenType(lexer.ItemDot),
-				NewTokenType(lexer.ItemNode),
-				NewTokenType(lexer.ItemPredicate),
-				NewSymbol("DELETE_OBJECT"),
-				NewSymbol("DELETE_DATA"),
-			},
+}
+func insertDataClauses() []*Clause {
+	return []*Clause{{
+		Elements: []Element{
+			NewTokenType(lexer.ItemDot),
+			NewTokenType(lexer.ItemNode),
+			NewTokenType(lexer.ItemPredicate),
+			NewSymbol("INSERT_OBJECT"),
+			NewSymbol("INSERT_DATA"),
 		},
+	},
 		{},
 	}
-	constructFactsClauses = []*Clause{
+}
+func deleteObjectClauses() []*Clause {
+	return []*Clause{{
+		Elements: []Element{
+			NewTokenType(lexer.ItemNode),
+		},
+	},
 		{
 			Elements: []Element{
-				NewTokenType(lexer.ItemLBracket),
-				NewSymbol("CONSTRUCT_TRIPLES"),
-				NewTokenType(lexer.ItemRBracket),
+				NewTokenType(lexer.ItemPredicate),
+			},
+		},
+		{
+			Elements: []Element{
+				NewTokenType(lexer.ItemLiteral),
 			},
 		},
 	}
-	constructTriplesClauses = []*Clause{
-		{
-			Elements: []Element{
-				NewTokenType(lexer.ItemNode),
-				NewSymbol("CONSTRUCT_PREDICATE"),
-				NewSymbol("CONSTRUCT_OBJECT"),
-				NewSymbol("MORE_CONSTRUCT_PREDICATE_OBJECT_PAIRS"),
-				NewSymbol("MORE_CONSTRUCT_TRIPLES"),
-			},
+}
+func deleteDataClauses() []*Clause {
+	return []*Clause{{
+		Elements: []Element{
+			NewTokenType(lexer.ItemDot),
+			NewTokenType(lexer.ItemNode),
+			NewTokenType(lexer.ItemPredicate),
+			NewSymbol("DELETE_OBJECT"),
+			NewSymbol("DELETE_DATA"),
 		},
+	},
+		{},
+	}
+}
+func constructFactsClauses() []*Clause {
+	return []*Clause{{
+		Elements: []Element{
+			NewTokenType(lexer.ItemLBracket),
+			NewSymbol("CONSTRUCT_TRIPLES"),
+			NewTokenType(lexer.ItemRBracket),
+		},
+	},
+	}
+}
+func constructTriplesClauses() []*Clause {
+	return []*Clause{{
+		Elements: []Element{
+			NewTokenType(lexer.ItemNode),
+			NewSymbol("CONSTRUCT_PREDICATE"),
+			NewSymbol("CONSTRUCT_OBJECT"),
+			NewSymbol("MORE_CONSTRUCT_PREDICATE_OBJECT_PAIRS"),
+			NewSymbol("MORE_CONSTRUCT_TRIPLES"),
+		},
+	},
 		{
 			Elements: []Element{
 				NewTokenType(lexer.ItemBlankNode),
@@ -895,19 +1028,22 @@ var (
 			},
 		},
 	}
-	constructPredicateClauses = []*Clause{
-		{
-			Elements: []Element{
-				NewTokenType(lexer.ItemPredicate),
-			},
+}
+func constructPredicateClauses() []*Clause {
+	return []*Clause{{
+		Elements: []Element{
+			NewTokenType(lexer.ItemPredicate),
 		},
+	},
 		{
 			Elements: []Element{
 				NewTokenType(lexer.ItemBinding),
 			},
 		},
 	}
-	constructObjectClauses = []*Clause{
+}
+func constructObjectClauses() []*Clause {
+	return []*Clause{
 		{
 			Elements: []Element{
 				NewTokenType(lexer.ItemNode),
@@ -934,44 +1070,48 @@ var (
 			},
 		},
 	}
-	moreConstructPredicateObjectPairsClauses = []*Clause{
-		{
-			Elements: []Element{
-				NewTokenType(lexer.ItemSemicolon),
-				NewSymbol("CONSTRUCT_PREDICATE"),
-				NewSymbol("CONSTRUCT_OBJECT"),
-				NewSymbol("MORE_CONSTRUCT_PREDICATE_OBJECT_PAIRS"),
-			},
+}
+func moreConstructPredicateObjectPairsClauses() []*Clause {
+	return []*Clause{{
+		Elements: []Element{
+			NewTokenType(lexer.ItemSemicolon),
+			NewSymbol("CONSTRUCT_PREDICATE"),
+			NewSymbol("CONSTRUCT_OBJECT"),
+			NewSymbol("MORE_CONSTRUCT_PREDICATE_OBJECT_PAIRS"),
 		},
+	},
 		{},
 	}
-	moreConstructTriplesClauses = []*Clause{
-		{
-			Elements: []Element{
-				NewTokenType(lexer.ItemDot),
-				NewSymbol("CONSTRUCT_TRIPLES"),
-			},
+}
+func moreConstructTriplesClauses() []*Clause {
+	return []*Clause{{
+		Elements: []Element{
+			NewTokenType(lexer.ItemDot),
+			NewSymbol("CONSTRUCT_TRIPLES"),
 		},
+	},
 		{},
 	}
-	deconstructFactsClauses = []*Clause{
-		{
-			Elements: []Element{
-				NewTokenType(lexer.ItemLBracket),
-				NewSymbol("DECONSTRUCT_TRIPLES"),
-				NewTokenType(lexer.ItemRBracket),
-			},
+}
+func deconstructFactsClauses() []*Clause {
+	return []*Clause{{
+		Elements: []Element{
+			NewTokenType(lexer.ItemLBracket),
+			NewSymbol("DECONSTRUCT_TRIPLES"),
+			NewTokenType(lexer.ItemRBracket),
 		},
+	},
 	}
-	deconstructTriplesClauses = []*Clause{
-		{
-			Elements: []Element{
-				NewTokenType(lexer.ItemNode),
-				NewSymbol("CONSTRUCT_PREDICATE"),
-				NewSymbol("CONSTRUCT_OBJECT"),
-				NewSymbol("MORE_DECONSTRUCT_TRIPLES"),
-			},
+}
+func deconstructTriplesClauses() []*Clause {
+	return []*Clause{{
+		Elements: []Element{
+			NewTokenType(lexer.ItemNode),
+			NewSymbol("CONSTRUCT_PREDICATE"),
+			NewSymbol("CONSTRUCT_OBJECT"),
+			NewSymbol("MORE_DECONSTRUCT_TRIPLES"),
 		},
+	},
 		{
 			Elements: []Element{
 				NewTokenType(lexer.ItemBinding),
@@ -981,7 +1121,9 @@ var (
 			},
 		},
 	}
-	moreDeconstructTriplesClauses = []*Clause{
+}
+func moreDeconstructTriplesClauses() []*Clause {
+	return []*Clause{
 		{
 			Elements: []Element{
 				NewTokenType(lexer.ItemDot),
@@ -990,85 +1132,87 @@ var (
 		},
 		{},
 	}
-	graphShowClauses = []*Clause{
+}
+func graphShowClauses() []*Clause {
+	return []*Clause{
 		{
 			Elements: []Element{
 				NewTokenType(lexer.ItemGraphs),
 			},
 		},
 	}
-)
+}
 
 // BQL LL1 grammar.
 func BQL() *Grammar {
 	return &Grammar{
-		"START":                                  startClauses,
-		"CREATE_GRAPHS":                          createGraphClauses,
-		"DROP_GRAPHS":                            dropGraphClauses,
-		"VARS":                                   varsClauses,
-		"COUNT_DISTINCT":                         countDistinctClauses,
-		"VARS_AS":                                varsAsClauses,
-		"MORE_VARS":                              moreVarsClauses,
-		"GRAPHS":                                 graphsClauses,
-		"MORE_GRAPHS":                            moreGraphsClauses,
-		"INPUT_GRAPHS":                           inputGraphClauses,
-		"MORE_INPUT_GRAPHS":                      moreInputGraphClauses,
-		"OUTPUT_GRAPHS":                          outputGraphClauses,
-		"MORE_OUTPUT_GRAPHS":                     moreOutputGraphClauses,
-		"WHERE":                                  whereClauses,
-		"FIRST_CLAUSE":                           firstClauses,
-		"MORE_CLAUSES":                           moreClauses,
-		"CLAUSES":                                clauses,
-		"OPTIONAL_CLAUSE":                        optionalClauses,
-		"SUBJECT_EXTRACT":                        subjectExtractClauses,
-		"SUBJECT_TYPE":                           subjectTypeClauses,
-		"SUBJECT_ID":                             subjectIDClauses,
-		"PREDICATE":                              predicateClauses,
-		"PREDICATE_AS":                           predicateAsClauses,
-		"PREDICATE_ID":                           predicateIDClauses,
-		"PREDICATE_AT":                           predicateAtClauses,
-		"PREDICATE_BOUND_AT":                     predicateBoundAtClauses,
-		"PREDICATE_BOUND_AT_BINDINGS":            predicateBoundAtBindingsClauses,
-		"PREDICATE_BOUND_AT_BINDINGS_END":        predicateBoundAtBindingsEndClauses,
-		"OBJECT":                                 objectClauses,
-		"OBJECT_SUBJECT_EXTRACT":                 objectSubjectExtractClauses,
-		"OBJECT_SUBJECT_TYPE":                    objectSubjectTypeClauses,
-		"OBJECT_SUBJECT_ID":                      objectSubjectIDClauses,
-		"OBJECT_PREDICATE_AS":                    objectPredicateAsClauses,
-		"OBJECT_PREDICATE_ID":                    objectPredicateIDClauses,
-		"OBJECT_PREDICATE_AT":                    objectPredicateAtClauses,
-		"OBJECT_PREDICATE_BOUND_AT":              objectPredicateBoundAtClauses,
-		"OBJECT_PREDICATE_BOUND_AT_BINDINGS":     objectPredicateBoundAtBindingsClauses,
-		"OBJECT_PREDICATE_BOUND_AT_BINDINGS_END": objectPredicateBoundAtBindingsEndClauses,
-		"OBJECT_LITERAL_AS":                      objectLiteralAsClauses,
-		"OBJECT_LITERAL_BINDING_AS":              objectLiteralBindingAsClauses,
-		"OBJECT_LITERAL_BINDING_TYPE":            objectLiteralBindingTypeClauses,
-		"OBJECT_LITERAL_BINDING_ID":              objectLiteralBindingIDClauses,
-		"OBJECT_LITERAL_BINDING_AT":              objectLiteralBindingAtClauses,
-		"GROUP_BY":                               groupByClauses,
-		"GROUP_BY_BINDINGS":                      groupByBindingsClauses,
-		"ORDER_BY":                               orderByClauses,
-		"ORDER_BY_DIRECTION":                     orderByDirectionClauses,
-		"ORDER_BY_BINDINGS":                      orderByBindingsClauses,
-		"HAVING":                                 topHavingClauses,
-		"HAVING_CLAUSE":                          havingClauses,
-		"HAVING_CLAUSE_BINARY_COMPOSITE":         havingClausesBinaryCompositeClauses,
-		"GLOBAL_TIME_BOUND":                      globalTimeBoundClauses,
-		"LIMIT":                                  limitClauses,
-		"INSERT_OBJECT":                          insertObjectClauses,
-		"INSERT_DATA":                            insertDataClauses,
-		"DELETE_OBJECT":                          deleteObjectClauses,
-		"DELETE_DATA":                            deleteDataClauses,
-		"CONSTRUCT_FACTS":                        constructFactsClauses,
-		"CONSTRUCT_TRIPLES":                      constructTriplesClauses,
-		"CONSTRUCT_PREDICATE":                    constructPredicateClauses,
-		"CONSTRUCT_OBJECT":                       constructObjectClauses,
-		"MORE_CONSTRUCT_PREDICATE_OBJECT_PAIRS":  moreConstructPredicateObjectPairsClauses,
-		"MORE_CONSTRUCT_TRIPLES":                 moreConstructTriplesClauses,
-		"DECONSTRUCT_FACTS":                      deconstructFactsClauses,
-		"DECONSTRUCT_TRIPLES":                    deconstructTriplesClauses,
-		"MORE_DECONSTRUCT_TRIPLES":               moreDeconstructTriplesClauses,
-		"GRAPH_SHOW":                             graphShowClauses,
+		"START":                                  startClauses(),
+		"CREATE_GRAPHS":                          createGraphClauses(),
+		"DROP_GRAPHS":                            dropGraphClauses(),
+		"VARS":                                   varsClauses(),
+		"COUNT_DISTINCT":                         countDistinctClauses(),
+		"VARS_AS":                                varsAsClauses(),
+		"MORE_VARS":                              moreVarsClauses(),
+		"GRAPHS":                                 graphsClauses(),
+		"MORE_GRAPHS":                            moreGraphsClauses(),
+		"INPUT_GRAPHS":                           inputGraphClauses(),
+		"MORE_INPUT_GRAPHS":                      moreInputGraphClauses(),
+		"OUTPUT_GRAPHS":                          outputGraphClauses(),
+		"MORE_OUTPUT_GRAPHS":                     moreOutputGraphClauses(),
+		"WHERE":                                  whereClauses(),
+		"FIRST_CLAUSE":                           firstClauses(),
+		"MORE_CLAUSES":                           moreClauses(),
+		"CLAUSES":                                clauses(),
+		"OPTIONAL_CLAUSE":                        optionalClauses(),
+		"SUBJECT_EXTRACT":                        subjectExtractClauses(),
+		"SUBJECT_TYPE":                           subjectTypeClauses(),
+		"SUBJECT_ID":                             subjectIDClauses(),
+		"PREDICATE":                              predicateClauses(),
+		"PREDICATE_AS":                           predicateAsClauses(),
+		"PREDICATE_ID":                           predicateIDClauses(),
+		"PREDICATE_AT":                           predicateAtClauses(),
+		"PREDICATE_BOUND_AT":                     predicateBoundAtClauses(),
+		"PREDICATE_BOUND_AT_BINDINGS":            predicateBoundAtBindingsClauses(),
+		"PREDICATE_BOUND_AT_BINDINGS_END":        predicateBoundAtBindingsEndClauses(),
+		"OBJECT":                                 objectClauses(),
+		"OBJECT_SUBJECT_EXTRACT":                 objectSubjectExtractClauses(),
+		"OBJECT_SUBJECT_TYPE":                    objectSubjectTypeClauses(),
+		"OBJECT_SUBJECT_ID":                      objectSubjectIDClauses(),
+		"OBJECT_PREDICATE_AS":                    objectPredicateAsClauses(),
+		"OBJECT_PREDICATE_ID":                    objectPredicateIDClauses(),
+		"OBJECT_PREDICATE_AT":                    objectPredicateAtClauses(),
+		"OBJECT_PREDICATE_BOUND_AT":              objectPredicateBoundAtClauses(),
+		"OBJECT_PREDICATE_BOUND_AT_BINDINGS":     objectPredicateBoundAtBindingsClauses(),
+		"OBJECT_PREDICATE_BOUND_AT_BINDINGS_END": objectPredicateBoundAtBindingsEndClauses(),
+		"OBJECT_LITERAL_AS":                      objectLiteralAsClauses(),
+		"OBJECT_LITERAL_BINDING_AS":              objectLiteralBindingAsClauses(),
+		"OBJECT_LITERAL_BINDING_TYPE":            objectLiteralBindingTypeClauses(),
+		"OBJECT_LITERAL_BINDING_ID":              objectLiteralBindingIDClauses(),
+		"OBJECT_LITERAL_BINDING_AT":              objectLiteralBindingAtClauses(),
+		"GROUP_BY":                               groupByClauses(),
+		"GROUP_BY_BINDINGS":                      groupByBindingsClauses(),
+		"ORDER_BY":                               orderByClauses(),
+		"ORDER_BY_DIRECTION":                     orderByDirectionClauses(),
+		"ORDER_BY_BINDINGS":                      orderByBindingsClauses(),
+		"HAVING":                                 topHavingClauses(),
+		"HAVING_CLAUSE":                          havingClauses(),
+		"HAVING_CLAUSE_BINARY_COMPOSITE":         havingClausesBinaryCompositeClauses(),
+		"GLOBAL_TIME_BOUND":                      globalTimeBoundClauses(),
+		"LIMIT":                                  limitClauses(),
+		"INSERT_OBJECT":                          insertObjectClauses(),
+		"INSERT_DATA":                            insertDataClauses(),
+		"DELETE_OBJECT":                          deleteObjectClauses(),
+		"DELETE_DATA":                            deleteDataClauses(),
+		"CONSTRUCT_FACTS":                        constructFactsClauses(),
+		"CONSTRUCT_TRIPLES":                      constructTriplesClauses(),
+		"CONSTRUCT_PREDICATE":                    constructPredicateClauses(),
+		"CONSTRUCT_OBJECT":                       constructObjectClauses(),
+		"MORE_CONSTRUCT_PREDICATE_OBJECT_PAIRS":  moreConstructPredicateObjectPairsClauses(),
+		"MORE_CONSTRUCT_TRIPLES":                 moreConstructTriplesClauses(),
+		"DECONSTRUCT_FACTS":                      deconstructFactsClauses(),
+		"DECONSTRUCT_TRIPLES":                    deconstructTriplesClauses(),
+		"MORE_DECONSTRUCT_TRIPLES":               moreDeconstructTriplesClauses(),
+		"GRAPH_SHOW":                             graphShowClauses(),
 	}
 }
 
@@ -1208,3 +1352,4 @@ func SemanticBQL() *Grammar {
 
 	return semanticBQL
 }
+


### PR DESCRIPTION
The previous refactoring made all BQL objects share the same clause objects which caused data races.
This should keep the navigability benefits while making each BQL have specific non-shared clauses.
