### PR TITLE
Adjust behavior of AT and time anchor bindings for immutable predicates

### DIFF
--- a/bql/planner/data_access.go
+++ b/bql/planner/data_access.go
@@ -716,12 +716,15 @@ func tripleToRow(t *triple.Triple, cls *semantic.GraphClause) (table.Row, error)
 				return nil, &skippableError{"cls.OAnchorAlias in non-optional clause", err}
 			}
 			c = &table.Cell{}
+		} else if p.Type() != predicate.Temporal {
+			// in the case of AT bindings for objects that are immutable predicates we provide an empty Cell as we want <NULL> to appear in the query result.
+			c = &table.Cell{}
 		} else {
-			ts, err := p.TimeAnchor()
+			t, err := p.TimeAnchor()
 			if err != nil {
-				return nil, err
+				return nil, fmt.Errorf("failed to retrieve the time anchor value for predicate %q in binding %q with error: %v", p, cls.OAnchorAlias, err)
 			}
-			c = &table.Cell{T: ts}
+			c = &table.Cell{T: t}
 		}
 		r[cls.OAnchorAlias] = c
 		if !validBinding(cls.OAnchorAlias, c) {

--- a/bql/planner/data_access.go
+++ b/bql/planner/data_access.go
@@ -611,15 +611,17 @@ func tripleToRow(t *triple.Triple, cls *semantic.GraphClause) (table.Row, error)
 		}
 	}
 	if cls.PAnchorAlias != "" {
+		var c *table.Cell
 		if p.Type() != predicate.Temporal {
-			// in the case of AT binding for an immutable predicate we just want to skip this triple and proceed to the next one, not returning any errors.
-			return nil, nil
+			// in the case of AT bindings for immutable predicates we provide an empty Cell as we want <NULL> to appear in the query result.
+			c = &table.Cell{}
+		} else {
+			t, err := p.TimeAnchor()
+			if err != nil {
+				return nil, fmt.Errorf("failed to retrieve the time anchor value for predicate %q in binding %q with error: %v", p, cls.PAnchorAlias, err)
+			}
+			c = &table.Cell{T: t}
 		}
-		t, err := p.TimeAnchor()
-		if err != nil {
-			return nil, fmt.Errorf("failed to retrieve the time anchor value for predicate %q in binding %q with error %v", p, cls.PAnchorAlias, err)
-		}
-		c := &table.Cell{T: t}
 		r[cls.PAnchorAlias] = c
 		if !validBinding(cls.PAnchorAlias, c) {
 			return nil, nil

--- a/bql/planner/data_access.go
+++ b/bql/planner/data_access.go
@@ -524,8 +524,8 @@ func objectToCell(o *triple.Object) (*table.Cell, error) {
 	return nil, fmt.Errorf("unknown object type in object %q", o)
 }
 
-// tripleToRow converts a triple into a row using the binndings specidfied
-// on the graph clause.
+// tripleToRow converts a triple into a row using the bindings specified
+// in the graph clause.
 func tripleToRow(t *triple.Triple, cls *semantic.GraphClause) (table.Row, error) {
 	r, s, p, o := make(table.Row), t.Subject(), t.Predicate(), t.Object()
 

--- a/bql/planner/data_access.go
+++ b/bql/planner/data_access.go
@@ -598,7 +598,10 @@ func tripleToRow(t *triple.Triple, cls *semantic.GraphClause) (table.Row, error)
 	if cls.PAnchorBinding != "" {
 		var c *table.Cell
 		if p.Type() != predicate.Temporal {
-			// in the case of time anchor bindings (eg: "bought"@[?time]) for immutable predicates we provide an empty Cell as we want <NULL> to appear in the query result.
+			// In the case of time anchor bindings (eg: "bought"@[?time]) for immutable predicates we skip the triple if the clause is not optional, otherwise we provide an empty Cell as we want <NULL> to appear in the query result.
+			if !cls.Optional {
+				return nil, &skippableError{"cls.PAnchorBinding in non-optional clause", fmt.Errorf("tried to extract a time anchor binding from an immutable predicate")}
+			}
 			c = &table.Cell{}
 		} else {
 			t, err := p.TimeAnchor()
@@ -615,7 +618,10 @@ func tripleToRow(t *triple.Triple, cls *semantic.GraphClause) (table.Row, error)
 	if cls.PAnchorAlias != "" {
 		var c *table.Cell
 		if p.Type() != predicate.Temporal {
-			// in the case of AT bindings for immutable predicates we provide an empty Cell as we want <NULL> to appear in the query result.
+			// In the case of AT bindings for immutable predicates we skip the triple if the clause is not optional, otherwise we provide an empty Cell as we want <NULL> to appear in the query result.
+			if !cls.Optional {
+				return nil, &skippableError{"cls.PAnchorAlias in non-optional clause", fmt.Errorf("tried to extract an AT binding from an immutable predicate")}
+			}
 			c = &table.Cell{}
 		} else {
 			t, err := p.TimeAnchor()
@@ -696,7 +702,10 @@ func tripleToRow(t *triple.Triple, cls *semantic.GraphClause) (table.Row, error)
 			}
 			c = &table.Cell{}
 		} else if p.Type() != predicate.Temporal {
-			// in the case of time anchor bindings for objects that are immutable predicates we provide an empty Cell as we want <NULL> to appear in the query result.
+			// In the case of time anchor bindings for objects that are immutable predicates we skip the triple if the clause is not optional, otherwise we provide an empty Cell as we want <NULL> to appear in the query result.
+			if !cls.Optional {
+				return nil, &skippableError{"cls.OAnchorBinding in non-optional clause", fmt.Errorf("tried to extract a time anchor binding from an object that is an immutable predicate")}
+			}
 			c = &table.Cell{}
 		} else {
 			t, err := p.TimeAnchor()
@@ -720,7 +729,10 @@ func tripleToRow(t *triple.Triple, cls *semantic.GraphClause) (table.Row, error)
 			}
 			c = &table.Cell{}
 		} else if p.Type() != predicate.Temporal {
-			// in the case of AT bindings for objects that are immutable predicates we provide an empty Cell as we want <NULL> to appear in the query result.
+			// In the case of AT bindings for objects that are immutable predicates we skip the triple if the clause is not optional, otherwise we provide an empty Cell as we want <NULL> to appear in the query result.
+			if !cls.Optional {
+				return nil, &skippableError{"cls.OAnchorAlias in non-optional clause", fmt.Errorf("tried to extract an AT binding from an object that is an immutable predicate")}
+			}
 			c = &table.Cell{}
 		} else {
 			t, err := p.TimeAnchor()

--- a/bql/planner/data_access_test.go
+++ b/bql/planner/data_access_test.go
@@ -575,13 +575,17 @@ func TestDataAccessTripleToRowObjectBindings(t *testing.T) {
 		{
 			t: fmt.Sprintf("%s\t%s\t%s", n, pImmutable, pImmutable),
 			cls: &semantic.GraphClause{
-				OBinding: "?o",
-				OAlias:   "?alias",
-				OIDAlias: "?id",
+				OBinding:       "?o",
+				OAlias:         "?alias",
+				OIDAlias:       "?id",
+				OAnchorBinding: "?anchorBinding",
+				OAnchorAlias:   "?anchorAlias",
 			},
-			oBinding: &table.Cell{P: pImmutable},
-			oAlias:   &table.Cell{P: pImmutable},
-			oIDAlias: &table.Cell{S: table.CellString(string(pImmutable.ID()))},
+			oBinding:       &table.Cell{P: pImmutable},
+			oAlias:         &table.Cell{P: pImmutable},
+			oIDAlias:       &table.Cell{S: table.CellString(string(pImmutable.ID()))},
+			oAnchorBinding: &table.Cell{},
+			oAnchorAlias:   &table.Cell{},
 		},
 	}
 

--- a/bql/planner/data_access_test.go
+++ b/bql/planner/data_access_test.go
@@ -443,15 +443,21 @@ func TestDataAccessTripleToRowPredicateBindings(t *testing.T) {
 		{
 			t: fmt.Sprintf("%s\t%s\t%s", n, pImmutable, n),
 			cls: &semantic.GraphClause{
-				PBinding:       "?p",
-				PAlias:         "?alias",
-				PIDAlias:       "?id",
+				PBinding: "?p",
+				PAlias:   "?alias",
+				PIDAlias: "?id",
+			},
+			pBinding: &table.Cell{P: pImmutable},
+			pAlias:   &table.Cell{P: pImmutable},
+			pIDAlias: &table.Cell{S: table.CellString(string(pImmutable.ID()))},
+		},
+		{
+			t: fmt.Sprintf("%s\t%s\t%s", n, pImmutable, n),
+			cls: &semantic.GraphClause{
 				PAnchorBinding: "?anchorBinding",
 				PAnchorAlias:   "?anchorAlias",
+				Optional:       true,
 			},
-			pBinding:       &table.Cell{P: pImmutable},
-			pAlias:         &table.Cell{P: pImmutable},
-			pIDAlias:       &table.Cell{S: table.CellString(string(pImmutable.ID()))},
 			pAnchorBinding: &table.Cell{},
 			pAnchorAlias:   &table.Cell{},
 		},
@@ -475,6 +481,42 @@ func TestDataAccessTripleToRowPredicateBindings(t *testing.T) {
 			if got, want := r[binding], entryCells[i]; !reflect.DeepEqual(got, want) {
 				t.Errorf(`tripleToRow(%q) = "%s", _; want "%s", _`, binding, got, want)
 			}
+		}
+	}
+}
+
+func TestDataAccessTripleToRowPredicateBindingsError(t *testing.T) {
+	n, pImmutable, _ := testNodePredicateLiteral(t)
+
+	testTable := []struct {
+		t   string
+		cls *semantic.GraphClause
+	}{
+		{
+			t: fmt.Sprintf("%s\t%s\t%s", n, pImmutable, n),
+			cls: &semantic.GraphClause{
+				PAnchorBinding: "?anchorBinding",
+			},
+		},
+		{
+			t: fmt.Sprintf("%s\t%s\t%s", n, pImmutable, n),
+			cls: &semantic.GraphClause{
+				PAnchorAlias: "?anchorAlias",
+			},
+		},
+	}
+
+	for _, entry := range testTable {
+		// Setup for test:
+		tpl, err := triple.Parse(entry.t, literal.DefaultBuilder())
+		if err != nil {
+			t.Fatalf(`triple.Parse failed for triple "%s": %v`, entry.t, err)
+		}
+
+		// Actual test:
+		_, err = tripleToRow(tpl, entry.cls)
+		if _, ok := err.(*skippableError); !ok {
+			t.Errorf(`tripleToRow("%s", %q) = _, %v; want _, skippableError`, tpl, entry.cls, err)
 		}
 	}
 }
@@ -575,15 +617,21 @@ func TestDataAccessTripleToRowObjectBindings(t *testing.T) {
 		{
 			t: fmt.Sprintf("%s\t%s\t%s", n, pImmutable, pImmutable),
 			cls: &semantic.GraphClause{
-				OBinding:       "?o",
-				OAlias:         "?alias",
-				OIDAlias:       "?id",
+				OBinding: "?o",
+				OAlias:   "?alias",
+				OIDAlias: "?id",
+			},
+			oBinding: &table.Cell{P: pImmutable},
+			oAlias:   &table.Cell{P: pImmutable},
+			oIDAlias: &table.Cell{S: table.CellString(string(pImmutable.ID()))},
+		},
+		{
+			t: fmt.Sprintf("%s\t%s\t%s", n, pImmutable, pImmutable),
+			cls: &semantic.GraphClause{
 				OAnchorBinding: "?anchorBinding",
 				OAnchorAlias:   "?anchorAlias",
+				Optional:       true,
 			},
-			oBinding:       &table.Cell{P: pImmutable},
-			oAlias:         &table.Cell{P: pImmutable},
-			oIDAlias:       &table.Cell{S: table.CellString(string(pImmutable.ID()))},
 			oAnchorBinding: &table.Cell{},
 			oAnchorAlias:   &table.Cell{},
 		},
@@ -659,6 +707,18 @@ func TestDataAccessTripleToRowObjectBindingsError(t *testing.T) {
 			t: fmt.Sprintf("%s\t%s\t%s", n, pTemporal, pTemporal),
 			cls: &semantic.GraphClause{
 				OTypeAlias: "?type",
+			},
+		},
+		{
+			t: fmt.Sprintf("%s\t%s\t%s", n, pImmutable, pImmutable),
+			cls: &semantic.GraphClause{
+				OAnchorBinding: "?anchorBinding",
+			},
+		},
+		{
+			t: fmt.Sprintf("%s\t%s\t%s", n, pImmutable, pImmutable),
+			cls: &semantic.GraphClause{
+				OAnchorAlias: "?anchorAlias",
 			},
 		},
 	}

--- a/bql/planner/data_access_test.go
+++ b/bql/planner/data_access_test.go
@@ -409,11 +409,12 @@ func TestDataAccessTripleToRowSubjectBindings(t *testing.T) {
 }
 
 func TestDataAccessTripleToRowPredicateBindings(t *testing.T) {
-	n, p, _ := testNodeTemporalPredicateLiteral(t)
-	ta, err := p.TimeAnchor()
+	n, pTemporal, _ := testNodeTemporalPredicateLiteral(t)
+	ta, err := pTemporal.TimeAnchor()
 	if err != nil {
 		t.Fatal(err)
 	}
+	_, pImmutable, _ := testNodePredicateLiteral(t)
 
 	testTable := []struct {
 		t              string
@@ -425,7 +426,7 @@ func TestDataAccessTripleToRowPredicateBindings(t *testing.T) {
 		pAnchorAlias   *table.Cell
 	}{
 		{
-			t: fmt.Sprintf("%s\t%s\t%s", n, p, n),
+			t: fmt.Sprintf("%s\t%s\t%s", n, pTemporal, n),
 			cls: &semantic.GraphClause{
 				PBinding:       "?p",
 				PAlias:         "?alias",
@@ -433,11 +434,26 @@ func TestDataAccessTripleToRowPredicateBindings(t *testing.T) {
 				PAnchorBinding: "?anchorBinding",
 				PAnchorAlias:   "?anchorAlias",
 			},
-			pBinding:       &table.Cell{P: p},
-			pAlias:         &table.Cell{P: p},
-			pIDAlias:       &table.Cell{S: table.CellString(string(p.ID()))},
+			pBinding:       &table.Cell{P: pTemporal},
+			pAlias:         &table.Cell{P: pTemporal},
+			pIDAlias:       &table.Cell{S: table.CellString(string(pTemporal.ID()))},
 			pAnchorBinding: &table.Cell{T: ta},
 			pAnchorAlias:   &table.Cell{T: ta},
+		},
+		{
+			t: fmt.Sprintf("%s\t%s\t%s", n, pImmutable, n),
+			cls: &semantic.GraphClause{
+				PBinding:       "?p",
+				PAlias:         "?alias",
+				PIDAlias:       "?id",
+				PAnchorBinding: "?anchorBinding",
+				PAnchorAlias:   "?anchorAlias",
+			},
+			pBinding:       &table.Cell{P: pImmutable},
+			pAlias:         &table.Cell{P: pImmutable},
+			pIDAlias:       &table.Cell{S: table.CellString(string(pImmutable.ID()))},
+			pAnchorBinding: &table.Cell{},
+			pAnchorAlias:   &table.Cell{},
 		},
 	}
 

--- a/bql/planner/planner_test.go
+++ b/bql/planner/planner_test.go
@@ -47,6 +47,7 @@ const (
 		/l<barcelona> "predicate"@[] "turned"@[2016-02-01T00:00:00-08:00]
 		/l<barcelona> "predicate"@[] "turned"@[2016-03-01T00:00:00-08:00]
 		/l<barcelona> "predicate"@[] "turned"@[2016-04-01T00:00:00-08:00]
+		/l<barcelona> "predicate"@[] "immutable_predicate"@[]
 		/u<alice> "height_cm"@[] "174"^^type:int64
 		/u<alice> "tag"@[] "abc"^^type:text
 		/u<bob> "height_cm"@[] "151"^^type:int64
@@ -674,7 +675,7 @@ func TestPlannerQuery(t *testing.T) {
 				}
 				HAVING (?s = /u<joe>) OR (?s = /l<barcelona>) OR (?s = /u<alice>);`,
 			nBindings: 2,
-			nRows:     8,
+			nRows:     9,
 		},
 		{
 			q: `SELECT ?p, ?time, ?o
@@ -910,7 +911,7 @@ func TestPlannerQuery(t *testing.T) {
 				}
 				HAVING (?s = /l<barcelona>) OR (?s = /u<joe>) OR (?s = /u<bob>);`,
 			nBindings: 3,
-			nRows:     7,
+			nRows:     8,
 		},
 		{
 			q: `SELECT ?s, ?o_time

--- a/bql/planner/planner_test.go
+++ b/bql/planner/planner_test.go
@@ -692,7 +692,7 @@ func TestPlannerQuery(t *testing.T) {
 					?s "parent_of"@[?time] ?o
 				};`,
 			nBindings: 3,
-			nRows:     0,
+			nRows:     4,
 		},
 		{
 			q: `SELECT ?s, ?s_alias, ?s_id, ?s_type

--- a/bql/planner/planner_test.go
+++ b/bql/planner/planner_test.go
@@ -684,13 +684,42 @@ func TestPlannerQuery(t *testing.T) {
 					/u<peter> ?p AT ?time ?o
 				};`,
 			nBindings: 3,
+			nRows:     4,
+		},
+		{
+			q: `SELECT ?p, ?time, ?o
+				FROM ?test
+				WHERE {
+					/u<peter> ?p ?o .
+					OPTIONAL { /u<peter> ?p AT ?time ?o }
+				};`,
+			nBindings: 3,
 			nRows:     6,
 		},
 		{
-			q: `SELECT ?s, ?time, ?o
+			q: `SELECT ?time, ?o
 				FROM ?test
 				WHERE {
-					?s "parent_of"@[?time] ?o
+					/u<joe> "parent_of"@[?time] ?o
+				};`,
+			nBindings: 2,
+			nRows:     0,
+		},
+		{
+			q: `SELECT ?time, ?o
+				FROM ?test
+				WHERE {
+					/u<joe> ?p ?o .
+					OPTIONAL { /u<joe> "parent_of"@[?time] ?o }
+				};`,
+			nBindings: 2,
+			nRows:     2,
+		},
+		{
+			q: `SELECT ?p, ?o, ?time_o
+				FROM ?test
+				WHERE {
+					/l<barcelona> ?p ?o AT ?time_o
 				};`,
 			nBindings: 3,
 			nRows:     4,
@@ -699,7 +728,8 @@ func TestPlannerQuery(t *testing.T) {
 			q: `SELECT ?p, ?o, ?time_o
 				FROM ?test
 				WHERE {
-					/l<barcelona> ?p ?o AT ?time_o
+					/l<barcelona> ?p ?o .
+					OPTIONAL { /l<barcelona> ?p ?o AT ?time_o }
 				};`,
 			nBindings: 3,
 			nRows:     5,
@@ -711,7 +741,17 @@ func TestPlannerQuery(t *testing.T) {
 					/l<barcelona> ?p "immutable_predicate"@[?o_time]
 				};`,
 			nBindings: 2,
-			nRows:     1,
+			nRows:     0,
+		},
+		{
+			q: `SELECT ?p, ?o_time
+				FROM ?test
+				WHERE {
+					/l<barcelona> ?p ?o .
+					OPTIONAL { /l<barcelona> ?p "immutable_predicate"@[?o_time] }
+				};`,
+			nBindings: 2,
+			nRows:     5,
 		},
 		{
 			q: `SELECT ?s, ?s_alias, ?s_id, ?s_type

--- a/bql/planner/planner_test.go
+++ b/bql/planner/planner_test.go
@@ -705,6 +705,15 @@ func TestPlannerQuery(t *testing.T) {
 			nRows:     5,
 		},
 		{
+			q: `SELECT ?p, ?o_time
+				FROM ?test
+				WHERE {
+					/l<barcelona> ?p "immutable_predicate"@[?o_time]
+				};`,
+			nBindings: 2,
+			nRows:     1,
+		},
+		{
 			q: `SELECT ?s, ?s_alias, ?s_id, ?s_type
 				FROM ?test
 				WHERE {

--- a/bql/planner/planner_test.go
+++ b/bql/planner/planner_test.go
@@ -683,7 +683,7 @@ func TestPlannerQuery(t *testing.T) {
 					/u<peter> ?p AT ?time ?o
 				};`,
 			nBindings: 3,
-			nRows:     4,
+			nRows:     6,
 		},
 		{
 			q: `SELECT ?s, ?time, ?o

--- a/bql/planner/planner_test.go
+++ b/bql/planner/planner_test.go
@@ -696,6 +696,15 @@ func TestPlannerQuery(t *testing.T) {
 			nRows:     4,
 		},
 		{
+			q: `SELECT ?p, ?o, ?time_o
+				FROM ?test
+				WHERE {
+					/l<barcelona> ?p ?o AT ?time_o
+				};`,
+			nBindings: 3,
+			nRows:     5,
+		},
+		{
 			q: `SELECT ?s, ?s_alias, ?s_id, ?s_type
 				FROM ?test
 				WHERE {


### PR DESCRIPTION
We have two types of time bindings: `AT` bindings (using the `AT` keyword) and time anchor bindings (eg: `"bought"@[?time]`). 

In both cases, if a graph pattern tries to extract the time anchor from an immutable predicate (like `"parent_of"@[]`) we want to skip this triple and do not show it in the query result (as it does not precisely match the exact graph pattern specified - the pattern required a time anchor). 

Nevertheless, there is one exception: if this graph pattern is marked as `OPTIONAL` we expect to see `<NULL>` in the query result for that time binding.

This PR comes to enforce this behavior.

To illustrate for the case of a `AT` binding, take the query below:

```
SELECT ?p, ?time, ?o
FROM ?test
WHERE {
    /u<peter> ?p AT ?time ?o
};
```

In a `?test` graph having only the two following triples:

```
/u<peter> "parent_of"@[] /u<eve>
/u<peter> "bought"@[2016-01-01T00:00:00-08:00] /c<mini>
```

We expect as result:

```
Result:
?p					?time				?o
"bought"@[2016-01-01T00:00:00-08:00]	2016-01-01T00:00:00-08:00	/c<mini>
```

Note how the triple with the immutable predicate `"parent_of"@[]` was skipped and not shown in the query result as it did not precisely match the exact graph pattern specified in the `WHERE` clause (it had no time anchor to be extracted by the `AT` binding).

On the other hand, if the query was:

```
SELECT ?p, ?time, ?o
FROM ?test
WHERE {
    /u<peter> ?p ?o .
    OPTIONAL { /u<peter> ?p AT ?time ?o }
};
```

We would expect as result:

```
Result:
?p					?time				?o
"parent_of"@[]				<NULL>				/u<eve>
"bought"@[2016-01-01T00:00:00-08:00]	2016-01-01T00:00:00-08:00	/c<mini>
```

Note how the triple with the immutable predicate `"parent_of"@[]` appeared in the query result this time, with the `?time` binding indeed shown as `<NULL>` in the result table. This happened because the clause with the `AT` binding was marked as `OPTIONAL` in the `WHERE` clause.

For time anchor bindings such as `"parent_of"@[?time]` the expected behavior enforced by this PR is analogous, as better detailed by the tests added in `planner_test.go`.

Note that this shall apply if we are extracting time bindings from objects that are immutable predicates too. For example, in a reification scenario like in the clause below (taken from a `WHERE`):

```
/_<blank_node> "_predicate"@[] ?obj AT ?time_obj
```

In the case of `?obj` being an immutable predicate such as `"parent_of"@[]` we also expect the triple to be skipped (as it did not precisely match the exact graph pattern detailed above). On the other hand, if this clause was marked as `OPTIONAL` we would expect `?time_obj` to appear as `<NULL>` in the query result.

For any other doubts on the expected behavior for a given situation refer to the new tests added in `planner_test.go` and `data_access_test.go`.