### PR TITLE
Allow single AT extraction just after object binding in grammar

### DIFF
--- a/bql/grammar/grammar.go
+++ b/bql/grammar/grammar.go
@@ -773,6 +773,12 @@ func objectBindingExtractClauses() []*Clause {
 				NewSymbol("OBJECT_BINDING_AT"),
 			},
 		},
+		{
+			Elements: []Element{
+				NewTokenType(lexer.ItemAt),
+				NewTokenType(lexer.ItemBinding),
+			},
+		},
 		{},
 	}
 }

--- a/bql/grammar/grammar_test.go
+++ b/bql/grammar/grammar_test.go
@@ -51,6 +51,7 @@ func TestAcceptByParse(t *testing.T) {
 		`select ?a from ?b where{?s ?p ?o as ?x id ?y type ?z};`,
 		`select ?a from ?b where{?s ?p ?o as ?x type ?y id ?z at ?t};`,
 		`select ?a from ?b where{?s ?p ?o as ?x id ?y type ?z at ?t};`,
+		`select ?a from ?b where{?s ?p ?o at ?x};`,
 		// Test more permutations of the keywords "type" and "id".
 		`select ?a from ?b where{?s id ?x type ?y ?p ?o};`,
 		`select ?a from ?b where{?s type ?x id ?y ?p ?o};`,


### PR DESCRIPTION
Allow the user to do a single AT extraction just after an object binding (useful when the object is a predicate, in a reification scenario for example). To illustrate: 

```
SELECT ?p, ?o, ?o_time
FROM ?test
WHERE {
    ?s ?p ?o AT ?o_time
};
```