### PR TITLE
Adjust behavior of time bindings for immutable predicates and TYPE bindings for non-node objects

### DIFF
--- a/bql/planner/data_access.go
+++ b/bql/planner/data_access.go
@@ -570,7 +570,8 @@ func tripleToRow(t *triple.Triple, cls *semantic.GraphClause) (table.Row, error)
 	}
 	if cls.PAnchorBinding != "" {
 		if p.Type() != predicate.Temporal {
-			return nil, fmt.Errorf("cannot retrieve the time anchor value for non temporal predicate %q in binding %q", p, cls.PAnchorBinding)
+			// in the case of time anchor binding (eg: "bought"@[?time]) for an immutable predicate we just want (for now) to skip this triple and proceed to the next one, not returning any errors.
+			return nil, nil
 		}
 		t, err := p.TimeAnchor()
 		if err != nil {

--- a/bql/planner/data_access.go
+++ b/bql/planner/data_access.go
@@ -581,15 +581,17 @@ func tripleToRow(t *triple.Triple, cls *semantic.GraphClause) (table.Row, error)
 		}
 	}
 	if cls.PAnchorAlias != "" {
+		var c *table.Cell
 		if p.Type() != predicate.Temporal {
-			// in the case of AT binding for an immutable predicate we just want (for now) to skip this triple and proceed to the next one, not returning any errors.
-			return nil, nil
+			// in the case of AT bindings for immutable predicates we provide an empty Cell as we want <NULL> to appear in the query result.
+			c = &table.Cell{}
+		} else {
+			t, err := p.TimeAnchor()
+			if err != nil {
+				return nil, fmt.Errorf("failed to retrieve the time anchor value for predicate %q in binding %q with error: %v", p, cls.PAnchorAlias, err)
+			}
+			c = &table.Cell{T: t}
 		}
-		t, err := p.TimeAnchor()
-		if err != nil {
-			return nil, fmt.Errorf("failed to retrieve the time anchor value for predicate %q in binding %q with error %v", p, cls.PAnchorAlias, err)
-		}
-		c := &table.Cell{T: t}
 		r[cls.PAnchorAlias] = c
 		if !validBinding(cls.PAnchorAlias, c) {
 			return nil, nil

--- a/bql/planner/data_access.go
+++ b/bql/planner/data_access.go
@@ -420,7 +420,7 @@ func addTriples(ts <-chan *triple.Triple, cls *semantic.GraphClause, tbl *table.
 			if string(t.Predicate().ID()) != cls.PID {
 				continue
 			}
-			if cls.PTemporal {
+			if cls.PTemporal && cls.PAnchorBinding == "" {
 				if t.Predicate().Type() != predicate.Temporal {
 					continue
 				}
@@ -566,15 +566,17 @@ func tripleToRow(t *triple.Triple, cls *semantic.GraphClause) (table.Row, error)
 		}
 	}
 	if cls.PAnchorBinding != "" {
+		var c *table.Cell
 		if p.Type() != predicate.Temporal {
-			// in the case of time anchor binding (eg: "bought"@[?time]) for an immutable predicate we just want (for now) to skip this triple and proceed to the next one, not returning any errors.
-			return nil, nil
+			// in the case of time anchor bindings (eg: "bought"@[?time]) for immutable predicates we provide an empty Cell as we want <NULL> to appear in the query result.
+			c = &table.Cell{}
+		} else {
+			t, err := p.TimeAnchor()
+			if err != nil {
+				return nil, fmt.Errorf("failed to retrieve the time anchor value for predicate %q in binding %q with error: %v", p, cls.PAnchorBinding, err)
+			}
+			c = &table.Cell{T: t}
 		}
-		t, err := p.TimeAnchor()
-		if err != nil {
-			return nil, fmt.Errorf("failed to retrieve the time anchor value for predicate %q in binding %q with error %v", p, cls.PAnchorBinding, err)
-		}
-		c := &table.Cell{T: t}
 		r[cls.PAnchorBinding] = c
 		if !validBinding(cls.PAnchorBinding, c) {
 			return nil, nil

--- a/bql/planner/data_access.go
+++ b/bql/planner/data_access.go
@@ -624,7 +624,8 @@ func tripleToRow(t *triple.Triple, cls *semantic.GraphClause) (table.Row, error)
 	if cls.OTypeAlias != "" {
 		n, err := o.Node()
 		if err != nil {
-			return nil, err
+			// in the case of TYPE binding for a non-node object we just want (for now) to skip this triple and proceed to the next one, not returning any errors.
+			return nil, nil
 		}
 		c := &table.Cell{S: table.CellString(n.Type().String())}
 		r[cls.OTypeAlias] = c

--- a/bql/planner/data_access.go
+++ b/bql/planner/data_access.go
@@ -582,10 +582,10 @@ func tripleToRow(t *triple.Triple, cls *semantic.GraphClause) (table.Row, error)
 			return nil, nil
 		}
 	}
-
 	if cls.PAnchorAlias != "" {
 		if p.Type() != predicate.Temporal {
-			return nil, fmt.Errorf("cannot retrieve the time anchor value for non temporal predicate %q in binding %q", p, cls.PAnchorAlias)
+			// in the case of AT binding for an immutable predicate we just want (for now) to skip this triple and proceed to the next one, not returning any errors.
+			return nil, nil
 		}
 		t, err := p.TimeAnchor()
 		if err != nil {

--- a/bql/planner/data_access.go
+++ b/bql/planner/data_access.go
@@ -624,12 +624,14 @@ func tripleToRow(t *triple.Triple, cls *semantic.GraphClause) (table.Row, error)
 		}
 	}
 	if cls.OTypeAlias != "" {
+		var c *table.Cell
 		n, err := o.Node()
 		if err != nil {
-			// in the case of TYPE binding for a non-node object we just want (for now) to skip this triple and proceed to the next one, not returning any errors.
-			return nil, nil
+			// in the case of TYPE bindings for non-node objects we provide an empty Cell as we want <NULL> to appear in the query result (for now, see Issue 124).
+			c = &table.Cell{}
+		} else {
+			c = &table.Cell{S: table.CellString(n.Type().String())}
 		}
-		c := &table.Cell{S: table.CellString(n.Type().String())}
 		r[cls.OTypeAlias] = c
 		if !validBinding(cls.OTypeAlias, c) {
 			return nil, nil

--- a/bql/planner/data_access.go
+++ b/bql/planner/data_access.go
@@ -673,11 +673,17 @@ func tripleToRow(t *triple.Triple, cls *semantic.GraphClause) (table.Row, error)
 		if err != nil {
 			return nil, err
 		}
-		ts, err := p.TimeAnchor()
-		if err != nil {
-			return nil, err
+		var c *table.Cell
+		if p.Type() != predicate.Temporal {
+			// in the case of AT bindings for objects that are immutable predicates we provide an empty Cell as we want <NULL> to appear in the query result.
+			c = &table.Cell{}
+		} else {
+			t, err := p.TimeAnchor()
+			if err != nil {
+				return nil, fmt.Errorf("failed to retrieve the time anchor value for predicate %q in binding %q with error: %v", p, cls.OAnchorAlias, err)
+			}
+			c = &table.Cell{T: t}
 		}
-		c := &table.Cell{T: ts}
 		r[cls.OAnchorAlias] = c
 		if !validBinding(cls.OAnchorAlias, c) {
 			return nil, nil

--- a/bql/planner/data_access.go
+++ b/bql/planner/data_access.go
@@ -472,11 +472,8 @@ func addTriples(ts <-chan *triple.Triple, cls *semantic.GraphClause, tbl *table.
 			tbl.AddRow(r)
 		}
 	}
-	if lastErr != nil {
-		return lastErr
-	}
 
-	return nil
+	return lastErr
 }
 
 // objectToCell returns a cell containing the data boxed in the object.

--- a/bql/planner/data_access.go
+++ b/bql/planner/data_access.go
@@ -494,7 +494,7 @@ func objectToCell(o *triple.Object) (*table.Cell, error) {
 	return nil, fmt.Errorf("unknown object type in object %q", o)
 }
 
-// tripleToRow converts a triple into a row using the binndings specidfied
+// tripleToRow converts a triple into a row using the bindings specified
 // on the graph clause.
 func tripleToRow(t *triple.Triple, cls *semantic.GraphClause) (table.Row, error) {
 	r, s, p, o := make(table.Row), t.Subject(), t.Predicate(), t.Object()

--- a/bql/planner/data_access_test.go
+++ b/bql/planner/data_access_test.go
@@ -543,15 +543,19 @@ func TestDataAccessTripleToRowObjectBindings(t *testing.T) {
 		{
 			t: n.String() + "\t" + pImmutable.String() + "\t" + pImmutable.String(),
 			cls: &semantic.GraphClause{
-				OBinding:   "?o",
-				OAlias:     "?alias",
-				OTypeAlias: "?type",
-				OIDAlias:   "?id",
+				OBinding:       "?o",
+				OAlias:         "?alias",
+				OTypeAlias:     "?type",
+				OIDAlias:       "?id",
+				OAnchorBinding: "?anchorBinding",
+				OAnchorAlias:   "?anchorAlias",
 			},
-			oBinding:   &table.Cell{P: pImmutable},
-			oAlias:     &table.Cell{P: pImmutable},
-			oTypeAlias: &table.Cell{},
-			oIDAlias:   &table.Cell{S: table.CellString(string(pImmutable.ID()))},
+			oBinding:       &table.Cell{P: pImmutable},
+			oAlias:         &table.Cell{P: pImmutable},
+			oTypeAlias:     &table.Cell{},
+			oIDAlias:       &table.Cell{S: table.CellString(string(pImmutable.ID()))},
+			oAnchorBinding: &table.Cell{},
+			oAnchorAlias:   &table.Cell{},
 		},
 	}
 

--- a/bql/planner/data_access_test.go
+++ b/bql/planner/data_access_test.go
@@ -482,11 +482,12 @@ func TestDataAccessTripleToRowPredicateBindings(t *testing.T) {
 }
 
 func TestDataAccessTripleToRowObjectBindings(t *testing.T) {
-	n, p, _ := testNodeTemporalPredicateLiteral(t)
-	ta, err := p.TimeAnchor()
+	n, pTemporal, l := testNodeTemporalPredicateLiteral(t)
+	ta, err := pTemporal.TimeAnchor()
 	if err != nil {
 		t.Fatal(err)
 	}
+	_, pImmutable, _ := testNodePredicateLiteral(t)
 
 	testTable := []struct {
 		t              string
@@ -499,7 +500,7 @@ func TestDataAccessTripleToRowObjectBindings(t *testing.T) {
 		oAnchorAlias   *table.Cell
 	}{
 		{
-			t: n.String() + "\t" + p.String() + "\t" + n.String(),
+			t: n.String() + "\t" + pTemporal.String() + "\t" + n.String(),
 			cls: &semantic.GraphClause{
 				OBinding:   "?o",
 				OAlias:     "?alias",
@@ -512,19 +513,45 @@ func TestDataAccessTripleToRowObjectBindings(t *testing.T) {
 			oIDAlias:   &table.Cell{S: table.CellString(n.ID().String())},
 		},
 		{
-			t: n.String() + "\t" + p.String() + "\t" + p.String(),
+			t: n.String() + "\t" + pTemporal.String() + "\t" + pTemporal.String(),
 			cls: &semantic.GraphClause{
 				OBinding:       "?o",
 				OAlias:         "?alias",
+				OTypeAlias:     "?type",
 				OIDAlias:       "?id",
 				OAnchorBinding: "?anchorBinding",
 				OAnchorAlias:   "?anchorAlias",
 			},
-			oBinding:       &table.Cell{P: p},
-			oAlias:         &table.Cell{P: p},
-			oIDAlias:       &table.Cell{S: table.CellString(string(p.ID()))},
+			oBinding:       &table.Cell{P: pTemporal},
+			oAlias:         &table.Cell{P: pTemporal},
+			oTypeAlias:     &table.Cell{},
+			oIDAlias:       &table.Cell{S: table.CellString(string(pTemporal.ID()))},
 			oAnchorBinding: &table.Cell{T: ta},
 			oAnchorAlias:   &table.Cell{T: ta},
+		},
+		{
+			t: n.String() + "\t" + pTemporal.String() + "\t" + l.String(),
+			cls: &semantic.GraphClause{
+				OBinding:   "?o",
+				OAlias:     "?alias",
+				OTypeAlias: "?type",
+			},
+			oBinding:   &table.Cell{L: l},
+			oAlias:     &table.Cell{L: l},
+			oTypeAlias: &table.Cell{},
+		},
+		{
+			t: n.String() + "\t" + pImmutable.String() + "\t" + pImmutable.String(),
+			cls: &semantic.GraphClause{
+				OBinding:   "?o",
+				OAlias:     "?alias",
+				OTypeAlias: "?type",
+				OIDAlias:   "?id",
+			},
+			oBinding:   &table.Cell{P: pImmutable},
+			oAlias:     &table.Cell{P: pImmutable},
+			oTypeAlias: &table.Cell{},
+			oIDAlias:   &table.Cell{S: table.CellString(string(pImmutable.ID()))},
 		},
 	}
 

--- a/bql/planner/data_access_test.go
+++ b/bql/planner/data_access_test.go
@@ -463,19 +463,20 @@ func TestDataAccessTripleToRowPredicateBindings(t *testing.T) {
 
 func TestDataAccessTripleToRowObjectBindings(t *testing.T) {
 	n, p, _ := testNodeTemporalPredicateLiteral(t)
-	ts, err := p.TimeAnchor()
+	ta, err := p.TimeAnchor()
 	if err != nil {
 		t.Fatal(err)
 	}
+
 	testTable := []struct {
-		t   string
-		cls *semantic.GraphClause
-		bc  *table.Cell
-		ac  *table.Cell
-		tc  *table.Cell
-		ic  *table.Cell
-		tsc *table.Cell
-		atc *table.Cell
+		t              string
+		cls            *semantic.GraphClause
+		oBinding       *table.Cell
+		oAlias         *table.Cell
+		oTypeAlias     *table.Cell
+		oIDAlias       *table.Cell
+		oAnchorBinding *table.Cell
+		oAnchorAlias   *table.Cell
 	}{
 		{
 			t: n.String() + "\t" + p.String() + "\t" + n.String(),
@@ -485,10 +486,10 @@ func TestDataAccessTripleToRowObjectBindings(t *testing.T) {
 				OTypeAlias: "?type",
 				OIDAlias:   "?id",
 			},
-			bc: &table.Cell{N: n},
-			ac: &table.Cell{N: n},
-			tc: &table.Cell{S: table.CellString(n.Type().String())},
-			ic: &table.Cell{S: table.CellString(n.ID().String())},
+			oBinding:   &table.Cell{N: n},
+			oAlias:     &table.Cell{N: n},
+			oTypeAlias: &table.Cell{S: table.CellString(n.Type().String())},
+			oIDAlias:   &table.Cell{S: table.CellString(n.ID().String())},
 		},
 		{
 			t: n.String() + "\t" + p.String() + "\t" + p.String(),
@@ -496,42 +497,36 @@ func TestDataAccessTripleToRowObjectBindings(t *testing.T) {
 				OBinding:       "?o",
 				OAlias:         "?alias",
 				OIDAlias:       "?id",
-				OAnchorBinding: "?ts",
-				OAnchorAlias:   "?tsa",
+				OAnchorBinding: "?anchorBinding",
+				OAnchorAlias:   "?anchorAlias",
 			},
-			bc:  &table.Cell{P: p},
-			ac:  &table.Cell{P: p},
-			ic:  &table.Cell{S: table.CellString(string(p.ID()))},
-			tsc: &table.Cell{T: ts},
-			atc: &table.Cell{T: ts},
+			oBinding:       &table.Cell{P: p},
+			oAlias:         &table.Cell{P: p},
+			oIDAlias:       &table.Cell{S: table.CellString(string(p.ID()))},
+			oAnchorBinding: &table.Cell{T: ta},
+			oAnchorAlias:   &table.Cell{T: ta},
 		},
 	}
+
 	for _, entry := range testTable {
+		// Setup for test:
 		tpl, err := triple.Parse(entry.t, literal.DefaultBuilder())
 		if err != nil {
-			t.Errorf("triple.Parse failed to parse valid triple %q with error %v", entry.t, err)
+			t.Fatalf(`triple.Parse failed to parse valid triple "%s" with error: %v`, entry.t, err)
 		}
+
+		// Actual test:
 		r, err := tripleToRow(tpl, entry.cls)
 		if err != nil {
-			t.Errorf("tripleToRow for triple %q and clasuse %v, failed with error %v", tpl, entry.cls, err)
+			t.Errorf(`tripleToRow for triple "%s" and clause %q failed with error: %v`, tpl, entry.cls, err)
+			continue
 		}
-		if got, want := r["?o"], entry.bc; !reflect.DeepEqual(got, want) {
-			t.Errorf("tripleToRow failed to return right value for binding \"?o\"; got %q, want %q", got, want)
-		}
-		if got, want := r["?alias"], entry.ac; !reflect.DeepEqual(got, want) {
-			t.Errorf("tripleToRow failed to return right value for binding alias \"?alias\"; got %q, want %q", got, want)
-		}
-		if got, want := r["?id"], entry.ic; !reflect.DeepEqual(got, want) {
-			t.Errorf("tripleToRow failed to return right value for binding \"?id\"; got %q, want %q", got, want)
-		}
-		if got, want := r["?type"], entry.tc; entry.tc != nil && !reflect.DeepEqual(got, want) {
-			t.Errorf("tripleToRow failed to return right value for binding \"?type\"; got %q, want %q", got, want)
-		}
-		if got, want := r["?ts"], entry.tsc; entry.tsc != nil && !reflect.DeepEqual(got, want) {
-			t.Errorf("tripleToRow failed to return right value for binding \"?ts\"; got %q, want %q", got, want)
-		}
-		if got, want := r["?tsa"], entry.atc; entry.atc != nil && !reflect.DeepEqual(got, want) {
-			t.Errorf("tripleToRow failed to return right value for binding \"?tsa\"; got %q, want %q", got, want)
+		bindings := []string{"?o", "?alias", "?type", "?id", "?anchorBinding", "?anchorAlias"}
+		entryCells := []*table.Cell{entry.oBinding, entry.oAlias, entry.oTypeAlias, entry.oIDAlias, entry.oAnchorBinding, entry.oAnchorAlias}
+		for i, binding := range bindings {
+			if got, want := r[binding], entryCells[i]; !reflect.DeepEqual(got, want) {
+				t.Errorf(`tripleToRow(%q) = "%s"; want "%s"`, binding, got, want)
+			}
 		}
 	}
 }

--- a/bql/planner/data_access_test.go
+++ b/bql/planner/data_access_test.go
@@ -311,48 +311,52 @@ func TestDataAccessBasicBindings(t *testing.T) {
 		PBinding: "?p",
 		OBinding: "?o",
 	}
+
 	testTable := []struct {
-		t  string
-		sc *table.Cell
-		pc *table.Cell
-		oc *table.Cell
+		t        string
+		sBinding *table.Cell
+		pBinding *table.Cell
+		oBinding *table.Cell
 	}{
 		{
-			t:  n.String() + "\t" + p.String() + "\t" + n.String(),
-			sc: &table.Cell{N: n},
-			pc: &table.Cell{P: p},
-			oc: &table.Cell{N: n},
+			t:        n.String() + "\t" + p.String() + "\t" + n.String(),
+			sBinding: &table.Cell{N: n},
+			pBinding: &table.Cell{P: p},
+			oBinding: &table.Cell{N: n},
 		},
 		{
-			t:  n.String() + "\t" + p.String() + "\t" + p.String(),
-			sc: &table.Cell{N: n},
-			pc: &table.Cell{P: p},
-			oc: &table.Cell{P: p},
+			t:        n.String() + "\t" + p.String() + "\t" + p.String(),
+			sBinding: &table.Cell{N: n},
+			pBinding: &table.Cell{P: p},
+			oBinding: &table.Cell{P: p},
 		},
 		{
-			t:  n.String() + "\t" + p.String() + "\t" + l.String(),
-			sc: &table.Cell{N: n},
-			pc: &table.Cell{P: p},
-			oc: &table.Cell{L: l},
+			t:        n.String() + "\t" + p.String() + "\t" + l.String(),
+			sBinding: &table.Cell{N: n},
+			pBinding: &table.Cell{P: p},
+			oBinding: &table.Cell{L: l},
 		},
 	}
+
 	for _, entry := range testTable {
+		// Setup for test:
 		tpl, err := triple.Parse(entry.t, literal.DefaultBuilder())
 		if err != nil {
-			t.Errorf("triple.Parse failed to parse valid triple %q with error %v", entry.t, err)
+			t.Fatalf(`triple.Parse failed to parse valid triple "%s" with error: %v`, entry.t, err)
 		}
+
+		// Actual test:
 		r, err := tripleToRow(tpl, cls)
 		if err != nil {
-			t.Errorf("tripleToRow for triple %q and clasuse %v, failed with error %v", tpl, cls, err)
+			t.Errorf(`tripleToRow for triple "%s" and clause %q failed with error: %v`, tpl, cls, err)
+			continue
 		}
-		if got, want := r["?s"], entry.sc; !reflect.DeepEqual(got, want) {
-			t.Errorf("tripleToRow failed to return right value for binding \"?s\"; got %q, want %q", got, want)
-		}
-		if got, want := r["?p"], entry.pc; !reflect.DeepEqual(got, want) {
-			t.Errorf("tripleToRow failed to return right value for binding \"?p\"; got %q, want %q", got, want)
-		}
-		if got, want := r["?o"], entry.oc; !reflect.DeepEqual(got, want) {
-			t.Errorf("tripleToRow failed to return right value for binding \"?o\"; got %q, want %q", got, want)
+		bindings := []string{"?s", "?p", "?o"}
+		entryCells := []*table.Cell{entry.sBinding, entry.pBinding, entry.oBinding}
+		for i, binding := range bindings {
+			if got, want := r[binding], entryCells[i]; !reflect.DeepEqual(got, want) {
+				t.Errorf(`tripleToRow(%q) = "%s"; want "%s"`, binding, got, want)
+			}
 		}
 	}
 }

--- a/bql/planner/data_access_test.go
+++ b/bql/planner/data_access_test.go
@@ -410,11 +410,12 @@ func TestDataAccessTripleToRowSubjectBindings(t *testing.T) {
 }
 
 func TestDataAccessTripleToRowPredicateBindings(t *testing.T) {
-	n, p, _ := testNodeTemporalPredicateLiteral(t)
-	ta, err := p.TimeAnchor()
+	n, pTemporal, _ := testNodeTemporalPredicateLiteral(t)
+	ta, err := pTemporal.TimeAnchor()
 	if err != nil {
 		t.Fatal(err)
 	}
+	_, pImmutable, _ := testNodePredicateLiteral(t)
 
 	testTable := []struct {
 		t              string
@@ -426,7 +427,7 @@ func TestDataAccessTripleToRowPredicateBindings(t *testing.T) {
 		pAnchorAlias   *table.Cell
 	}{
 		{
-			t: n.String() + "\t" + p.String() + "\t" + n.String(),
+			t: n.String() + "\t" + pTemporal.String() + "\t" + n.String(),
 			cls: &semantic.GraphClause{
 				PBinding:       "?p",
 				PAlias:         "?alias",
@@ -434,11 +435,26 @@ func TestDataAccessTripleToRowPredicateBindings(t *testing.T) {
 				PAnchorBinding: "?anchorBinding",
 				PAnchorAlias:   "?anchorAlias",
 			},
-			pBinding:       &table.Cell{P: p},
-			pAlias:         &table.Cell{P: p},
-			pIDAlias:       &table.Cell{S: table.CellString(string(p.ID()))},
+			pBinding:       &table.Cell{P: pTemporal},
+			pAlias:         &table.Cell{P: pTemporal},
+			pIDAlias:       &table.Cell{S: table.CellString(string(pTemporal.ID()))},
 			pAnchorBinding: &table.Cell{T: ta},
 			pAnchorAlias:   &table.Cell{T: ta},
+		},
+		{
+			t: n.String() + "\t" + pImmutable.String() + "\t" + n.String(),
+			cls: &semantic.GraphClause{
+				PBinding:       "?p",
+				PAlias:         "?alias",
+				PIDAlias:       "?id",
+				PAnchorBinding: "?anchorBinding",
+				PAnchorAlias:   "?anchorAlias",
+			},
+			pBinding:       &table.Cell{P: pImmutable},
+			pAlias:         &table.Cell{P: pImmutable},
+			pIDAlias:       &table.Cell{S: table.CellString(string(pImmutable.ID()))},
+			pAnchorBinding: &table.Cell{},
+			pAnchorAlias:   &table.Cell{},
 		},
 	}
 

--- a/bql/planner/planner_test.go
+++ b/bql/planner/planner_test.go
@@ -689,6 +689,15 @@ func TestPlannerQuery(t *testing.T) {
 			nBindings: 3,
 			nRows:     4,
 		},
+		{
+			q: `SELECT ?s, ?time, ?o
+				FROM ?test
+				WHERE {
+					?s "parent_of"@[?time] ?o
+				};`,
+			nBindings: 3,
+			nRows:     0,
+		},
 	}
 
 	s, ctx := memory.NewStore(), context.Background()

--- a/bql/planner/planner_test.go
+++ b/bql/planner/planner_test.go
@@ -680,6 +680,15 @@ func TestPlannerQuery(t *testing.T) {
 			nBindings: 2,
 			nRows:     2,
 		},
+		{
+			q: `SELECT ?p, ?time, ?o
+				FROM ?test
+				WHERE {
+					/u<peter> ?p AT ?time ?o
+				};`,
+			nBindings: 3,
+			nRows:     4,
+		},
 	}
 
 	s, ctx := memory.NewStore(), context.Background()

--- a/bql/planner/planner_test.go
+++ b/bql/planner/planner_test.go
@@ -708,6 +708,15 @@ func TestPlannerQuery(t *testing.T) {
 			nBindings: 3,
 			nRows:     5,
 		},
+		{
+			q: `SELECT ?p, ?time_o
+				FROM ?test
+				WHERE {
+					/l<barcelona> ?p "immutable_predicate"@[?time_o]
+				};`,
+			nBindings: 2,
+			nRows:     1,
+		},
 	}
 
 	s, ctx := memory.NewStore(), context.Background()

--- a/bql/planner/planner_test.go
+++ b/bql/planner/planner_test.go
@@ -47,6 +47,7 @@ const (
 		/l<barcelona> "predicate"@[] "turned"@[2016-02-01T00:00:00-08:00]
 		/l<barcelona> "predicate"@[] "turned"@[2016-03-01T00:00:00-08:00]
 		/l<barcelona> "predicate"@[] "turned"@[2016-04-01T00:00:00-08:00]
+		/l<barcelona> "predicate"@[] "immutable_predicate"@[]
 		/u<alice> "height_cm"@[] "174"^^type:int64
 		/u<alice> "tag"@[] "abc"^^type:text
 		/u<bob> "height_cm"@[] "151"^^type:int64
@@ -678,7 +679,7 @@ func TestPlannerQuery(t *testing.T) {
 				}
 				HAVING (?s = /u<joe>) OR (?s = /l<barcelona>) OR (?s = /u<alice>);`,
 			nBindings: 2,
-			nRows:     8,
+			nRows:     9,
 		},
 		{
 			q: `SELECT ?p, ?time, ?o

--- a/bql/planner/planner_test.go
+++ b/bql/planner/planner_test.go
@@ -678,7 +678,7 @@ func TestPlannerQuery(t *testing.T) {
 				}
 				HAVING (?s = /u<joe>) OR (?s = /l<barcelona>) OR (?s = /u<alice>);`,
 			nBindings: 2,
-			nRows:     2,
+			nRows:     8,
 		},
 		{
 			q: `SELECT ?p, ?time, ?o

--- a/bql/planner/planner_test.go
+++ b/bql/planner/planner_test.go
@@ -687,7 +687,7 @@ func TestPlannerQuery(t *testing.T) {
 					/u<peter> ?p AT ?time ?o
 				};`,
 			nBindings: 3,
-			nRows:     4,
+			nRows:     6,
 		},
 		{
 			q: `SELECT ?s, ?time, ?o

--- a/bql/planner/planner_test.go
+++ b/bql/planner/planner_test.go
@@ -696,7 +696,7 @@ func TestPlannerQuery(t *testing.T) {
 					?s "parent_of"@[?time] ?o
 				};`,
 			nBindings: 3,
-			nRows:     0,
+			nRows:     4,
 		},
 	}
 

--- a/bql/planner/planner_test.go
+++ b/bql/planner/planner_test.go
@@ -670,6 +670,16 @@ func TestPlannerQuery(t *testing.T) {
 			nBindings: 3,
 			nRows:     4,
 		},
+		{
+			q: `SELECT ?o, ?o_type
+				FROM ?test
+				WHERE {
+					?s ?p ?o TYPE ?o_type
+				}
+				HAVING (?s = /u<joe>) OR (?s = /l<barcelona>) OR (?s = /u<alice>);`,
+			nBindings: 2,
+			nRows:     2,
+		},
 	}
 
 	s, ctx := memory.NewStore(), context.Background()

--- a/bql/planner/planner_test.go
+++ b/bql/planner/planner_test.go
@@ -699,6 +699,15 @@ func TestPlannerQuery(t *testing.T) {
 			nBindings: 3,
 			nRows:     4,
 		},
+		{
+			q: `SELECT ?p, ?o, ?time_o
+				FROM ?test
+				WHERE {
+					/l<barcelona> ?p ?o AT ?time_o
+				};`,
+			nBindings: 3,
+			nRows:     5,
+		},
 	}
 
 	s, ctx := memory.NewStore(), context.Background()


### PR DESCRIPTION
We have two types of time bindings: `AT` bindings (using the `AT` keyword) and time anchor bindings (eg: `"bought"@[?time]`). In both cases, when extracting the time anchor from an immutable predicate like `"parent_of"@[]` we expect to see `<NULL>` in the query result. This PR comes to enforce this expected behavior.

To illustrate for the case of the `AT` binding, given the query below:

```
SELECT ?p, ?time, ?o
FROM ?test
WHERE {
	/u<peter> ?p AT ?time ?o
};
```

In a `?test` graph having only the two following triples:

```
/u<peter> "parent_of"@[] /u<eve>
/u<peter> "bought"@[2016-01-01T00:00:00-08:00] /c<mini>
```

We expect as result:

```
Result:
?p					?time				?o
"parent_of"@[]				<NULL>				/u<eve>
"bought"@[2016-01-01T00:00:00-08:00]	2016-01-01T00:00:00-08:00	/c<mini>
```

Note how the `?time` binding is shown as `<NULL>` in the case of the immutable predicate `"parent_of"@[]`. For time anchor bindings such as `"parent_of"@[?time]` the expected behavior enforced by this PR is the same.

Note that this shall apply if we are extracting time bindings from objects that are immutable predicates too, in a reification scenario like in the clause below for example:

```
/_<BUID> "_predicate"@[] ?obj AT ?time_obj
```

On which, in the case `?obj` is an immutable predicate as `"parent_of"@[]` we also expect `?time_obj` to appear as `<NULL>` in the query result.

In a very similar way, with`TYPE` bindings for non-node objects the expected behavior is analogous. In the case the object is a predicate or a literal we will not succeed in extracting the node type and so we also expect, for now, a `<NULL>` in the query result. To illustrate, given a query like:

```
SELECT ?o, ?o_type
FROM ?test
WHERE {
	?s ?p ?o TYPE ?o_type
};
```

In a `?test` graph with only the following triples:

```
/u<alice> "height_cm"@[] "174"^^type:int64
/u<peter> "parent_of"@[] /u<eve>
```

We expect as result:

```
Result:
?o			?o_type
"174"^^type:int64	<NULL>
/u<eve>			/u
```

Note how the extracted `?o_type` is `<NULL>` for the literal object `"174"^^type:int64`. This PR, then, also comes to enforce this behavior for the `TYPE` keyword.