### PR TITLE
Fix problem with short variable assignment in "data_access.go"

### DIFF
--- a/bql/planner/data_access.go
+++ b/bql/planner/data_access.go
@@ -463,7 +463,8 @@ func shouldIgnoreTriple(t *triple.Triple, cls *semantic.GraphClause) (bool, erro
 func addTriples(ts <-chan *triple.Triple, cls *semantic.GraphClause, tbl *table.Table) error {
 	var err error
 	for t := range ts {
-		ignoreTriple, err := shouldIgnoreTriple(t, cls)
+		var ignoreTriple bool
+		ignoreTriple, err = shouldIgnoreTriple(t, cls)
 		if err != nil {
 			break
 		}
@@ -471,7 +472,8 @@ func addTriples(ts <-chan *triple.Triple, cls *semantic.GraphClause, tbl *table.
 			continue
 		}
 
-		r, err := tripleToRow(t, cls)
+		var r table.Row
+		r, err = tripleToRow(t, cls)
 		if err != nil {
 			break
 		}


### PR DESCRIPTION
Inside `addTriples` in "data_access.go", the short assignment `:=` was recreating a local version of the variable `err`. Then, the value eventually assigned to it was lost as soon as the `for` loop was finished (instead of keeping this value assigned to the `addTriples` scope level `err` variable). This PR comes to fix this problem.