### PR TITLE
Refactor tests into separate functions that expect errors or not

### DIFF
--- a/bql/planner/planner_test.go
+++ b/bql/planner/planner_test.go
@@ -272,286 +272,239 @@ func populateStoreWithTriples(ctx context.Context, s storage.Store, gn string, t
 
 func TestPlannerQuery(t *testing.T) {
 	testTable := []struct {
-		q       string
-		wantErr bool
-		nbs     int
-		nrws    int
+		q    string
+		nbs  int
+		nrws int
 	}{
 		{
-			q:       `select ?s, ?p, ?o from ?test where {?s ?p ?o};`,
-			wantErr: false,
-			nbs:     3,
-			nrws:    len(strings.Split(testTriples, "\n")) - 1,
+			q:    `select ?s, ?p, ?o from ?test where {?s ?p ?o};`,
+			nbs:  3,
+			nrws: len(strings.Split(testTriples, "\n")) - 1,
 		},
 		{
-			q:       `select ?s as ?s1, ?p as ?p1, ?o as ?o1 from ?test where {?s ?p ?o};`,
-			wantErr: false,
-			nbs:     3,
-			nrws:    len(strings.Split(testTriples, "\n")) - 1,
+			q:    `select ?s as ?s1, ?p as ?p1, ?o as ?o1 from ?test where {?s ?p ?o};`,
+			nbs:  3,
+			nrws: len(strings.Split(testTriples, "\n")) - 1,
 		},
 		{
-			q:       `select ?p, ?o from ?test where {/u<joe> ?p ?o};`,
-			wantErr: false,
-			nbs:     2,
-			nrws:    2,
+			q:    `select ?p, ?o from ?test where {/u<joe> ?p ?o};`,
+			nbs:  2,
+			nrws: 2,
 		},
 		{
-			q:       `select ?p as ?p1, ?o as ?o1 from ?test where {/u<joe> ?p ?o};`,
-			wantErr: false,
-			nbs:     2,
-			nrws:    2,
+			q:    `select ?p as ?p1, ?o as ?o1 from ?test where {/u<joe> ?p ?o};`,
+			nbs:  2,
+			nrws: 2,
 		},
 		{
-			q:       `select ?s, ?p from ?test where {?s ?p /t<car>};`,
-			wantErr: false,
-			nbs:     2,
-			nrws:    4,
+			q:    `select ?s, ?p from ?test where {?s ?p /t<car>};`,
+			nbs:  2,
+			nrws: 4,
 		},
 		{
-			q:       `select ?s, ?o from ?test where {?s "parent_of"@[] ?o};`,
-			wantErr: false,
-			nbs:     2,
-			nrws:    4,
+			q:    `select ?s, ?o from ?test where {?s "parent_of"@[] ?o};`,
+			nbs:  2,
+			nrws: 4,
 		},
 		{
-			q:       `select ?s, ?p, ?o from ?test where {/u<joe> as ?s "parent_of"@[] as ?p /u<mary> as ?o};`,
-			wantErr: false,
-			nbs:     3,
-			nrws:    1,
+			q:    `select ?s, ?p, ?o from ?test where {/u<joe> as ?s "parent_of"@[] as ?p /u<mary> as ?o};`,
+			nbs:  3,
+			nrws: 1,
 		},
 		{
-			q:       `select ?s, ?p, ?o from ?test where {/u<unknown> as ?s "parent_of"@[] as ?p /u<mary> as ?o};`,
-			wantErr: false,
-			nbs:     3,
-			nrws:    0,
+			q:    `select ?s, ?p, ?o from ?test where {/u<unknown> as ?s "parent_of"@[] as ?p /u<mary> as ?o};`,
+			nbs:  3,
+			nrws: 0,
 		},
 		{
-			q:       `select ?o from ?test where {/u<joe> "parent_of"@[] ?o};`,
-			wantErr: false,
-			nbs:     1,
-			nrws:    2,
+			q:    `select ?o from ?test where {/u<joe> "parent_of"@[] ?o};`,
+			nbs:  1,
+			nrws: 2,
 		},
 		{
-			q:       `select ?p from ?test where {/u<joe> ?p /u<mary>};`,
-			wantErr: false,
-			nbs:     1,
-			nrws:    1,
+			q:    `select ?p from ?test where {/u<joe> ?p /u<mary>};`,
+			nbs:  1,
+			nrws: 1,
 		},
 		{
-			q:       `select ?s from ?test where {?s "is_a"@[] /t<car>};`,
-			wantErr: false,
-			nbs:     1,
-			nrws:    4,
+			q:    `select ?s from ?test where {?s "is_a"@[] /t<car>};`,
+			nbs:  1,
+			nrws: 4,
 		},
 		{
-			q:       `select ?s as ?s1 from ?test where {?s "is_a"@[] /t<car>};`,
-			wantErr: false,
-			nbs:     1,
-			nrws:    4,
+			q:    `select ?s as ?s1 from ?test where {?s "is_a"@[] /t<car>};`,
+			nbs:  1,
+			nrws: 4,
 		},
 		{
-			q:       `select ?o from ?test where {/u<joe> "parent_of"@[] ?o. ?o "parent_of"@[] /u<john>};`,
-			wantErr: false,
-			nbs:     1,
-			nrws:    1,
+			q:    `select ?o from ?test where {/u<joe> "parent_of"@[] ?o. ?o "parent_of"@[] /u<john>};`,
+			nbs:  1,
+			nrws: 1,
 		},
 		{
-			q:       `select ?s, ?o from ?test where {/u<joe> "parent_of"@[] ?o. ?o "parent_of"@[] ?s};`,
-			wantErr: false,
-			nbs:     2,
-			nrws:    2,
+			q:    `select ?s, ?o from ?test where {/u<joe> "parent_of"@[] ?o. ?o "parent_of"@[] ?s};`,
+			nbs:  2,
+			nrws: 2,
 		},
 		{
-			q:       `select ?s, ?p, ?o, ?k, ?l, ?m from ?test where {?s ?p ?o. ?k ?l ?m};`,
-			wantErr: false,
-			nbs:     6,
-			nrws:    (len(strings.Split(testTriples, "\n")) - 1) * (len(strings.Split(testTriples, "\n")) - 1),
+			q:    `select ?s, ?p, ?o, ?k, ?l, ?m from ?test where {?s ?p ?o. ?k ?l ?m};`,
+			nbs:  6,
+			nrws: (len(strings.Split(testTriples, "\n")) - 1) * (len(strings.Split(testTriples, "\n")) - 1),
 		},
 		{
-			q:       `select ?s, ?p, ?o, ?k, ?l from ?test where {?s ?p ?o. ?k ?l ?m};`,
-			wantErr: false,
-			nbs:     5,
-			nrws:    (len(strings.Split(testTriples, "\n")) - 1) * (len(strings.Split(testTriples, "\n")) - 1),
+			q:    `select ?s, ?p, ?o, ?k, ?l from ?test where {?s ?p ?o. ?k ?l ?m};`,
+			nbs:  5,
+			nrws: (len(strings.Split(testTriples, "\n")) - 1) * (len(strings.Split(testTriples, "\n")) - 1),
 		},
 		{
-			q:       `select ?s, ?p, ?o, ?k from ?test where {?s ?p ?o. ?k ?l ?m};`,
-			wantErr: false,
-			nbs:     4,
-			nrws:    (len(strings.Split(testTriples, "\n")) - 1) * (len(strings.Split(testTriples, "\n")) - 1),
+			q:    `select ?s, ?p, ?o, ?k from ?test where {?s ?p ?o. ?k ?l ?m};`,
+			nbs:  4,
+			nrws: (len(strings.Split(testTriples, "\n")) - 1) * (len(strings.Split(testTriples, "\n")) - 1),
 		},
 		{
-			q:       `select ?s, ?p, ?o from ?test where {?s ?p ?o. ?k ?l ?m};`,
-			wantErr: false,
-			nbs:     3,
-			nrws:    (len(strings.Split(testTriples, "\n")) - 1) * (len(strings.Split(testTriples, "\n")) - 1),
+			q:    `select ?s, ?p, ?o from ?test where {?s ?p ?o. ?k ?l ?m};`,
+			nbs:  3,
+			nrws: (len(strings.Split(testTriples, "\n")) - 1) * (len(strings.Split(testTriples, "\n")) - 1),
 		},
 		{
-			q:       `select ?s, ?p from ?test where {?s ?p ?o. ?k ?l ?m};`,
-			wantErr: false,
-			nbs:     2,
-			nrws:    (len(strings.Split(testTriples, "\n")) - 1) * (len(strings.Split(testTriples, "\n")) - 1),
+			q:    `select ?s, ?p from ?test where {?s ?p ?o. ?k ?l ?m};`,
+			nbs:  2,
+			nrws: (len(strings.Split(testTriples, "\n")) - 1) * (len(strings.Split(testTriples, "\n")) - 1),
 		},
 		{
-			q:       `select ?s from ?test where {?s ?p ?o. ?k ?l ?m};`,
-			wantErr: false,
-			nbs:     1,
-			nrws:    (len(strings.Split(testTriples, "\n")) - 1) * (len(strings.Split(testTriples, "\n")) - 1),
+			q:    `select ?s from ?test where {?s ?p ?o. ?k ?l ?m};`,
+			nbs:  1,
+			nrws: (len(strings.Split(testTriples, "\n")) - 1) * (len(strings.Split(testTriples, "\n")) - 1),
 		},
 		{
-			q:       `select ?o from ?test where {/u<peter> "bought"@[,] ?o};`,
-			wantErr: false,
-			nbs:     1,
-			nrws:    4,
+			q:    `select ?o from ?test where {/u<peter> "bought"@[,] ?o};`,
+			nbs:  1,
+			nrws: 4,
 		},
 		{
-			q:       `select ?o from ?test where {/u<peter> "bought"@[,2015-01-01T00:00:00-08:00] ?o};`,
-			wantErr: false,
-			nbs:     1,
-			nrws:    0,
+			q:    `select ?o from ?test where {/u<peter> "bought"@[,2015-01-01T00:00:00-08:00] ?o};`,
+			nbs:  1,
+			nrws: 0,
 		},
 		{
-			q:       `select ?o from ?test where {/u<peter> "bought"@[2017-01-01T00:00:00-08:00,] ?o};`,
-			wantErr: false,
-			nbs:     1,
-			nrws:    0,
+			q:    `select ?o from ?test where {/u<peter> "bought"@[2017-01-01T00:00:00-08:00,] ?o};`,
+			nbs:  1,
+			nrws: 0,
 		},
 		{
-			q:       `select ?o from ?test where {/u<peter> "bought"@[2015-01-01T00:00:00-08:00,2017-01-01T00:00:00-08:00] ?o};`,
-			wantErr: false,
-			nbs:     1,
-			nrws:    4,
+			q:    `select ?o from ?test where {/u<peter> "bought"@[2015-01-01T00:00:00-08:00,2017-01-01T00:00:00-08:00] ?o};`,
+			nbs:  1,
+			nrws: 4,
 		},
 		{
-			q:       `select ?o from ?test where {/l<barcelona> "predicate"@[] "turned"@[,] as ?o};`,
-			wantErr: false,
-			nbs:     1,
-			nrws:    4,
+			q:    `select ?o from ?test where {/l<barcelona> "predicate"@[] "turned"@[,] as ?o};`,
+			nbs:  1,
+			nrws: 4,
 		},
 		{
-			q:       `select ?o from ?test where {/l<barcelona> "predicate"@[] "turned"@[,2015-01-01T00:00:00-08:00] as ?o};`,
-			wantErr: false,
-			nbs:     1,
-			nrws:    0,
+			q:    `select ?o from ?test where {/l<barcelona> "predicate"@[] "turned"@[,2015-01-01T00:00:00-08:00] as ?o};`,
+			nbs:  1,
+			nrws: 0,
 		},
 		{
-			q:       `select ?o from ?test where {/l<barcelona> "predicate"@[] "turned"@[2017-01-01T00:00:00-08:00,] as ?o};`,
-			wantErr: false,
-			nbs:     1,
-			nrws:    0,
+			q:    `select ?o from ?test where {/l<barcelona> "predicate"@[] "turned"@[2017-01-01T00:00:00-08:00,] as ?o};`,
+			nbs:  1,
+			nrws: 0,
 		},
 		{
-			q:       `select ?o from ?test where {/l<barcelona> "predicate"@[] "turned"@[2015-01-01T00:00:00-08:00,2017-01-01T00:00:00-08:00] as ?o};`,
-			wantErr: false,
-			nbs:     1,
-			nrws:    4,
+			q:    `select ?o from ?test where {/l<barcelona> "predicate"@[] "turned"@[2015-01-01T00:00:00-08:00,2017-01-01T00:00:00-08:00] as ?o};`,
+			nbs:  1,
+			nrws: 4,
 		},
 		{
-			q:       `select ?grandparent, count(?name) as ?grandchildren from ?test where {/u<joe> as ?grandparent "parent_of"@[] ?offspring . ?offspring "parent_of"@[] ?name} group by ?grandparent;`,
-			wantErr: false,
-			nbs:     2,
-			nrws:    1,
+			q:    `select ?grandparent, count(?name) as ?grandchildren from ?test where {/u<joe> as ?grandparent "parent_of"@[] ?offspring . ?offspring "parent_of"@[] ?name} group by ?grandparent;`,
+			nbs:  2,
+			nrws: 1,
 		},
 		{
-			q:       `select ?grandparent, count(distinct ?name) as ?grandchildren from ?test where {/u<joe> as ?grandparent "parent_of"@[] ?offspring . ?offspring "parent_of"@[] ?name} group by ?grandparent;`,
-			wantErr: false,
-			nbs:     2,
-			nrws:    1,
+			q:    `select ?grandparent, count(distinct ?name) as ?grandchildren from ?test where {/u<joe> as ?grandparent "parent_of"@[] ?offspring . ?offspring "parent_of"@[] ?name} group by ?grandparent;`,
+			nbs:  2,
+			nrws: 1,
 		},
 		{
-			q:       `select ?s, ?p, ?o, ?k, ?l, ?m from ?test where {?s ?p ?o. ?k ?l ?m} order by ?s, ?p, ?o, ?k, ?l, ?m;`,
-			wantErr: false,
-			nbs:     6,
-			nrws:    (len(strings.Split(testTriples, "\n")) - 1) * (len(strings.Split(testTriples, "\n")) - 1),
+			q:    `select ?s, ?p, ?o, ?k, ?l, ?m from ?test where {?s ?p ?o. ?k ?l ?m} order by ?s, ?p, ?o, ?k, ?l, ?m;`,
+			nbs:  6,
+			nrws: (len(strings.Split(testTriples, "\n")) - 1) * (len(strings.Split(testTriples, "\n")) - 1),
 		},
 		{
-			q:       `select ?s, ?p, ?o, ?k, ?l, ?m from ?test where {?s ?p ?o. ?k ?l ?m} order by ?s, ?p, ?o, ?k, ?l, ?m  having not(?s = ?s);`,
-			wantErr: false,
-			nbs:     6,
-			nrws:    0,
+			q:    `select ?s, ?p, ?o, ?k, ?l, ?m from ?test where {?s ?p ?o. ?k ?l ?m} order by ?s, ?p, ?o, ?k, ?l, ?m  having not(?s = ?s);`,
+			nbs:  6,
+			nrws: 0,
 		},
 		{
-			q:       `select ?o from ?test where {/l<barcelona> "predicate"@[] "turned"@[2015-01-01T00:00:00-08:00,2017-01-01T00:00:00-08:00] as ?o} LIMIT "2"^^type:int64;`,
-			wantErr: false,
-			nbs:     1,
-			nrws:    2,
+			q:    `select ?o from ?test where {/l<barcelona> "predicate"@[] "turned"@[2015-01-01T00:00:00-08:00,2017-01-01T00:00:00-08:00] as ?o} LIMIT "2"^^type:int64;`,
+			nbs:  1,
+			nrws: 2,
 		},
 		{
-			q:       `select ?o from ?test where {/u<peter> "bought"@[2015-01-01T00:00:00-08:00,2017-01-01T00:00:00-08:00] ?o} before 2014-01-01T00:00:00-08:00;`,
-			wantErr: false,
-			nbs:     1,
-			nrws:    0,
+			q:    `select ?o from ?test where {/u<peter> "bought"@[2015-01-01T00:00:00-08:00,2017-01-01T00:00:00-08:00] ?o} before 2014-01-01T00:00:00-08:00;`,
+			nbs:  1,
+			nrws: 0,
 		},
 		{
-			q:       `select ?o from ?test where {/u<peter> "bought"@[2015-01-01T00:00:00-08:00,2017-01-01T00:00:00-08:00] ?o} after 2017-01-01T00:00:00-08:00;`,
-			wantErr: false,
-			nbs:     1,
-			nrws:    0,
+			q:    `select ?o from ?test where {/u<peter> "bought"@[2015-01-01T00:00:00-08:00,2017-01-01T00:00:00-08:00] ?o} after 2017-01-01T00:00:00-08:00;`,
+			nbs:  1,
+			nrws: 0,
 		},
 		{
-			q:       `select ?o from ?test where {/u<peter> "bought"@[2015-01-01T00:00:00-08:00,2017-01-01T00:00:00-08:00] ?o} between 2014-01-01T00:00:00-08:00, 2017-01-01T00:00:00-08:00;`,
-			wantErr: false,
-			nbs:     1,
-			nrws:    4,
+			q:    `select ?o from ?test where {/u<peter> "bought"@[2015-01-01T00:00:00-08:00,2017-01-01T00:00:00-08:00] ?o} between 2014-01-01T00:00:00-08:00, 2017-01-01T00:00:00-08:00;`,
+			nbs:  1,
+			nrws: 4,
 		},
 		{
-			q:       `SELECT ?grandparent, COUNT(?grandparent) AS ?number_of_grandchildren FROM ?test WHERE{ ?gp ID ?grandparent "parent_of"@[] ?c . ?c "parent_of"@[] ?gc ID ?gc } GROUP BY ?grandparent;`,
-			wantErr: false,
-			nbs:     2,
-			nrws:    1,
+			q:    `SELECT ?grandparent, COUNT(?grandparent) AS ?number_of_grandchildren FROM ?test WHERE{ ?gp ID ?grandparent "parent_of"@[] ?c . ?c "parent_of"@[] ?gc ID ?gc } GROUP BY ?grandparent;`,
+			nbs:  2,
+			nrws: 1,
 		},
 		{ // Issue 40 (https://github.com/google/badwolf/issues/40)
-			q:       `SELECT ?item, ?t FROM ?test WHERE {?item "in"@[?t] /room<Bedroom>};`,
-			wantErr: false,
-			nbs:     2,
-			nrws:    1,
+			q:    `SELECT ?item, ?t FROM ?test WHERE {?item "in"@[?t] /room<Bedroom>};`,
+			nbs:  2,
+			nrws: 1,
 		},
 		{
-			q:       `SHOW GRAPHS;`,
-			wantErr: false,
-			nbs:     1,
-			nrws:    1,
+			q:    `SHOW GRAPHS;`,
+			nbs:  1,
+			nrws: 1,
 		},
 		{
-			q:       `select ?s, ?o from ?test where {?s "tag"@[] ?o} having ?o = "abc"^^type:text;`,
-			wantErr: false,
-			nbs:     2,
-			nrws:    1,
+			q:    `select ?s, ?o from ?test where {?s "tag"@[] ?o} having ?o = "abc"^^type:text;`,
+			nbs:  2,
+			nrws: 1,
 		},
 		{
-			q:       `select ?s, ?height from ?test where {?s "height_cm"@[] ?height} having ?height > "0"^^type:int64;`,
-			wantErr: false,
-			nbs:     2,
-			nrws:    4,
+			q:    `select ?s, ?height from ?test where {?s "height_cm"@[] ?height} having ?height > "0"^^type:int64;`,
+			nbs:  2,
+			nrws: 4,
 		},
 		{
-			q:       `select ?s, ?height from ?test where {?s "height_cm"@[] ?height} having ?height > "160"^^type:int64;`,
-			wantErr: false,
-			nbs:     2,
-			nrws:    3,
+			q:    `select ?s, ?height from ?test where {?s "height_cm"@[] ?height} having ?height > "160"^^type:int64;`,
+			nbs:  2,
+			nrws: 3,
 		},
 		{
-			q:       `select ?s, ?height from ?test where {?s "height_cm"@[] ?height} having ?height = "151"^^type:int64;`,
-			wantErr: false,
-			nbs:     2,
-			nrws:    1,
+			q:    `select ?s, ?height from ?test where {?s "height_cm"@[] ?height} having ?height = "151"^^type:int64;`,
+			nbs:  2,
+			nrws: 1,
 		},
 		{
-			q:       `select ?s, ?height from ?test where {?s "height_cm"@[] ?height} having ?s > /u<zzzzz>;`,
-			wantErr: false,
-			nbs:     2,
-			nrws:    0,
+			q:    `select ?s, ?height from ?test where {?s "height_cm"@[] ?height} having ?s > /u<zzzzz>;`,
+			nbs:  2,
+			nrws: 0,
 		},
 		{
-			q:       `select ?s, ?height from ?test where {?s "height_cm"@[] ?height} having ?s > /u<alice>;`,
-			wantErr: false,
-			nbs:     2,
-			nrws:    3,
+			q:    `select ?s, ?height from ?test where {?s "height_cm"@[] ?height} having ?s > /u<alice>;`,
+			nbs:  2,
+			nrws: 3,
 		},
 		{
-			q:       `select ?s, ?height from ?test where {?s "height_cm"@[] ?height} having ?s > /u<bob>;`,
-			wantErr: false,
-			nbs:     2,
-			nrws:    2,
+			q:    `select ?s, ?height from ?test where {?s "height_cm"@[] ?height} having ?s > /u<bob>;`,
+			nbs:  2,
+			nrws: 2,
 		},
 		/*
 			/c<model s> "is_a"@[] /t<car>
@@ -560,10 +513,9 @@ func TestPlannerQuery(t *testing.T) {
 		*/
 		// OPTIONAL clauses.
 		{
-			q:       `SELECT ?car FROM ?test WHERE { ?car "is_a"@[] /t<car> };`,
-			wantErr: false,
-			nbs:     1,
-			nrws:    4,
+			q:    `SELECT ?car FROM ?test WHERE { ?car "is_a"@[] /t<car> };`,
+			nbs:  1,
+			nrws: 4,
 		},
 		{
 			q: `SELECT ?car
@@ -571,9 +523,8 @@ func TestPlannerQuery(t *testing.T) {
 			    WHERE {
 				   /c<model s> as ?car "is_a"@[] /t<car>
 				};`,
-			wantErr: false,
-			nbs:     1,
-			nrws:    1,
+			nbs:  1,
+			nrws: 1,
 		},
 		{
 			q: `SELECT ?car
@@ -582,9 +533,8 @@ func TestPlannerQuery(t *testing.T) {
 				   ?car "is_a"@[] /t<car> .
 				   /c<model z> as ?car "is_a"@[] /t<car>
 				};`,
-			wantErr: false,
-			nbs:     1,
-			nrws:    0,
+			nbs:  1,
+			nrws: 0,
 		},
 		{
 			q: `SELECT ?car
@@ -593,9 +543,8 @@ func TestPlannerQuery(t *testing.T) {
 					?car "is_a"@[] /t<car> .
 					OPTIONAL { /c<model O> "is_a"@[] /t<car> }
 				};`,
-			wantErr: false,
-			nbs:     1,
-			nrws:    4,
+			nbs:  1,
+			nrws: 4,
 		},
 		{
 			q: `SELECT ?car
@@ -604,9 +553,8 @@ func TestPlannerQuery(t *testing.T) {
 					?car "is_a"@[] /t<car> .
 					OPTIONAL { ?car "is_a"@[] /t<car> }
 				};`,
-			wantErr: false,
-			nbs:     1,
-			nrws:    4,
+			nbs:  1,
+			nrws: 4,
 		},
 		{
 			q: `SELECT ?cars, ?type
@@ -615,9 +563,8 @@ func TestPlannerQuery(t *testing.T) {
 					?cars "is_a"@[] /t<car> .
 					OPTIONAL { ?cars "is_a"@[] ?type }
 				};`,
-			wantErr: false,
-			nbs:     2,
-			nrws:    4,
+			nbs:  2,
+			nrws: 4,
 		},
 		{
 			q: `SELECT ?p, ?o
@@ -626,9 +573,8 @@ func TestPlannerQuery(t *testing.T) {
 					/c<mini> ?p ?o
 				}
 				HAVING ?o > "37"^^type:int64;`,
-			wantErr: false,
-			nbs:     2,
-			nrws:    0,
+			nbs:  2,
+			nrws: 0,
 		},
 		{
 			q: `SELECT ?o
@@ -637,9 +583,8 @@ func TestPlannerQuery(t *testing.T) {
 					/u<alice> "height_cm"@[] ?o
 				}
 				HAVING ?o = /u<peter>;`,
-			wantErr: false,
-			nbs:     1,
-			nrws:    0,
+			nbs:  1,
+			nrws: 0,
 		},
 		{
 			q: `SELECT ?s_id, ?height
@@ -648,31 +593,8 @@ func TestPlannerQuery(t *testing.T) {
 					?s ID ?s_id "height_cm"@[] ?height
 				}
 				HAVING ?s_id = "alice"^^type:text;`,
-			wantErr: false,
-			nbs:     2,
-			nrws:    1,
-		},
-		{
-			q: `SELECT ?s_id, ?height
-				FROM ?test
-				WHERE {
-					?s ID ?s_id "height_cm"@[] ?height
-				}
-				HAVING ?s_id > "37"^^type:int64;`,
-			wantErr: true,
-			nbs:     2,
-			nrws:    1,
-		},
-		{
-			q: `SELECT ?s_id, ?height
-				FROM ?test
-				WHERE {
-					?s ID ?s_id "height_cm"@[] ?height
-				}
-				HAVING ?s_id = /u<alice>;`,
-			wantErr: true,
-			nbs:     2,
-			nrws:    0,
+			nbs:  2,
+			nrws: 1,
 		},
 		{
 			q: `SELECT ?p_id, ?o
@@ -681,9 +603,8 @@ func TestPlannerQuery(t *testing.T) {
 					/u<peter> ?p ID ?p_id ?o
 				}
 				HAVING ?p_id < "parent_of"^^type:text;`,
-			wantErr: false,
-			nbs:     2,
-			nrws:    4,
+			nbs:  2,
+			nrws: 4,
 		},
 		{
 			q: `SELECT ?s, ?s_type
@@ -692,9 +613,8 @@ func TestPlannerQuery(t *testing.T) {
 					?s TYPE ?s_type ?p ?o
 				}
 				HAVING ?s_type = "/c"^^type:text;`,
-			wantErr: false,
-			nbs:     2,
-			nrws:    4,
+			nbs:  2,
+			nrws: 4,
 		},
 		{
 			q: `SELECT ?s, ?s_type
@@ -703,9 +623,8 @@ func TestPlannerQuery(t *testing.T) {
 					?s TYPE ?s_type ?p ?o
 				}
 				HAVING ?s_type < "/l"^^type:text;`,
-			wantErr: false,
-			nbs:     2,
-			nrws:    7,
+			nbs:  2,
+			nrws: 7,
 		},
 		{
 			q: `SELECT ?p, ?p_id, ?o
@@ -715,9 +634,8 @@ func TestPlannerQuery(t *testing.T) {
 				}
 				HAVING ?p_id = "bought"^^type:text
 				AFTER 2016-03-01T00:00:00-08:00;`,
-			wantErr: false,
-			nbs:     3,
-			nrws:    2,
+			nbs:  3,
+			nrws: 2,
 		},
 		{
 			q: `SELECT ?p, ?p_id, ?o
@@ -727,9 +645,8 @@ func TestPlannerQuery(t *testing.T) {
 				}
 				HAVING ?p_id < "parent_of"^^type:text
 				BEFORE 2016-03-01T00:00:00-08:00;`,
-			wantErr: false,
-			nbs:     3,
-			nrws:    3,
+			nbs:  3,
+			nrws: 3,
 		},
 		{
 			q: `SELECT ?p, ?p_id, ?o
@@ -739,9 +656,8 @@ func TestPlannerQuery(t *testing.T) {
 				}
 				HAVING ?p_id = "bought"^^type:text
 				BETWEEN 2016-02-01T00:00:00-08:00, 2016-03-01T00:00:00-08:00;`,
-			wantErr: false,
-			nbs:     3,
-			nrws:    2,
+			nbs:  3,
+			nrws: 2,
 		},
 		{
 			q: `SELECT ?p, ?p_id, ?o
@@ -751,16 +667,15 @@ func TestPlannerQuery(t *testing.T) {
 				}
 				HAVING ?p_id < "work_with"^^type:text
 				BEFORE 2016-02-01T00:00:00-08:00;`,
-			wantErr: false,
-			nbs:     3,
-			nrws:    4,
+			nbs:  3,
+			nrws: 4,
 		},
 	}
 
 	s, ctx := memory.NewStore(), context.Background()
 	populateStoreWithTriples(ctx, s, "?test", testTriples, t)
 	for _, entry := range testTable {
-		// Test setup:
+		// Setup for test:
 		p, err := grammar.NewParser(grammar.SemanticBQL())
 		if err != nil {
 			t.Fatalf("grammar.NewParser should have produced a valid BQL parser but got error: %v", err)
@@ -776,16 +691,8 @@ func TestPlannerQuery(t *testing.T) {
 
 		// Actual test:
 		tbl, err := plnr.Execute(ctx)
-		if !entry.wantErr && err != nil {
+		if err != nil {
 			t.Errorf("planner.Execute(%s)\n= _, %v; want nil error", entry.q, err)
-			continue
-		}
-		if entry.wantErr && err == nil {
-			t.Errorf("planner.Execute(%s)\n= _, nil; want non-nil error", entry.q)
-			continue
-		}
-		if entry.wantErr {
-			// an error was expected and it was indeed caught.
 			continue
 		}
 		if got, want := len(tbl.Bindings()), entry.nbs; got != want {
@@ -793,6 +700,53 @@ func TestPlannerQuery(t *testing.T) {
 		}
 		if got, want := len(tbl.Rows()), entry.nrws; got != want {
 			t.Errorf("planner.Execute(%s)\n= a Table with %d rows; want %d\nTable:\n%v\n", entry.q, got, want, tbl)
+		}
+	}
+}
+
+func TestPlannerQueryError(t *testing.T) {
+	testTable := []struct {
+		q string
+	}{
+		{
+			q: `SELECT ?s_id, ?height
+				FROM ?test
+				WHERE {
+					?s ID ?s_id "height_cm"@[] ?height
+				}
+				HAVING ?s_id > "37"^^type:int64;`,
+		},
+		{
+			q: `SELECT ?s_id, ?height
+				FROM ?test
+				WHERE {
+					?s ID ?s_id "height_cm"@[] ?height
+				}
+				HAVING ?s_id = /u<alice>;`,
+		},
+	}
+
+	s, ctx := memory.NewStore(), context.Background()
+	populateStoreWithTriples(ctx, s, "?test", testTriples, t)
+	for _, entry := range testTable {
+		// Setup for test:
+		p, err := grammar.NewParser(grammar.SemanticBQL())
+		if err != nil {
+			t.Fatalf("grammar.NewParser should have produced a valid BQL parser but got error: %v", err)
+		}
+		st := &semantic.Statement{}
+		if err := p.Parse(grammar.NewLLk(entry.q, 1), st); err != nil {
+			t.Fatalf("parser.Parse failed for query \"%s\"\nwith error: %v", entry.q, err)
+		}
+		plnr, err := New(ctx, s, st, 0, 10, nil)
+		if err != nil {
+			t.Fatalf("planner.New failed to create a valid query plan with error: %v", err)
+		}
+
+		// Actual test:
+		_, err = plnr.Execute(ctx)
+		if err == nil {
+			t.Errorf("planner.Execute(%s)\n= _, nil; want non-nil error", entry.q)
 		}
 	}
 }

--- a/bql/planner/planner_test.go
+++ b/bql/planner/planner_test.go
@@ -272,239 +272,239 @@ func populateStoreWithTriples(ctx context.Context, s storage.Store, gn string, t
 
 func TestPlannerQuery(t *testing.T) {
 	testTable := []struct {
-		q    string
-		nbs  int
-		nrws int
+		q         string
+		nBindings int
+		nRows     int
 	}{
 		{
-			q:    `select ?s, ?p, ?o from ?test where {?s ?p ?o};`,
-			nbs:  3,
-			nrws: len(strings.Split(testTriples, "\n")) - 1,
+			q:         `select ?s, ?p, ?o from ?test where {?s ?p ?o};`,
+			nBindings: 3,
+			nRows:     len(strings.Split(testTriples, "\n")) - 1,
 		},
 		{
-			q:    `select ?s as ?s1, ?p as ?p1, ?o as ?o1 from ?test where {?s ?p ?o};`,
-			nbs:  3,
-			nrws: len(strings.Split(testTriples, "\n")) - 1,
+			q:         `select ?s as ?s1, ?p as ?p1, ?o as ?o1 from ?test where {?s ?p ?o};`,
+			nBindings: 3,
+			nRows:     len(strings.Split(testTriples, "\n")) - 1,
 		},
 		{
-			q:    `select ?p, ?o from ?test where {/u<joe> ?p ?o};`,
-			nbs:  2,
-			nrws: 2,
+			q:         `select ?p, ?o from ?test where {/u<joe> ?p ?o};`,
+			nBindings: 2,
+			nRows:     2,
 		},
 		{
-			q:    `select ?p as ?p1, ?o as ?o1 from ?test where {/u<joe> ?p ?o};`,
-			nbs:  2,
-			nrws: 2,
+			q:         `select ?p as ?p1, ?o as ?o1 from ?test where {/u<joe> ?p ?o};`,
+			nBindings: 2,
+			nRows:     2,
 		},
 		{
-			q:    `select ?s, ?p from ?test where {?s ?p /t<car>};`,
-			nbs:  2,
-			nrws: 4,
+			q:         `select ?s, ?p from ?test where {?s ?p /t<car>};`,
+			nBindings: 2,
+			nRows:     4,
 		},
 		{
-			q:    `select ?s, ?o from ?test where {?s "parent_of"@[] ?o};`,
-			nbs:  2,
-			nrws: 4,
+			q:         `select ?s, ?o from ?test where {?s "parent_of"@[] ?o};`,
+			nBindings: 2,
+			nRows:     4,
 		},
 		{
-			q:    `select ?s, ?p, ?o from ?test where {/u<joe> as ?s "parent_of"@[] as ?p /u<mary> as ?o};`,
-			nbs:  3,
-			nrws: 1,
+			q:         `select ?s, ?p, ?o from ?test where {/u<joe> as ?s "parent_of"@[] as ?p /u<mary> as ?o};`,
+			nBindings: 3,
+			nRows:     1,
 		},
 		{
-			q:    `select ?s, ?p, ?o from ?test where {/u<unknown> as ?s "parent_of"@[] as ?p /u<mary> as ?o};`,
-			nbs:  3,
-			nrws: 0,
+			q:         `select ?s, ?p, ?o from ?test where {/u<unknown> as ?s "parent_of"@[] as ?p /u<mary> as ?o};`,
+			nBindings: 3,
+			nRows:     0,
 		},
 		{
-			q:    `select ?o from ?test where {/u<joe> "parent_of"@[] ?o};`,
-			nbs:  1,
-			nrws: 2,
+			q:         `select ?o from ?test where {/u<joe> "parent_of"@[] ?o};`,
+			nBindings: 1,
+			nRows:     2,
 		},
 		{
-			q:    `select ?p from ?test where {/u<joe> ?p /u<mary>};`,
-			nbs:  1,
-			nrws: 1,
+			q:         `select ?p from ?test where {/u<joe> ?p /u<mary>};`,
+			nBindings: 1,
+			nRows:     1,
 		},
 		{
-			q:    `select ?s from ?test where {?s "is_a"@[] /t<car>};`,
-			nbs:  1,
-			nrws: 4,
+			q:         `select ?s from ?test where {?s "is_a"@[] /t<car>};`,
+			nBindings: 1,
+			nRows:     4,
 		},
 		{
-			q:    `select ?s as ?s1 from ?test where {?s "is_a"@[] /t<car>};`,
-			nbs:  1,
-			nrws: 4,
+			q:         `select ?s as ?s1 from ?test where {?s "is_a"@[] /t<car>};`,
+			nBindings: 1,
+			nRows:     4,
 		},
 		{
-			q:    `select ?o from ?test where {/u<joe> "parent_of"@[] ?o. ?o "parent_of"@[] /u<john>};`,
-			nbs:  1,
-			nrws: 1,
+			q:         `select ?o from ?test where {/u<joe> "parent_of"@[] ?o. ?o "parent_of"@[] /u<john>};`,
+			nBindings: 1,
+			nRows:     1,
 		},
 		{
-			q:    `select ?s, ?o from ?test where {/u<joe> "parent_of"@[] ?o. ?o "parent_of"@[] ?s};`,
-			nbs:  2,
-			nrws: 2,
+			q:         `select ?s, ?o from ?test where {/u<joe> "parent_of"@[] ?o. ?o "parent_of"@[] ?s};`,
+			nBindings: 2,
+			nRows:     2,
 		},
 		{
-			q:    `select ?s, ?p, ?o, ?k, ?l, ?m from ?test where {?s ?p ?o. ?k ?l ?m};`,
-			nbs:  6,
-			nrws: (len(strings.Split(testTriples, "\n")) - 1) * (len(strings.Split(testTriples, "\n")) - 1),
+			q:         `select ?s, ?p, ?o, ?k, ?l, ?m from ?test where {?s ?p ?o. ?k ?l ?m};`,
+			nBindings: 6,
+			nRows:     (len(strings.Split(testTriples, "\n")) - 1) * (len(strings.Split(testTriples, "\n")) - 1),
 		},
 		{
-			q:    `select ?s, ?p, ?o, ?k, ?l from ?test where {?s ?p ?o. ?k ?l ?m};`,
-			nbs:  5,
-			nrws: (len(strings.Split(testTriples, "\n")) - 1) * (len(strings.Split(testTriples, "\n")) - 1),
+			q:         `select ?s, ?p, ?o, ?k, ?l from ?test where {?s ?p ?o. ?k ?l ?m};`,
+			nBindings: 5,
+			nRows:     (len(strings.Split(testTriples, "\n")) - 1) * (len(strings.Split(testTriples, "\n")) - 1),
 		},
 		{
-			q:    `select ?s, ?p, ?o, ?k from ?test where {?s ?p ?o. ?k ?l ?m};`,
-			nbs:  4,
-			nrws: (len(strings.Split(testTriples, "\n")) - 1) * (len(strings.Split(testTriples, "\n")) - 1),
+			q:         `select ?s, ?p, ?o, ?k from ?test where {?s ?p ?o. ?k ?l ?m};`,
+			nBindings: 4,
+			nRows:     (len(strings.Split(testTriples, "\n")) - 1) * (len(strings.Split(testTriples, "\n")) - 1),
 		},
 		{
-			q:    `select ?s, ?p, ?o from ?test where {?s ?p ?o. ?k ?l ?m};`,
-			nbs:  3,
-			nrws: (len(strings.Split(testTriples, "\n")) - 1) * (len(strings.Split(testTriples, "\n")) - 1),
+			q:         `select ?s, ?p, ?o from ?test where {?s ?p ?o. ?k ?l ?m};`,
+			nBindings: 3,
+			nRows:     (len(strings.Split(testTriples, "\n")) - 1) * (len(strings.Split(testTriples, "\n")) - 1),
 		},
 		{
-			q:    `select ?s, ?p from ?test where {?s ?p ?o. ?k ?l ?m};`,
-			nbs:  2,
-			nrws: (len(strings.Split(testTriples, "\n")) - 1) * (len(strings.Split(testTriples, "\n")) - 1),
+			q:         `select ?s, ?p from ?test where {?s ?p ?o. ?k ?l ?m};`,
+			nBindings: 2,
+			nRows:     (len(strings.Split(testTriples, "\n")) - 1) * (len(strings.Split(testTriples, "\n")) - 1),
 		},
 		{
-			q:    `select ?s from ?test where {?s ?p ?o. ?k ?l ?m};`,
-			nbs:  1,
-			nrws: (len(strings.Split(testTriples, "\n")) - 1) * (len(strings.Split(testTriples, "\n")) - 1),
+			q:         `select ?s from ?test where {?s ?p ?o. ?k ?l ?m};`,
+			nBindings: 1,
+			nRows:     (len(strings.Split(testTriples, "\n")) - 1) * (len(strings.Split(testTriples, "\n")) - 1),
 		},
 		{
-			q:    `select ?o from ?test where {/u<peter> "bought"@[,] ?o};`,
-			nbs:  1,
-			nrws: 4,
+			q:         `select ?o from ?test where {/u<peter> "bought"@[,] ?o};`,
+			nBindings: 1,
+			nRows:     4,
 		},
 		{
-			q:    `select ?o from ?test where {/u<peter> "bought"@[,2015-01-01T00:00:00-08:00] ?o};`,
-			nbs:  1,
-			nrws: 0,
+			q:         `select ?o from ?test where {/u<peter> "bought"@[,2015-01-01T00:00:00-08:00] ?o};`,
+			nBindings: 1,
+			nRows:     0,
 		},
 		{
-			q:    `select ?o from ?test where {/u<peter> "bought"@[2017-01-01T00:00:00-08:00,] ?o};`,
-			nbs:  1,
-			nrws: 0,
+			q:         `select ?o from ?test where {/u<peter> "bought"@[2017-01-01T00:00:00-08:00,] ?o};`,
+			nBindings: 1,
+			nRows:     0,
 		},
 		{
-			q:    `select ?o from ?test where {/u<peter> "bought"@[2015-01-01T00:00:00-08:00,2017-01-01T00:00:00-08:00] ?o};`,
-			nbs:  1,
-			nrws: 4,
+			q:         `select ?o from ?test where {/u<peter> "bought"@[2015-01-01T00:00:00-08:00,2017-01-01T00:00:00-08:00] ?o};`,
+			nBindings: 1,
+			nRows:     4,
 		},
 		{
-			q:    `select ?o from ?test where {/l<barcelona> "predicate"@[] "turned"@[,] as ?o};`,
-			nbs:  1,
-			nrws: 4,
+			q:         `select ?o from ?test where {/l<barcelona> "predicate"@[] "turned"@[,] as ?o};`,
+			nBindings: 1,
+			nRows:     4,
 		},
 		{
-			q:    `select ?o from ?test where {/l<barcelona> "predicate"@[] "turned"@[,2015-01-01T00:00:00-08:00] as ?o};`,
-			nbs:  1,
-			nrws: 0,
+			q:         `select ?o from ?test where {/l<barcelona> "predicate"@[] "turned"@[,2015-01-01T00:00:00-08:00] as ?o};`,
+			nBindings: 1,
+			nRows:     0,
 		},
 		{
-			q:    `select ?o from ?test where {/l<barcelona> "predicate"@[] "turned"@[2017-01-01T00:00:00-08:00,] as ?o};`,
-			nbs:  1,
-			nrws: 0,
+			q:         `select ?o from ?test where {/l<barcelona> "predicate"@[] "turned"@[2017-01-01T00:00:00-08:00,] as ?o};`,
+			nBindings: 1,
+			nRows:     0,
 		},
 		{
-			q:    `select ?o from ?test where {/l<barcelona> "predicate"@[] "turned"@[2015-01-01T00:00:00-08:00,2017-01-01T00:00:00-08:00] as ?o};`,
-			nbs:  1,
-			nrws: 4,
+			q:         `select ?o from ?test where {/l<barcelona> "predicate"@[] "turned"@[2015-01-01T00:00:00-08:00,2017-01-01T00:00:00-08:00] as ?o};`,
+			nBindings: 1,
+			nRows:     4,
 		},
 		{
-			q:    `select ?grandparent, count(?name) as ?grandchildren from ?test where {/u<joe> as ?grandparent "parent_of"@[] ?offspring . ?offspring "parent_of"@[] ?name} group by ?grandparent;`,
-			nbs:  2,
-			nrws: 1,
+			q:         `select ?grandparent, count(?name) as ?grandchildren from ?test where {/u<joe> as ?grandparent "parent_of"@[] ?offspring . ?offspring "parent_of"@[] ?name} group by ?grandparent;`,
+			nBindings: 2,
+			nRows:     1,
 		},
 		{
-			q:    `select ?grandparent, count(distinct ?name) as ?grandchildren from ?test where {/u<joe> as ?grandparent "parent_of"@[] ?offspring . ?offspring "parent_of"@[] ?name} group by ?grandparent;`,
-			nbs:  2,
-			nrws: 1,
+			q:         `select ?grandparent, count(distinct ?name) as ?grandchildren from ?test where {/u<joe> as ?grandparent "parent_of"@[] ?offspring . ?offspring "parent_of"@[] ?name} group by ?grandparent;`,
+			nBindings: 2,
+			nRows:     1,
 		},
 		{
-			q:    `select ?s, ?p, ?o, ?k, ?l, ?m from ?test where {?s ?p ?o. ?k ?l ?m} order by ?s, ?p, ?o, ?k, ?l, ?m;`,
-			nbs:  6,
-			nrws: (len(strings.Split(testTriples, "\n")) - 1) * (len(strings.Split(testTriples, "\n")) - 1),
+			q:         `select ?s, ?p, ?o, ?k, ?l, ?m from ?test where {?s ?p ?o. ?k ?l ?m} order by ?s, ?p, ?o, ?k, ?l, ?m;`,
+			nBindings: 6,
+			nRows:     (len(strings.Split(testTriples, "\n")) - 1) * (len(strings.Split(testTriples, "\n")) - 1),
 		},
 		{
-			q:    `select ?s, ?p, ?o, ?k, ?l, ?m from ?test where {?s ?p ?o. ?k ?l ?m} order by ?s, ?p, ?o, ?k, ?l, ?m  having not(?s = ?s);`,
-			nbs:  6,
-			nrws: 0,
+			q:         `select ?s, ?p, ?o, ?k, ?l, ?m from ?test where {?s ?p ?o. ?k ?l ?m} order by ?s, ?p, ?o, ?k, ?l, ?m  having not(?s = ?s);`,
+			nBindings: 6,
+			nRows:     0,
 		},
 		{
-			q:    `select ?o from ?test where {/l<barcelona> "predicate"@[] "turned"@[2015-01-01T00:00:00-08:00,2017-01-01T00:00:00-08:00] as ?o} LIMIT "2"^^type:int64;`,
-			nbs:  1,
-			nrws: 2,
+			q:         `select ?o from ?test where {/l<barcelona> "predicate"@[] "turned"@[2015-01-01T00:00:00-08:00,2017-01-01T00:00:00-08:00] as ?o} LIMIT "2"^^type:int64;`,
+			nBindings: 1,
+			nRows:     2,
 		},
 		{
-			q:    `select ?o from ?test where {/u<peter> "bought"@[2015-01-01T00:00:00-08:00,2017-01-01T00:00:00-08:00] ?o} before 2014-01-01T00:00:00-08:00;`,
-			nbs:  1,
-			nrws: 0,
+			q:         `select ?o from ?test where {/u<peter> "bought"@[2015-01-01T00:00:00-08:00,2017-01-01T00:00:00-08:00] ?o} before 2014-01-01T00:00:00-08:00;`,
+			nBindings: 1,
+			nRows:     0,
 		},
 		{
-			q:    `select ?o from ?test where {/u<peter> "bought"@[2015-01-01T00:00:00-08:00,2017-01-01T00:00:00-08:00] ?o} after 2017-01-01T00:00:00-08:00;`,
-			nbs:  1,
-			nrws: 0,
+			q:         `select ?o from ?test where {/u<peter> "bought"@[2015-01-01T00:00:00-08:00,2017-01-01T00:00:00-08:00] ?o} after 2017-01-01T00:00:00-08:00;`,
+			nBindings: 1,
+			nRows:     0,
 		},
 		{
-			q:    `select ?o from ?test where {/u<peter> "bought"@[2015-01-01T00:00:00-08:00,2017-01-01T00:00:00-08:00] ?o} between 2014-01-01T00:00:00-08:00, 2017-01-01T00:00:00-08:00;`,
-			nbs:  1,
-			nrws: 4,
+			q:         `select ?o from ?test where {/u<peter> "bought"@[2015-01-01T00:00:00-08:00,2017-01-01T00:00:00-08:00] ?o} between 2014-01-01T00:00:00-08:00, 2017-01-01T00:00:00-08:00;`,
+			nBindings: 1,
+			nRows:     4,
 		},
 		{
-			q:    `SELECT ?grandparent, COUNT(?grandparent) AS ?number_of_grandchildren FROM ?test WHERE{ ?gp ID ?grandparent "parent_of"@[] ?c . ?c "parent_of"@[] ?gc ID ?gc } GROUP BY ?grandparent;`,
-			nbs:  2,
-			nrws: 1,
+			q:         `SELECT ?grandparent, COUNT(?grandparent) AS ?number_of_grandchildren FROM ?test WHERE{ ?gp ID ?grandparent "parent_of"@[] ?c . ?c "parent_of"@[] ?gc ID ?gc } GROUP BY ?grandparent;`,
+			nBindings: 2,
+			nRows:     1,
 		},
 		{ // Issue 40 (https://github.com/google/badwolf/issues/40)
-			q:    `SELECT ?item, ?t FROM ?test WHERE {?item "in"@[?t] /room<Bedroom>};`,
-			nbs:  2,
-			nrws: 1,
+			q:         `SELECT ?item, ?t FROM ?test WHERE {?item "in"@[?t] /room<Bedroom>};`,
+			nBindings: 2,
+			nRows:     1,
 		},
 		{
-			q:    `SHOW GRAPHS;`,
-			nbs:  1,
-			nrws: 1,
+			q:         `SHOW GRAPHS;`,
+			nBindings: 1,
+			nRows:     1,
 		},
 		{
-			q:    `select ?s, ?o from ?test where {?s "tag"@[] ?o} having ?o = "abc"^^type:text;`,
-			nbs:  2,
-			nrws: 1,
+			q:         `select ?s, ?o from ?test where {?s "tag"@[] ?o} having ?o = "abc"^^type:text;`,
+			nBindings: 2,
+			nRows:     1,
 		},
 		{
-			q:    `select ?s, ?height from ?test where {?s "height_cm"@[] ?height} having ?height > "0"^^type:int64;`,
-			nbs:  2,
-			nrws: 4,
+			q:         `select ?s, ?height from ?test where {?s "height_cm"@[] ?height} having ?height > "0"^^type:int64;`,
+			nBindings: 2,
+			nRows:     4,
 		},
 		{
-			q:    `select ?s, ?height from ?test where {?s "height_cm"@[] ?height} having ?height > "160"^^type:int64;`,
-			nbs:  2,
-			nrws: 3,
+			q:         `select ?s, ?height from ?test where {?s "height_cm"@[] ?height} having ?height > "160"^^type:int64;`,
+			nBindings: 2,
+			nRows:     3,
 		},
 		{
-			q:    `select ?s, ?height from ?test where {?s "height_cm"@[] ?height} having ?height = "151"^^type:int64;`,
-			nbs:  2,
-			nrws: 1,
+			q:         `select ?s, ?height from ?test where {?s "height_cm"@[] ?height} having ?height = "151"^^type:int64;`,
+			nBindings: 2,
+			nRows:     1,
 		},
 		{
-			q:    `select ?s, ?height from ?test where {?s "height_cm"@[] ?height} having ?s > /u<zzzzz>;`,
-			nbs:  2,
-			nrws: 0,
+			q:         `select ?s, ?height from ?test where {?s "height_cm"@[] ?height} having ?s > /u<zzzzz>;`,
+			nBindings: 2,
+			nRows:     0,
 		},
 		{
-			q:    `select ?s, ?height from ?test where {?s "height_cm"@[] ?height} having ?s > /u<alice>;`,
-			nbs:  2,
-			nrws: 3,
+			q:         `select ?s, ?height from ?test where {?s "height_cm"@[] ?height} having ?s > /u<alice>;`,
+			nBindings: 2,
+			nRows:     3,
 		},
 		{
-			q:    `select ?s, ?height from ?test where {?s "height_cm"@[] ?height} having ?s > /u<bob>;`,
-			nbs:  2,
-			nrws: 2,
+			q:         `select ?s, ?height from ?test where {?s "height_cm"@[] ?height} having ?s > /u<bob>;`,
+			nBindings: 2,
+			nRows:     2,
 		},
 		/*
 			/c<model s> "is_a"@[] /t<car>
@@ -513,9 +513,9 @@ func TestPlannerQuery(t *testing.T) {
 		*/
 		// OPTIONAL clauses.
 		{
-			q:    `SELECT ?car FROM ?test WHERE { ?car "is_a"@[] /t<car> };`,
-			nbs:  1,
-			nrws: 4,
+			q:         `SELECT ?car FROM ?test WHERE { ?car "is_a"@[] /t<car> };`,
+			nBindings: 1,
+			nRows:     4,
 		},
 		{
 			q: `SELECT ?car
@@ -523,8 +523,8 @@ func TestPlannerQuery(t *testing.T) {
 			    WHERE {
 				   /c<model s> as ?car "is_a"@[] /t<car>
 				};`,
-			nbs:  1,
-			nrws: 1,
+			nBindings: 1,
+			nRows:     1,
 		},
 		{
 			q: `SELECT ?car
@@ -533,8 +533,8 @@ func TestPlannerQuery(t *testing.T) {
 				   ?car "is_a"@[] /t<car> .
 				   /c<model z> as ?car "is_a"@[] /t<car>
 				};`,
-			nbs:  1,
-			nrws: 0,
+			nBindings: 1,
+			nRows:     0,
 		},
 		{
 			q: `SELECT ?car
@@ -543,8 +543,8 @@ func TestPlannerQuery(t *testing.T) {
 					?car "is_a"@[] /t<car> .
 					OPTIONAL { /c<model O> "is_a"@[] /t<car> }
 				};`,
-			nbs:  1,
-			nrws: 4,
+			nBindings: 1,
+			nRows:     4,
 		},
 		{
 			q: `SELECT ?car
@@ -553,8 +553,8 @@ func TestPlannerQuery(t *testing.T) {
 					?car "is_a"@[] /t<car> .
 					OPTIONAL { ?car "is_a"@[] /t<car> }
 				};`,
-			nbs:  1,
-			nrws: 4,
+			nBindings: 1,
+			nRows:     4,
 		},
 		{
 			q: `SELECT ?cars, ?type
@@ -563,8 +563,8 @@ func TestPlannerQuery(t *testing.T) {
 					?cars "is_a"@[] /t<car> .
 					OPTIONAL { ?cars "is_a"@[] ?type }
 				};`,
-			nbs:  2,
-			nrws: 4,
+			nBindings: 2,
+			nRows:     4,
 		},
 		{
 			q: `SELECT ?p, ?o
@@ -573,8 +573,8 @@ func TestPlannerQuery(t *testing.T) {
 					/c<mini> ?p ?o
 				}
 				HAVING ?o > "37"^^type:int64;`,
-			nbs:  2,
-			nrws: 0,
+			nBindings: 2,
+			nRows:     0,
 		},
 		{
 			q: `SELECT ?o
@@ -583,8 +583,8 @@ func TestPlannerQuery(t *testing.T) {
 					/u<alice> "height_cm"@[] ?o
 				}
 				HAVING ?o = /u<peter>;`,
-			nbs:  1,
-			nrws: 0,
+			nBindings: 1,
+			nRows:     0,
 		},
 		{
 			q: `SELECT ?s_id, ?height
@@ -593,8 +593,8 @@ func TestPlannerQuery(t *testing.T) {
 					?s ID ?s_id "height_cm"@[] ?height
 				}
 				HAVING ?s_id = "alice"^^type:text;`,
-			nbs:  2,
-			nrws: 1,
+			nBindings: 2,
+			nRows:     1,
 		},
 		{
 			q: `SELECT ?p_id, ?o
@@ -603,8 +603,8 @@ func TestPlannerQuery(t *testing.T) {
 					/u<peter> ?p ID ?p_id ?o
 				}
 				HAVING ?p_id < "parent_of"^^type:text;`,
-			nbs:  2,
-			nrws: 4,
+			nBindings: 2,
+			nRows:     4,
 		},
 		{
 			q: `SELECT ?s, ?s_type
@@ -613,8 +613,8 @@ func TestPlannerQuery(t *testing.T) {
 					?s TYPE ?s_type ?p ?o
 				}
 				HAVING ?s_type = "/c"^^type:text;`,
-			nbs:  2,
-			nrws: 4,
+			nBindings: 2,
+			nRows:     4,
 		},
 		{
 			q: `SELECT ?s, ?s_type
@@ -623,8 +623,8 @@ func TestPlannerQuery(t *testing.T) {
 					?s TYPE ?s_type ?p ?o
 				}
 				HAVING ?s_type < "/l"^^type:text;`,
-			nbs:  2,
-			nrws: 7,
+			nBindings: 2,
+			nRows:     7,
 		},
 		{
 			q: `SELECT ?p, ?p_id, ?o
@@ -634,8 +634,8 @@ func TestPlannerQuery(t *testing.T) {
 				}
 				HAVING ?p_id = "bought"^^type:text
 				AFTER 2016-03-01T00:00:00-08:00;`,
-			nbs:  3,
-			nrws: 2,
+			nBindings: 3,
+			nRows:     2,
 		},
 		{
 			q: `SELECT ?p, ?p_id, ?o
@@ -645,8 +645,8 @@ func TestPlannerQuery(t *testing.T) {
 				}
 				HAVING ?p_id < "parent_of"^^type:text
 				BEFORE 2016-03-01T00:00:00-08:00;`,
-			nbs:  3,
-			nrws: 3,
+			nBindings: 3,
+			nRows:     3,
 		},
 		{
 			q: `SELECT ?p, ?p_id, ?o
@@ -656,8 +656,8 @@ func TestPlannerQuery(t *testing.T) {
 				}
 				HAVING ?p_id = "bought"^^type:text
 				BETWEEN 2016-02-01T00:00:00-08:00, 2016-03-01T00:00:00-08:00;`,
-			nbs:  3,
-			nrws: 2,
+			nBindings: 3,
+			nRows:     2,
 		},
 		{
 			q: `SELECT ?p, ?p_id, ?o
@@ -667,8 +667,8 @@ func TestPlannerQuery(t *testing.T) {
 				}
 				HAVING ?p_id < "work_with"^^type:text
 				BEFORE 2016-02-01T00:00:00-08:00;`,
-			nbs:  3,
-			nrws: 4,
+			nBindings: 3,
+			nRows:     4,
 		},
 	}
 
@@ -695,10 +695,10 @@ func TestPlannerQuery(t *testing.T) {
 			t.Errorf("planner.Execute(%s)\n= _, %v; want nil error", entry.q, err)
 			continue
 		}
-		if got, want := len(tbl.Bindings()), entry.nbs; got != want {
+		if got, want := len(tbl.Bindings()), entry.nBindings; got != want {
 			t.Errorf("planner.Execute(%s)\n= a Table with %d bindings; want %d", entry.q, got, want)
 		}
-		if got, want := len(tbl.Rows()), entry.nrws; got != want {
+		if got, want := len(tbl.Rows()), entry.nRows; got != want {
 			t.Errorf("planner.Execute(%s)\n= a Table with %d rows; want %d\nTable:\n%v\n", entry.q, got, want, tbl)
 		}
 	}

--- a/bql/semantic/expression_test.go
+++ b/bql/semantic/expression_test.go
@@ -205,7 +205,7 @@ func mustBuildNodeFromStrings(nodeType, nodeID string) *node.Node {
 	return n
 }
 
-func TestNewEvaluator(t *testing.T) {
+func TestEvaluatorEvaluate(t *testing.T) {
 	testTable := []struct {
 		id   string
 		in   []ConsumedElement
@@ -658,7 +658,7 @@ func TestNewEvaluator(t *testing.T) {
 	}
 }
 
-func TestNewEvaluatorError(t *testing.T) {
+func TestEvaluatorEvaluateError(t *testing.T) {
 	testTable := []struct {
 		id   string
 		in   []ConsumedElement

--- a/bql/semantic/expression_test.go
+++ b/bql/semantic/expression_test.go
@@ -210,7 +210,6 @@ func TestNewEvaluator(t *testing.T) {
 		id   string
 		in   []ConsumedElement
 		r    table.Row
-		err  bool
 		want bool
 	}{
 		{
@@ -232,7 +231,6 @@ func TestNewEvaluator(t *testing.T) {
 				"?foo": &table.Cell{S: table.CellString("VALUE")},
 				"?bar": &table.Cell{S: table.CellString("VALUE")},
 			},
-			err:  false,
 			want: true,
 		},
 		{
@@ -254,7 +252,6 @@ func TestNewEvaluator(t *testing.T) {
 				"?foo": &table.Cell{S: table.CellString("foo")},
 				"?bar": &table.Cell{S: table.CellString("bar")},
 			},
-			err:  false,
 			want: false,
 		},
 		{
@@ -276,7 +273,6 @@ func TestNewEvaluator(t *testing.T) {
 				"?foo": &table.Cell{S: table.CellString("foo")},
 				"?bar": &table.Cell{S: table.CellString("bar")},
 			},
-			err:  false,
 			want: true,
 		},
 		{
@@ -307,7 +303,6 @@ func TestNewEvaluator(t *testing.T) {
 				"?foo": &table.Cell{S: table.CellString("VALUE")},
 				"?bar": &table.Cell{S: table.CellString("VALUE")},
 			},
-			err:  false,
 			want: false,
 		},
 		{
@@ -355,7 +350,6 @@ func TestNewEvaluator(t *testing.T) {
 				"?foo": &table.Cell{S: table.CellString("foo")},
 				"?bar": &table.Cell{S: table.CellString("bar")},
 			},
-			err:  false,
 			want: true,
 		},
 		{
@@ -403,7 +397,6 @@ func TestNewEvaluator(t *testing.T) {
 				"?foo": &table.Cell{S: table.CellString("foo")},
 				"?bar": &table.Cell{S: table.CellString("bar")},
 			},
-			err:  false,
 			want: false,
 		},
 		{
@@ -426,7 +419,6 @@ func TestNewEvaluator(t *testing.T) {
 					L: mustBuildLiteral(`"abc"^^type:text`),
 				},
 			},
-			err:  false,
 			want: true,
 		},
 		{
@@ -447,7 +439,6 @@ func TestNewEvaluator(t *testing.T) {
 			r: table.Row{
 				"?id": &table.Cell{S: table.CellString("abc")},
 			},
-			err:  false,
 			want: true,
 		},
 		{
@@ -468,7 +459,6 @@ func TestNewEvaluator(t *testing.T) {
 			r: table.Row{
 				"?id": &table.Cell{S: table.CellString("aaa")},
 			},
-			err:  false,
 			want: true,
 		},
 		{
@@ -489,7 +479,6 @@ func TestNewEvaluator(t *testing.T) {
 			r: table.Row{
 				"?id": &table.Cell{S: table.CellString("bbb")},
 			},
-			err:  false,
 			want: false,
 		},
 		{
@@ -510,7 +499,6 @@ func TestNewEvaluator(t *testing.T) {
 			r: table.Row{
 				"?s_type": &table.Cell{S: table.CellString("/u")},
 			},
-			err:  false,
 			want: true,
 		},
 		{
@@ -531,7 +519,6 @@ func TestNewEvaluator(t *testing.T) {
 			r: table.Row{
 				"?foo": &table.Cell{L: mustBuildLiteral(`"99.0"^^type:float64`)},
 			},
-			err:  false,
 			want: true,
 		},
 		{
@@ -552,7 +539,6 @@ func TestNewEvaluator(t *testing.T) {
 			r: table.Row{
 				"?foo": &table.Cell{L: mustBuildLiteral(`"100"^^type:int64`)},
 			},
-			err:  false,
 			want: true,
 		},
 		{
@@ -573,7 +559,6 @@ func TestNewEvaluator(t *testing.T) {
 			r: table.Row{
 				"?foo": &table.Cell{L: mustBuildLiteral(`"100"^^type:int64`)},
 			},
-			err:  false,
 			want: false,
 		},
 		{
@@ -594,7 +579,6 @@ func TestNewEvaluator(t *testing.T) {
 			r: table.Row{
 				"?foo": &table.Cell{N: mustBuildNodeFromStrings("/_", "meowth")},
 			},
-			err:  false,
 			want: true,
 		},
 		{
@@ -615,7 +599,6 @@ func TestNewEvaluator(t *testing.T) {
 			r: table.Row{
 				"?o": &table.Cell{N: mustBuildNodeFromStrings("/u", "paul")},
 			},
-			err:  false,
 			want: false,
 		},
 		{
@@ -636,49 +619,6 @@ func TestNewEvaluator(t *testing.T) {
 			r: table.Row{
 				"?o": &table.Cell{L: mustBuildLiteral(`"73"^^type:int64`)},
 			},
-			err:  false,
-			want: false,
-		},
-		{
-			id: `?s ID ?id > "37"^^type:int64`,
-			in: []ConsumedElement{
-				NewConsumedToken(&lexer.Token{
-					Type: lexer.ItemBinding,
-					Text: "?id",
-				}),
-				NewConsumedToken(&lexer.Token{
-					Type: lexer.ItemGT,
-				}),
-				NewConsumedToken(&lexer.Token{
-					Type: lexer.ItemLiteral,
-					Text: `"37"^^type:int64`,
-				}),
-			},
-			r: table.Row{
-				"?id": &table.Cell{S: table.CellString("peter")},
-			},
-			err:  true,
-			want: false,
-		},
-		{
-			id: `?s ID ?id = /u<peter>`,
-			in: []ConsumedElement{
-				NewConsumedToken(&lexer.Token{
-					Type: lexer.ItemBinding,
-					Text: "?id",
-				}),
-				NewConsumedToken(&lexer.Token{
-					Type: lexer.ItemEQ,
-				}),
-				NewConsumedToken(&lexer.Token{
-					Type: lexer.ItemNode,
-					Text: "/u<peter>",
-				}),
-			},
-			r: table.Row{
-				"?id": &table.Cell{S: table.CellString("peter")},
-			},
-			err:  true,
 			want: false,
 		},
 		{
@@ -699,7 +639,6 @@ func TestNewEvaluator(t *testing.T) {
 			r: table.Row{
 				"?foo": &table.Cell{L: mustBuildLiteral(`"10"^^type:int64`)},
 			},
-			err:  false,
 			want: false,
 		},
 	}
@@ -710,10 +649,72 @@ func TestNewEvaluator(t *testing.T) {
 		}
 
 		got, err := eval.Evaluate(entry.r)
-		if !entry.err && err != nil {
+		if err != nil {
 			t.Errorf("%s: eval.Evaluate(%v) = _, %v; want nil error", entry.id, entry.r, err)
 		}
-		if entry.err && err == nil {
+		if want := entry.want; got != want {
+			t.Errorf("%s: eval.Evaluate(%v) = %v, _; want %v, _", entry.id, entry.r, got, want)
+		}
+	}
+}
+
+func TestNewEvaluatorError(t *testing.T) {
+	testTable := []struct {
+		id   string
+		in   []ConsumedElement
+		r    table.Row
+		want bool
+	}{
+		{
+			id: `?s ID ?id > "37"^^type:int64`,
+			in: []ConsumedElement{
+				NewConsumedToken(&lexer.Token{
+					Type: lexer.ItemBinding,
+					Text: "?id",
+				}),
+				NewConsumedToken(&lexer.Token{
+					Type: lexer.ItemGT,
+				}),
+				NewConsumedToken(&lexer.Token{
+					Type: lexer.ItemLiteral,
+					Text: `"37"^^type:int64`,
+				}),
+			},
+			r: table.Row{
+				"?id": &table.Cell{S: table.CellString("peter")},
+			},
+			want: false,
+		},
+		{
+			id: `?s ID ?id = /u<peter>`,
+			in: []ConsumedElement{
+				NewConsumedToken(&lexer.Token{
+					Type: lexer.ItemBinding,
+					Text: "?id",
+				}),
+				NewConsumedToken(&lexer.Token{
+					Type: lexer.ItemEQ,
+				}),
+				NewConsumedToken(&lexer.Token{
+					Type: lexer.ItemNode,
+					Text: "/u<peter>",
+				}),
+			},
+			r: table.Row{
+				"?id": &table.Cell{S: table.CellString("peter")},
+			},
+			want: false,
+		},
+	}
+
+	for _, entry := range testTable {
+		eval, err := NewEvaluator(entry.in)
+		if err != nil {
+			t.Fatalf("test %q should have never failed when creating a new evaluator from %v, got error: %v", entry.id, entry.in, err)
+		}
+
+		got, err := eval.Evaluate(entry.r)
+		if err == nil {
 			t.Errorf("%s: eval.Evaluate(%v) = _, nil; want non-nil error", entry.id, entry.r)
 		}
 		if want := entry.want; got != want {


### PR DESCRIPTION
For clarity, it is useful to not mix in the same test function cases for which it is expected an error and cases for which it is not. 

Separating these cases into two different test functions makes the code cleaner and avoids the unnecessary use of more complicated `ifs` inside the body of the test function. Also, it makes it easier to add new test cases in the future as it is simpler to realize where they belong to in the test file.

Then, this PR comes to follow this guideline for two important test functions inside `expression_test.go` and `planner_test.go`.