### PR TITLE
Adjust behavior of TYPE bindings for non-node objects

### DIFF
--- a/bql/planner/data_access_test.go
+++ b/bql/planner/data_access_test.go
@@ -464,11 +464,12 @@ func TestDataAccessTripleToRowPredicateBindings(t *testing.T) {
 }
 
 func TestDataAccessTripleToRowObjectBindings(t *testing.T) {
-	n, p, l := testNodeTemporalPredicateLiteral(t)
-	ta, err := p.TimeAnchor()
+	n, pTemporal, l := testNodeTemporalPredicateLiteral(t)
+	ta, err := pTemporal.TimeAnchor()
 	if err != nil {
 		t.Fatal(err)
 	}
+	_, pImmutable, _ := testNodePredicateLiteral(t)
 
 	testTable := []struct {
 		t              string
@@ -481,7 +482,7 @@ func TestDataAccessTripleToRowObjectBindings(t *testing.T) {
 		oAnchorAlias   *table.Cell
 	}{
 		{
-			t: fmt.Sprintf("%s\t%s\t%s", n, p, n),
+			t: fmt.Sprintf("%s\t%s\t%s", n, pTemporal, n),
 			cls: &semantic.GraphClause{
 				OBinding:   "?o",
 				OAlias:     "?alias",
@@ -494,7 +495,7 @@ func TestDataAccessTripleToRowObjectBindings(t *testing.T) {
 			oIDAlias:   &table.Cell{S: table.CellString(n.ID().String())},
 		},
 		{
-			t: fmt.Sprintf("%s\t%s\t%s", n, p, p),
+			t: fmt.Sprintf("%s\t%s\t%s", n, pTemporal, pTemporal),
 			cls: &semantic.GraphClause{
 				OBinding:       "?o",
 				OAlias:         "?alias",
@@ -502,14 +503,30 @@ func TestDataAccessTripleToRowObjectBindings(t *testing.T) {
 				OAnchorBinding: "?anchorBinding",
 				OAnchorAlias:   "?anchorAlias",
 			},
-			oBinding:       &table.Cell{P: p},
-			oAlias:         &table.Cell{P: p},
-			oIDAlias:       &table.Cell{S: table.CellString(string(p.ID()))},
+			oBinding:       &table.Cell{P: pTemporal},
+			oAlias:         &table.Cell{P: pTemporal},
+			oIDAlias:       &table.Cell{S: table.CellString(string(pTemporal.ID()))},
 			oAnchorBinding: &table.Cell{T: ta},
 			oAnchorAlias:   &table.Cell{T: ta},
 		},
 		{
-			t: fmt.Sprintf("%s\t%s\t%s", n, p, n),
+			t: fmt.Sprintf("%s\t%s\t%s", n, pTemporal, pTemporal),
+			cls: &semantic.GraphClause{
+				OTypeAlias: "?type",
+				Optional:   true,
+			},
+			oTypeAlias: &table.Cell{},
+		},
+		{
+			t: fmt.Sprintf("%s\t%s\t%s", n, pImmutable, pImmutable),
+			cls: &semantic.GraphClause{
+				OTypeAlias: "?type",
+				Optional:   true,
+			},
+			oTypeAlias: &table.Cell{},
+		},
+		{
+			t: fmt.Sprintf("%s\t%s\t%s", n, pTemporal, n),
 			cls: &semantic.GraphClause{
 				OAnchorBinding: "?anchorBinding",
 				OAnchorAlias:   "?anchorAlias",
@@ -519,14 +536,36 @@ func TestDataAccessTripleToRowObjectBindings(t *testing.T) {
 			oAnchorAlias:   &table.Cell{},
 		},
 		{
-			t: fmt.Sprintf("%s\t%s\t%s", n, p, l),
+			t: fmt.Sprintf("%s\t%s\t%s", n, pTemporal, l),
 			cls: &semantic.GraphClause{
+				OTypeAlias:     "?type",
 				OAnchorBinding: "?anchorBinding",
 				OAnchorAlias:   "?anchorAlias",
 				Optional:       true,
 			},
+			oTypeAlias:     &table.Cell{},
 			oAnchorBinding: &table.Cell{},
 			oAnchorAlias:   &table.Cell{},
+		},
+		{
+			t: fmt.Sprintf("%s\t%s\t%s", n, pTemporal, l),
+			cls: &semantic.GraphClause{
+				OBinding: "?o",
+				OAlias:   "?alias",
+			},
+			oBinding: &table.Cell{L: l},
+			oAlias:   &table.Cell{L: l},
+		},
+		{
+			t: fmt.Sprintf("%s\t%s\t%s", n, pImmutable, pImmutable),
+			cls: &semantic.GraphClause{
+				OBinding: "?o",
+				OAlias:   "?alias",
+				OIDAlias: "?id",
+			},
+			oBinding: &table.Cell{P: pImmutable},
+			oAlias:   &table.Cell{P: pImmutable},
+			oIDAlias: &table.Cell{S: table.CellString(string(pImmutable.ID()))},
 		},
 	}
 
@@ -554,6 +593,7 @@ func TestDataAccessTripleToRowObjectBindings(t *testing.T) {
 
 func TestDataAccessTripleToRowObjectBindingsError(t *testing.T) {
 	n, pImmutable, l := testNodePredicateLiteral(t)
+	_, pTemporal, _ := testNodeTemporalPredicateLiteral(t)
 
 	testTable := []struct {
 		t   string
@@ -581,6 +621,24 @@ func TestDataAccessTripleToRowObjectBindingsError(t *testing.T) {
 			t: fmt.Sprintf("%s\t%s\t%s", n, pImmutable, l),
 			cls: &semantic.GraphClause{
 				OAnchorAlias: "?anchorAlias",
+			},
+		},
+		{
+			t: fmt.Sprintf("%s\t%s\t%s", n, pImmutable, l),
+			cls: &semantic.GraphClause{
+				OTypeAlias: "?type",
+			},
+		},
+		{
+			t: fmt.Sprintf("%s\t%s\t%s", n, pImmutable, pImmutable),
+			cls: &semantic.GraphClause{
+				OTypeAlias: "?type",
+			},
+		},
+		{
+			t: fmt.Sprintf("%s\t%s\t%s", n, pTemporal, pTemporal),
+			cls: &semantic.GraphClause{
+				OTypeAlias: "?type",
 			},
 		},
 	}

--- a/bql/planner/planner_test.go
+++ b/bql/planner/planner_test.go
@@ -666,6 +666,17 @@ func TestPlannerQuery(t *testing.T) {
 			nRows:     2,
 		},
 		{
+			q: `SELECT ?o, ?o_type
+				FROM ?test
+				WHERE {
+					?s ?p ?o .
+					OPTIONAL { ?s ?p ?o TYPE ?o_type }
+				}
+				HAVING (?s = /u<joe>) OR (?s = /l<barcelona>) OR (?s = /u<alice>);`,
+			nBindings: 2,
+			nRows:     8,
+		},
+		{
 			q: `SELECT ?p, ?time, ?o
 				FROM ?test
 				WHERE {


### PR DESCRIPTION
In the case of `TYPE` bindings for non-node objects we want to skip this triple and do not show it in the query result as it does not precisely match the exact graph pattern specified (the pattern required a `TYPE` extraction, therefore the object had to be a node).

Nevertheless, there is one exception: if this graph pattern is marked as `OPTIONAL` we expect to see `<NULL>` in the query result for that `TYPE` binding.

This PR, then, comes to enforce this behavior.

In other words, if the object is a predicate or a literal we will not succeed in extracting the node type using the `TYPE` keyword and so we skip the triple if the clause is not optional, otherwise we put a `<NULL>` in the result table (for now, see Issue https://github.com/google/badwolf/issues/124). 

To illustrate, given a query like:

```
SELECT ?o, ?o_type
FROM ?test
WHERE {
    ?s ?p ?o TYPE ?o_type
};
```

In a `?test` graph with only the following triples:

```
/u<alice> "height_cm"@[] "174"^^type:int64
/u<peter> "parent_of"@[] /u<eve>
```

We expect as result:

```
Result:
?o			?o_type
/u<eve>			/u
```

Note how the triple with the non-node object `"174"^^type:int64` was skipped and not shown in the query result as it did not precisely match the exact graph pattern specified in the `WHERE` clause (the `TYPE` extraction made it necessary for the object to be a node).

On the other hand, if the query was:

```
SELECT ?o, ?o_type
FROM ?test
WHERE {
    ?s ?p ?o .
    OPTIONAL { ?s ?p ?o TYPE ?o_type }
};
```

We would expect as result:

```
Result:
?o			?o_type
"174"^^type:int64	<NULL>
/u<eve>			/u
```

Note how the triple with the literal object `"174"^^type:int64` appeared in the query result this time, with the `?o_type` binding indeed shown as `<NULL>` in the result table. This happened because the clause with the `TYPE` binding was marked as `OPTIONAL` in the `WHERE` clause.

For the case on which the objects are predicates (like in a reification scenario) the expected behavior enforced by this PR is analogous, as better detailed by the tests added by this PR in `planner_test.go` and `data_access_test.go`.