### PR TITLE
Refactor "data_access_test.go" for clarity and conciseness

### DIFF
--- a/bql/planner/data_access_test.go
+++ b/bql/planner/data_access_test.go
@@ -349,8 +349,7 @@ func TestDataAccessBasicBindings(t *testing.T) {
 		// Actual test:
 		r, err := tripleToRow(tpl, cls)
 		if err != nil {
-			t.Errorf(`tripleToRow(for triple "%s" and clause %q) got error: %v; want nil error`, tpl, cls, err)
-			continue
+			t.Fatalf(`tripleToRow(for triple "%s" and clause %q) got error: %v; want nil error`, tpl, cls, err)
 		}
 		bindings := []string{"?s", "?p", "?o"}
 		entryCells := []*table.Cell{entry.sBinding, entry.pBinding, entry.oBinding}
@@ -397,8 +396,7 @@ func TestDataAccessTripleToRowSubjectBindings(t *testing.T) {
 		// Actual test:
 		r, err := tripleToRow(tpl, entry.cls)
 		if err != nil {
-			t.Errorf(`tripleToRow(for triple "%s" and clause %q) got error: %v; want nil error`, tpl, entry.cls, err)
-			continue
+			t.Fatalf(`tripleToRow(for triple "%s" and clause %q) got error: %v; want nil error`, tpl, entry.cls, err)
 		}
 		bindings := []string{"?s", "?alias", "?type", "?id"}
 		entryCells := []*table.Cell{entry.sBinding, entry.sAlias, entry.sTypeAlias, entry.sIDAlias}
@@ -453,8 +451,7 @@ func TestDataAccessTripleToRowPredicateBindings(t *testing.T) {
 		// Actual test:
 		r, err := tripleToRow(tpl, entry.cls)
 		if err != nil {
-			t.Errorf(`tripleToRow(for triple "%s" and clause %q) got error: %v; want nil error`, tpl, entry.cls, err)
-			continue
+			t.Fatalf(`tripleToRow(for triple "%s" and clause %q) got error: %v; want nil error`, tpl, entry.cls, err)
 		}
 		bindings := []string{"?p", "?alias", "?id", "?anchorBinding", "?anchorAlias"}
 		entryCells := []*table.Cell{entry.pBinding, entry.pAlias, entry.pIDAlias, entry.pAnchorBinding, entry.pAnchorAlias}
@@ -523,8 +520,7 @@ func TestDataAccessTripleToRowObjectBindings(t *testing.T) {
 		// Actual test:
 		r, err := tripleToRow(tpl, entry.cls)
 		if err != nil {
-			t.Errorf(`tripleToRow(for triple "%s" and clause %q) got error: %v; want nil error`, tpl, entry.cls, err)
-			continue
+			t.Fatalf(`tripleToRow(for triple "%s" and clause %q) got error: %v; want nil error`, tpl, entry.cls, err)
 		}
 		bindings := []string{"?o", "?alias", "?type", "?id", "?anchorBinding", "?anchorAlias"}
 		entryCells := []*table.Cell{entry.oBinding, entry.oAlias, entry.oTypeAlias, entry.oIDAlias, entry.oAnchorBinding, entry.oAnchorAlias}
@@ -574,8 +570,7 @@ func TestDataAccessTripleToRowObjectBindingsDropping(t *testing.T) {
 		// Actual test:
 		r, err := tripleToRow(tpl, entry.cls)
 		if err != nil {
-			t.Errorf(`tripleToRow(for triple "%s" and clause %q) got error: %v; want nil error`, tpl, entry.cls, err)
-			continue
+			t.Fatalf(`tripleToRow(for triple "%s" and clause %q) got error: %v; want nil error`, tpl, entry.cls, err)
 		}
 		if r != nil {
 			t.Errorf(`tripleToRow(for triple "%s" and clause %q) failed to drop triple and returned row: %v; want nil row`, tpl, entry.cls, r)

--- a/bql/planner/data_access_test.go
+++ b/bql/planner/data_access_test.go
@@ -17,6 +17,7 @@ package planner
 import (
 	"context"
 	"errors"
+	"fmt"
 	"reflect"
 	"sync"
 	"testing"
@@ -319,19 +320,19 @@ func TestDataAccessBasicBindings(t *testing.T) {
 		oBinding *table.Cell
 	}{
 		{
-			t:        n.String() + "\t" + p.String() + "\t" + n.String(),
+			t:        fmt.Sprintf("%s\t%s\t%s", n, p, n),
 			sBinding: &table.Cell{N: n},
 			pBinding: &table.Cell{P: p},
 			oBinding: &table.Cell{N: n},
 		},
 		{
-			t:        n.String() + "\t" + p.String() + "\t" + p.String(),
+			t:        fmt.Sprintf("%s\t%s\t%s", n, p, p),
 			sBinding: &table.Cell{N: n},
 			pBinding: &table.Cell{P: p},
 			oBinding: &table.Cell{P: p},
 		},
 		{
-			t:        n.String() + "\t" + p.String() + "\t" + l.String(),
+			t:        fmt.Sprintf("%s\t%s\t%s", n, p, l),
 			sBinding: &table.Cell{N: n},
 			pBinding: &table.Cell{P: p},
 			oBinding: &table.Cell{L: l},
@@ -372,7 +373,7 @@ func TestDataAccessTripleToRowSubjectBindings(t *testing.T) {
 		sIDAlias   *table.Cell
 	}{
 		{
-			t: n.String() + "\t" + p.String() + "\t" + n.String(),
+			t: fmt.Sprintf("%s\t%s\t%s", n, p, n),
 			cls: &semantic.GraphClause{
 				SBinding:   "?s",
 				SAlias:     "?alias",
@@ -426,7 +427,7 @@ func TestDataAccessTripleToRowPredicateBindings(t *testing.T) {
 		pAnchorAlias   *table.Cell
 	}{
 		{
-			t: n.String() + "\t" + p.String() + "\t" + n.String(),
+			t: fmt.Sprintf("%s\t%s\t%s", n, p, n),
 			cls: &semantic.GraphClause{
 				PBinding:       "?p",
 				PAlias:         "?alias",
@@ -483,7 +484,7 @@ func TestDataAccessTripleToRowObjectBindings(t *testing.T) {
 		oAnchorAlias   *table.Cell
 	}{
 		{
-			t: n.String() + "\t" + p.String() + "\t" + n.String(),
+			t: fmt.Sprintf("%s\t%s\t%s", n, p, n),
 			cls: &semantic.GraphClause{
 				OBinding:   "?o",
 				OAlias:     "?alias",
@@ -496,7 +497,7 @@ func TestDataAccessTripleToRowObjectBindings(t *testing.T) {
 			oIDAlias:   &table.Cell{S: table.CellString(n.ID().String())},
 		},
 		{
-			t: n.String() + "\t" + p.String() + "\t" + p.String(),
+			t: fmt.Sprintf("%s\t%s\t%s", n, p, p),
 			cls: &semantic.GraphClause{
 				OBinding:       "?o",
 				OAlias:         "?alias",
@@ -553,7 +554,7 @@ func TestDataAccessTripleToRowObjectBindingsDropping(t *testing.T) {
 		oAnchorAlias   *table.Cell
 	}{
 		{
-			t: n.String() + "\t" + p.String() + "\t" + n.String(),
+			t: fmt.Sprintf("%s\t%s\t%s", n, p, n),
 			cls: &semantic.GraphClause{
 				OBinding:   "?o",
 				OAlias:     "?alias",
@@ -566,7 +567,7 @@ func TestDataAccessTripleToRowObjectBindingsDropping(t *testing.T) {
 			oIDAlias:   &table.Cell{S: table.CellString(n.ID().String())},
 		},
 		{
-			t: n.String() + "\t" + p.String() + "\t" + p.String(),
+			t: fmt.Sprintf("%s\t%s\t%s", n, p, p),
 			cls: &semantic.GraphClause{
 				OBinding:       "?o",
 				OAlias:         "?alias",

--- a/bql/planner/data_access_test.go
+++ b/bql/planner/data_access_test.go
@@ -343,7 +343,7 @@ func TestDataAccessBasicBindings(t *testing.T) {
 		// Setup for test:
 		tpl, err := triple.Parse(entry.t, literal.DefaultBuilder())
 		if err != nil {
-			t.Fatalf(`triple.Parse failed for triple "%s", got error: %v`, entry.t, err)
+			t.Fatalf(`triple.Parse failed for triple "%s": %v`, entry.t, err)
 		}
 
 		// Actual test:
@@ -390,7 +390,7 @@ func TestDataAccessTripleToRowSubjectBindings(t *testing.T) {
 		// Setup for test:
 		tpl, err := triple.Parse(entry.t, literal.DefaultBuilder())
 		if err != nil {
-			t.Fatalf(`triple.Parse failed for triple "%s", got error: %v`, entry.t, err)
+			t.Fatalf(`triple.Parse failed for triple "%s": %v`, entry.t, err)
 		}
 
 		// Actual test:
@@ -445,7 +445,7 @@ func TestDataAccessTripleToRowPredicateBindings(t *testing.T) {
 		// Setup for test:
 		tpl, err := triple.Parse(entry.t, literal.DefaultBuilder())
 		if err != nil {
-			t.Fatalf(`triple.Parse failed for triple "%s", got error: %v`, entry.t, err)
+			t.Fatalf(`triple.Parse failed for triple "%s": %v`, entry.t, err)
 		}
 
 		// Actual test:
@@ -514,7 +514,7 @@ func TestDataAccessTripleToRowObjectBindings(t *testing.T) {
 		// Setup for test:
 		tpl, err := triple.Parse(entry.t, literal.DefaultBuilder())
 		if err != nil {
-			t.Fatalf(`triple.Parse failed for triple "%s", got error: %v`, entry.t, err)
+			t.Fatalf(`triple.Parse failed for triple "%s": %v`, entry.t, err)
 		}
 
 		// Actual test:
@@ -564,7 +564,7 @@ func TestDataAccessTripleToRowObjectBindingsDropping(t *testing.T) {
 		// Setup for test:
 		tpl, err := triple.Parse(entry.t, literal.DefaultBuilder())
 		if err != nil {
-			t.Fatalf(`triple.Parse failed for triple "%s", got error: %v`, entry.t, err)
+			t.Fatalf(`triple.Parse failed for triple "%s": %v`, entry.t, err)
 		}
 
 		// Actual test:

--- a/bql/planner/data_access_test.go
+++ b/bql/planner/data_access_test.go
@@ -349,7 +349,7 @@ func TestDataAccessBasicBindings(t *testing.T) {
 		// Actual test:
 		r, err := tripleToRow(tpl, cls)
 		if err != nil {
-			t.Fatalf(`tripleToRow(for triple "%s" and clause %q) got error: %v; want nil error`, tpl, cls, err)
+			t.Fatalf(`tripleToRow("%s", %q) = _, %v; want _, nil error`, tpl, cls, err)
 		}
 		bindings := []string{"?s", "?p", "?o"}
 		entryCells := []*table.Cell{entry.sBinding, entry.pBinding, entry.oBinding}
@@ -396,7 +396,7 @@ func TestDataAccessTripleToRowSubjectBindings(t *testing.T) {
 		// Actual test:
 		r, err := tripleToRow(tpl, entry.cls)
 		if err != nil {
-			t.Fatalf(`tripleToRow(for triple "%s" and clause %q) got error: %v; want nil error`, tpl, entry.cls, err)
+			t.Fatalf(`tripleToRow("%s", %q) = _, %v; want _, nil error`, tpl, entry.cls, err)
 		}
 		bindings := []string{"?s", "?alias", "?type", "?id"}
 		entryCells := []*table.Cell{entry.sBinding, entry.sAlias, entry.sTypeAlias, entry.sIDAlias}
@@ -451,7 +451,7 @@ func TestDataAccessTripleToRowPredicateBindings(t *testing.T) {
 		// Actual test:
 		r, err := tripleToRow(tpl, entry.cls)
 		if err != nil {
-			t.Fatalf(`tripleToRow(for triple "%s" and clause %q) got error: %v; want nil error`, tpl, entry.cls, err)
+			t.Fatalf(`tripleToRow("%s", %q) = _, %v; want _, nil error`, tpl, entry.cls, err)
 		}
 		bindings := []string{"?p", "?alias", "?id", "?anchorBinding", "?anchorAlias"}
 		entryCells := []*table.Cell{entry.pBinding, entry.pAlias, entry.pIDAlias, entry.pAnchorBinding, entry.pAnchorAlias}
@@ -520,7 +520,7 @@ func TestDataAccessTripleToRowObjectBindings(t *testing.T) {
 		// Actual test:
 		r, err := tripleToRow(tpl, entry.cls)
 		if err != nil {
-			t.Fatalf(`tripleToRow(for triple "%s" and clause %q) got error: %v; want nil error`, tpl, entry.cls, err)
+			t.Fatalf(`tripleToRow("%s", %q) = _, %v; want _, nil error`, tpl, entry.cls, err)
 		}
 		bindings := []string{"?o", "?alias", "?type", "?id", "?anchorBinding", "?anchorAlias"}
 		entryCells := []*table.Cell{entry.oBinding, entry.oAlias, entry.oTypeAlias, entry.oIDAlias, entry.oAnchorBinding, entry.oAnchorAlias}
@@ -570,10 +570,10 @@ func TestDataAccessTripleToRowObjectBindingsDropping(t *testing.T) {
 		// Actual test:
 		r, err := tripleToRow(tpl, entry.cls)
 		if err != nil {
-			t.Fatalf(`tripleToRow(for triple "%s" and clause %q) got error: %v; want nil error`, tpl, entry.cls, err)
+			t.Fatalf(`tripleToRow("%s", %q) = _, %v; want _, nil error`, tpl, entry.cls, err)
 		}
 		if r != nil {
-			t.Errorf(`tripleToRow(for triple "%s" and clause %q) failed to drop triple and returned row: %v; want nil row`, tpl, entry.cls, r)
+			t.Errorf(`tripleToRow("%s", %q) = %v, _; want nil row, _`, tpl, entry.cls, r)
 		}
 	}
 }

--- a/bql/planner/data_access_test.go
+++ b/bql/planner/data_access_test.go
@@ -463,19 +463,20 @@ func TestDataAccessTripleToRowPredicateBindings(t *testing.T) {
 
 func TestDataAccessTripleToRowObjectBindings(t *testing.T) {
 	n, p, _ := testNodeTemporalPredicateLiteral(t)
-	ts, err := p.TimeAnchor()
+	ta, err := p.TimeAnchor()
 	if err != nil {
 		t.Fatal(err)
 	}
+
 	testTable := []struct {
-		t   string
-		cls *semantic.GraphClause
-		bc  *table.Cell
-		ac  *table.Cell
-		tc  *table.Cell
-		ic  *table.Cell
-		tsc *table.Cell
-		atc *table.Cell
+		t              string
+		cls            *semantic.GraphClause
+		oBinding       *table.Cell
+		oAlias         *table.Cell
+		oTypeAlias     *table.Cell
+		oIDAlias       *table.Cell
+		oAnchorBinding *table.Cell
+		oAnchorAlias   *table.Cell
 	}{
 		{
 			t: n.String() + "\t" + p.String() + "\t" + n.String(),
@@ -485,10 +486,10 @@ func TestDataAccessTripleToRowObjectBindings(t *testing.T) {
 				OTypeAlias: "?type",
 				OIDAlias:   "?id",
 			},
-			bc: &table.Cell{N: n},
-			ac: &table.Cell{N: n},
-			tc: &table.Cell{S: table.CellString(n.Type().String())},
-			ic: &table.Cell{S: table.CellString(n.ID().String())},
+			oBinding:   &table.Cell{N: n},
+			oAlias:     &table.Cell{N: n},
+			oTypeAlias: &table.Cell{S: table.CellString(n.Type().String())},
+			oIDAlias:   &table.Cell{S: table.CellString(n.ID().String())},
 		},
 		{
 			t: n.String() + "\t" + p.String() + "\t" + p.String(),
@@ -496,42 +497,36 @@ func TestDataAccessTripleToRowObjectBindings(t *testing.T) {
 				OBinding:       "?o",
 				OAlias:         "?alias",
 				OIDAlias:       "?id",
-				OAnchorBinding: "?ts",
-				OAnchorAlias:   "?tsa",
+				OAnchorBinding: "?anchorBinding",
+				OAnchorAlias:   "?anchorAlias",
 			},
-			bc:  &table.Cell{P: p},
-			ac:  &table.Cell{P: p},
-			ic:  &table.Cell{S: table.CellString(string(p.ID()))},
-			tsc: &table.Cell{T: ts},
-			atc: &table.Cell{T: ts},
+			oBinding:       &table.Cell{P: p},
+			oAlias:         &table.Cell{P: p},
+			oIDAlias:       &table.Cell{S: table.CellString(string(p.ID()))},
+			oAnchorBinding: &table.Cell{T: ta},
+			oAnchorAlias:   &table.Cell{T: ta},
 		},
 	}
+
 	for _, entry := range testTable {
+		// Setup for test:
 		tpl, err := triple.Parse(entry.t, literal.DefaultBuilder())
 		if err != nil {
-			t.Errorf("triple.Parse failed to parse valid triple %q with error %v", entry.t, err)
+			t.Fatalf(`triple.Parse failed to parse valid triple "%s" with error: %v`, entry.t, err)
 		}
+
+		// Actual test:
 		r, err := tripleToRow(tpl, entry.cls)
 		if err != nil {
-			t.Errorf("tripleToRow for triple %q and clasuse %v, failed with error %v", tpl, entry.cls, err)
+			t.Errorf(`tripleToRow for triple "%s" and clause %q failed with error: %v`, tpl, entry.cls, err)
+			continue
 		}
-		if got, want := r["?o"], entry.bc; !reflect.DeepEqual(got, want) {
-			t.Errorf("tripleToRow failed to return right value for binding \"?o\"; got %q, want %q", got, want)
-		}
-		if got, want := r["?alias"], entry.ac; !reflect.DeepEqual(got, want) {
-			t.Errorf("tripleToRow failed to return right value for binding alias \"?alias\"; got %q, want %q", got, want)
-		}
-		if got, want := r["?id"], entry.ic; !reflect.DeepEqual(got, want) {
-			t.Errorf("tripleToRow failed to return right value for binding \"?id\"; got %q, want %q", got, want)
-		}
-		if got, want := r["?type"], entry.tc; entry.tc != nil && !reflect.DeepEqual(got, want) {
-			t.Errorf("tripleToRow failed to return right value for binding \"?type\"; got %q, want %q", got, want)
-		}
-		if got, want := r["?ts"], entry.tsc; entry.tsc != nil && !reflect.DeepEqual(got, want) {
-			t.Errorf("tripleToRow failed to return right value for binding \"?ts\"; got %q, want %q", got, want)
-		}
-		if got, want := r["?tsa"], entry.atc; entry.atc != nil && !reflect.DeepEqual(got, want) {
-			t.Errorf("tripleToRow failed to return right value for binding \"?tsa\"; got %q, want %q", got, want)
+		bindings := []string{"?o", "?alias", "?type", "?id", "?anchorBinding", "?anchorAlias"}
+		entryCells := []*table.Cell{entry.oBinding, entry.oAlias, entry.oTypeAlias, entry.oIDAlias, entry.oAnchorBinding, entry.oAnchorAlias}
+		for i, binding := range bindings {
+			if got, want := r[binding], entryCells[i]; !reflect.DeepEqual(got, want) {
+				t.Errorf(`tripleToRow(%q) = "%s"; want "%s"`, binding, got, want)
+			}
 		}
 	}
 }

--- a/bql/planner/data_access_test.go
+++ b/bql/planner/data_access_test.go
@@ -538,20 +538,10 @@ func TestDataAccessTripleToRowObjectBindings(t *testing.T) {
 
 func TestDataAccessTripleToRowObjectBindingsDropping(t *testing.T) {
 	n, p, _ := testNodeTemporalPredicateLiteral(t)
-	ta, err := p.TimeAnchor()
-	if err != nil {
-		t.Fatal(err)
-	}
 
 	testTable := []struct {
-		t              string
-		cls            *semantic.GraphClause
-		oBinding       *table.Cell
-		oAlias         *table.Cell
-		oTypeAlias     *table.Cell
-		oIDAlias       *table.Cell
-		oAnchorBinding *table.Cell
-		oAnchorAlias   *table.Cell
+		t   string
+		cls *semantic.GraphClause
 	}{
 		{
 			t: fmt.Sprintf("%s\t%s\t%s", n, p, n),
@@ -561,10 +551,6 @@ func TestDataAccessTripleToRowObjectBindingsDropping(t *testing.T) {
 				OTypeAlias: "?o",
 				OIDAlias:   "?id",
 			},
-			oBinding:   &table.Cell{N: n},
-			oAlias:     &table.Cell{N: n},
-			oTypeAlias: &table.Cell{S: table.CellString(n.Type().String())},
-			oIDAlias:   &table.Cell{S: table.CellString(n.ID().String())},
 		},
 		{
 			t: fmt.Sprintf("%s\t%s\t%s", n, p, p),
@@ -575,11 +561,6 @@ func TestDataAccessTripleToRowObjectBindingsDropping(t *testing.T) {
 				OAnchorBinding: "?anchorBinding",
 				OAnchorAlias:   "?o",
 			},
-			oBinding:       &table.Cell{P: p},
-			oAlias:         &table.Cell{P: p},
-			oIDAlias:       &table.Cell{S: table.CellString(string(p.ID()))},
-			oAnchorBinding: &table.Cell{T: ta},
-			oAnchorAlias:   &table.Cell{T: ta},
 		},
 	}
 

--- a/bql/planner/data_access_test.go
+++ b/bql/planner/data_access_test.go
@@ -311,48 +311,52 @@ func TestDataAccessBasicBindings(t *testing.T) {
 		PBinding: "?p",
 		OBinding: "?o",
 	}
+
 	testTable := []struct {
-		t  string
-		sc *table.Cell
-		pc *table.Cell
-		oc *table.Cell
+		t        string
+		sBinding *table.Cell
+		pBinding *table.Cell
+		oBinding *table.Cell
 	}{
 		{
-			t:  n.String() + "\t" + p.String() + "\t" + n.String(),
-			sc: &table.Cell{N: n},
-			pc: &table.Cell{P: p},
-			oc: &table.Cell{N: n},
+			t:        n.String() + "\t" + p.String() + "\t" + n.String(),
+			sBinding: &table.Cell{N: n},
+			pBinding: &table.Cell{P: p},
+			oBinding: &table.Cell{N: n},
 		},
 		{
-			t:  n.String() + "\t" + p.String() + "\t" + p.String(),
-			sc: &table.Cell{N: n},
-			pc: &table.Cell{P: p},
-			oc: &table.Cell{P: p},
+			t:        n.String() + "\t" + p.String() + "\t" + p.String(),
+			sBinding: &table.Cell{N: n},
+			pBinding: &table.Cell{P: p},
+			oBinding: &table.Cell{P: p},
 		},
 		{
-			t:  n.String() + "\t" + p.String() + "\t" + l.String(),
-			sc: &table.Cell{N: n},
-			pc: &table.Cell{P: p},
-			oc: &table.Cell{L: l},
+			t:        n.String() + "\t" + p.String() + "\t" + l.String(),
+			sBinding: &table.Cell{N: n},
+			pBinding: &table.Cell{P: p},
+			oBinding: &table.Cell{L: l},
 		},
 	}
+
 	for _, entry := range testTable {
+		// Setup for test:
 		tpl, err := triple.Parse(entry.t, literal.DefaultBuilder())
 		if err != nil {
-			t.Errorf("triple.Parse failed to parse valid triple %q with error %v", entry.t, err)
+			t.Fatalf(`triple.Parse failed to parse valid triple "%s" with error: %v`, entry.t, err)
 		}
+
+		// Actual test:
 		r, err := tripleToRow(tpl, cls)
 		if err != nil {
-			t.Errorf("tripleToRow for triple %q and clasuse %v, failed with error %v", tpl, cls, err)
+			t.Errorf(`tripleToRow for triple "%s" and clause %q failed with error: %v`, tpl, cls, err)
+			continue
 		}
-		if got, want := r["?s"], entry.sc; !reflect.DeepEqual(got, want) {
-			t.Errorf("tripleToRow failed to return right value for binding \"?s\"; got %q, want %q", got, want)
-		}
-		if got, want := r["?p"], entry.pc; !reflect.DeepEqual(got, want) {
-			t.Errorf("tripleToRow failed to return right value for binding \"?p\"; got %q, want %q", got, want)
-		}
-		if got, want := r["?o"], entry.oc; !reflect.DeepEqual(got, want) {
-			t.Errorf("tripleToRow failed to return right value for binding \"?o\"; got %q, want %q", got, want)
+		bindings := []string{"?s", "?p", "?o"}
+		entryCells := []*table.Cell{entry.sBinding, entry.pBinding, entry.oBinding}
+		for i, binding := range bindings {
+			if got, want := r[binding], entryCells[i]; !reflect.DeepEqual(got, want) {
+				t.Errorf(`tripleToRow(%q) = "%s"; want "%s"`, binding, got, want)
+			}
 		}
 	}
 }

--- a/bql/planner/data_access_test.go
+++ b/bql/planner/data_access_test.go
@@ -343,20 +343,20 @@ func TestDataAccessBasicBindings(t *testing.T) {
 		// Setup for test:
 		tpl, err := triple.Parse(entry.t, literal.DefaultBuilder())
 		if err != nil {
-			t.Fatalf(`triple.Parse failed to parse valid triple "%s" with error: %v`, entry.t, err)
+			t.Fatalf(`triple.Parse failed for triple "%s", got error: %v`, entry.t, err)
 		}
 
 		// Actual test:
 		r, err := tripleToRow(tpl, cls)
 		if err != nil {
-			t.Errorf(`tripleToRow for triple "%s" and clause %q failed with error: %v`, tpl, cls, err)
+			t.Errorf(`tripleToRow(for triple "%s" and clause %q) got error: %v; want nil error`, tpl, cls, err)
 			continue
 		}
 		bindings := []string{"?s", "?p", "?o"}
 		entryCells := []*table.Cell{entry.sBinding, entry.pBinding, entry.oBinding}
 		for i, binding := range bindings {
 			if got, want := r[binding], entryCells[i]; !reflect.DeepEqual(got, want) {
-				t.Errorf(`tripleToRow(%q) = "%s"; want "%s"`, binding, got, want)
+				t.Errorf(`tripleToRow(%q) = "%s", _; want "%s", _`, binding, got, want)
 			}
 		}
 	}
@@ -391,20 +391,20 @@ func TestDataAccessTripleToRowSubjectBindings(t *testing.T) {
 		// Setup for test:
 		tpl, err := triple.Parse(entry.t, literal.DefaultBuilder())
 		if err != nil {
-			t.Fatalf(`triple.Parse failed to parse valid triple "%s" with error: %v`, entry.t, err)
+			t.Fatalf(`triple.Parse failed for triple "%s", got error: %v`, entry.t, err)
 		}
 
 		// Actual test:
 		r, err := tripleToRow(tpl, entry.cls)
 		if err != nil {
-			t.Errorf(`tripleToRow for triple "%s" and clause %q failed with error: %v`, tpl, entry.cls, err)
+			t.Errorf(`tripleToRow(for triple "%s" and clause %q) got error: %v; want nil error`, tpl, entry.cls, err)
 			continue
 		}
 		bindings := []string{"?s", "?alias", "?type", "?id"}
 		entryCells := []*table.Cell{entry.sBinding, entry.sAlias, entry.sTypeAlias, entry.sIDAlias}
 		for i, binding := range bindings {
 			if got, want := r[binding], entryCells[i]; !reflect.DeepEqual(got, want) {
-				t.Errorf(`tripleToRow(%q) = "%s"; want "%s"`, binding, got, want)
+				t.Errorf(`tripleToRow(%q) = "%s", _; want "%s", _`, binding, got, want)
 			}
 		}
 	}
@@ -447,20 +447,20 @@ func TestDataAccessTripleToRowPredicateBindings(t *testing.T) {
 		// Setup for test:
 		tpl, err := triple.Parse(entry.t, literal.DefaultBuilder())
 		if err != nil {
-			t.Fatalf(`triple.Parse failed to parse valid triple "%s" with error: %v`, entry.t, err)
+			t.Fatalf(`triple.Parse failed for triple "%s", got error: %v`, entry.t, err)
 		}
 
 		// Actual test:
 		r, err := tripleToRow(tpl, entry.cls)
 		if err != nil {
-			t.Errorf(`tripleToRow for triple "%s" and clause %q failed with error: %v`, tpl, entry.cls, err)
+			t.Errorf(`tripleToRow(for triple "%s" and clause %q) got error: %v; want nil error`, tpl, entry.cls, err)
 			continue
 		}
 		bindings := []string{"?p", "?alias", "?id", "?anchorBinding", "?anchorAlias"}
 		entryCells := []*table.Cell{entry.pBinding, entry.pAlias, entry.pIDAlias, entry.pAnchorBinding, entry.pAnchorAlias}
 		for i, binding := range bindings {
 			if got, want := r[binding], entryCells[i]; !reflect.DeepEqual(got, want) {
-				t.Errorf(`tripleToRow(%q) = "%s"; want "%s"`, binding, got, want)
+				t.Errorf(`tripleToRow(%q) = "%s", _; want "%s", _`, binding, got, want)
 			}
 		}
 	}
@@ -517,20 +517,20 @@ func TestDataAccessTripleToRowObjectBindings(t *testing.T) {
 		// Setup for test:
 		tpl, err := triple.Parse(entry.t, literal.DefaultBuilder())
 		if err != nil {
-			t.Fatalf(`triple.Parse failed to parse valid triple "%s" with error: %v`, entry.t, err)
+			t.Fatalf(`triple.Parse failed for triple "%s", got error: %v`, entry.t, err)
 		}
 
 		// Actual test:
 		r, err := tripleToRow(tpl, entry.cls)
 		if err != nil {
-			t.Errorf(`tripleToRow for triple "%s" and clause %q failed with error: %v`, tpl, entry.cls, err)
+			t.Errorf(`tripleToRow(for triple "%s" and clause %q) got error: %v; want nil error`, tpl, entry.cls, err)
 			continue
 		}
 		bindings := []string{"?o", "?alias", "?type", "?id", "?anchorBinding", "?anchorAlias"}
 		entryCells := []*table.Cell{entry.oBinding, entry.oAlias, entry.oTypeAlias, entry.oIDAlias, entry.oAnchorBinding, entry.oAnchorAlias}
 		for i, binding := range bindings {
 			if got, want := r[binding], entryCells[i]; !reflect.DeepEqual(got, want) {
-				t.Errorf(`tripleToRow(%q) = "%s"; want "%s"`, binding, got, want)
+				t.Errorf(`tripleToRow(%q) = "%s", _; want "%s", _`, binding, got, want)
 			}
 		}
 	}
@@ -568,17 +568,17 @@ func TestDataAccessTripleToRowObjectBindingsDropping(t *testing.T) {
 		// Setup for test:
 		tpl, err := triple.Parse(entry.t, literal.DefaultBuilder())
 		if err != nil {
-			t.Fatalf(`triple.Parse failed to parse valid triple "%s" with error: %v`, entry.t, err)
+			t.Fatalf(`triple.Parse failed for triple "%s", got error: %v`, entry.t, err)
 		}
 
 		// Actual test:
 		r, err := tripleToRow(tpl, entry.cls)
 		if err != nil {
-			t.Errorf(`tripleToRow for triple "%s" and clause %q failed with error: %v`, tpl, entry.cls, err)
+			t.Errorf(`tripleToRow(for triple "%s" and clause %q) got error: %v; want nil error`, tpl, entry.cls, err)
 			continue
 		}
 		if r != nil {
-			t.Errorf(`tripleToRow for triple "%s" and clause %q failed to drop triple and returned: %v; want nil`, tpl, entry.cls, r)
+			t.Errorf(`tripleToRow(for triple "%s" and clause %q) failed to drop triple and returned row: %v; want nil row`, tpl, entry.cls, r)
 		}
 	}
 }

--- a/bql/planner/planner_test.go
+++ b/bql/planner/planner_test.go
@@ -720,8 +720,7 @@ func TestPlannerQuery(t *testing.T) {
 		// Actual test:
 		tbl, err := plnr.Execute(ctx)
 		if err != nil {
-			t.Errorf("planner.Execute(%s)\n= _, %v; want nil error", entry.q, err)
-			continue
+			t.Fatalf("planner.Execute(%s)\n= _, %v; want nil error", entry.q, err)
 		}
 		if got, want := len(tbl.Bindings()), entry.nBindings; got != want {
 			t.Errorf("planner.Execute(%s)\n= a Table with %d bindings; want %d", entry.q, got, want)


### PR DESCRIPTION
Refactor `data_access_test.go` to make it cleaner, avoid repeated code (and multiple `if` clauses) and also use more clear variable names as a way of easing the job of anyone that may pass through or work on this file in the future.