### PR TITLE
Support time binding comparisons inside HAVING clauses

### DIFF
--- a/bql/grammar/grammar.go
+++ b/bql/grammar/grammar.go
@@ -914,12 +914,13 @@ func topHavingClauses() []*Clause {
 	}
 }
 func havingClauses() []*Clause {
-	return []*Clause{{
-		Elements: []Element{
-			NewTokenType(lexer.ItemBinding),
-			NewSymbol("HAVING_CLAUSE_BINARY_COMPOSITE"),
+	return []*Clause{
+		{
+			Elements: []Element{
+				NewTokenType(lexer.ItemBinding),
+				NewSymbol("HAVING_CLAUSE_BINARY_COMPOSITE"),
+			},
 		},
-	},
 		{
 			Elements: []Element{
 				NewTokenType(lexer.ItemNode),
@@ -929,6 +930,12 @@ func havingClauses() []*Clause {
 		{
 			Elements: []Element{
 				NewTokenType(lexer.ItemLiteral),
+				NewSymbol("HAVING_CLAUSE_BINARY_COMPOSITE"),
+			},
+		},
+		{
+			Elements: []Element{
+				NewTokenType(lexer.ItemTime),
 				NewSymbol("HAVING_CLAUSE_BINARY_COMPOSITE"),
 			},
 		},

--- a/bql/grammar/grammar_test.go
+++ b/bql/grammar/grammar_test.go
@@ -92,6 +92,12 @@ func TestAcceptByParse(t *testing.T) {
 		`select ?a from ?b where {?a ?p ?o} having ?b < ?b;`,
 		`select ?a from ?b where {?a ?p ?o} having ?b > ?b;`,
 		`select ?a from ?b where {?a ?p ?o} having ?b = ?b;`,
+		`select ?a from ?b where {?a ?p ?o} having ?b < 2014-03-10T00:00:00-08:00;`,
+		`select ?a from ?b where {?a ?p ?o} having ?b > 2014-03-10T00:00:00-08:00;`,
+		`select ?a from ?b where {?a ?p ?o} having ?b = 2014-03-10T00:00:00-08:00;`,
+		`select ?a from ?b where {?a ?p ?o} having ?b < 2014-03-10T00:00:00-08:00 limit "10"^^type:int64;`,
+		`select ?a from ?b where {?a ?p ?o} having ?b > 2014-03-10T00:00:00-08:00 limit "10"^^type:int64;`,
+		`select ?a from ?b where {?a ?p ?o} having ?b = 2014-03-10T00:00:00-08:00 limit "10"^^type:int64;`,
 		`select ?a from ?b where {?a ?p ?o} having (?b and ?b) or not (?b = ?b);`,
 		`select ?a from ?b where {?a ?p ?o} having ((?b and ?b) or not (?b = ?b));`,
 		// Test global time bounds.

--- a/bql/lexer/lexer_test.go
+++ b/bql/lexer/lexer_test.go
@@ -355,6 +355,39 @@ func TestIndividualTokens(t *testing.T) {
 				{Type: ItemEOF},
 			},
 		},
+		{
+			`HAVING ?time < 2010-03-10T00:00:00-08:00;`,
+			[]Token{
+				{Type: ItemHaving, Text: "HAVING"},
+				{Type: ItemBinding, Text: "?time"},
+				{Type: ItemLT, Text: "<"},
+				{Type: ItemTime, Text: `2010-03-10T00:00:00-08:00`},
+				{Type: ItemSemicolon, Text: ";"},
+				{Type: ItemEOF},
+			},
+		},
+		{
+			`HAVING ?time > 2010-03-10T00:00:00-08:00;`,
+			[]Token{
+				{Type: ItemHaving, Text: "HAVING"},
+				{Type: ItemBinding, Text: "?time"},
+				{Type: ItemGT, Text: ">"},
+				{Type: ItemTime, Text: `2010-03-10T00:00:00-08:00`},
+				{Type: ItemSemicolon, Text: ";"},
+				{Type: ItemEOF},
+			},
+		},
+		{
+			`HAVING ?time = 2010-03-10T00:00:00-08:00;`,
+			[]Token{
+				{Type: ItemHaving, Text: "HAVING"},
+				{Type: ItemBinding, Text: "?time"},
+				{Type: ItemEQ, Text: "="},
+				{Type: ItemTime, Text: `2010-03-10T00:00:00-08:00`},
+				{Type: ItemSemicolon, Text: ";"},
+				{Type: ItemEOF},
+			},
+		},
 	}
 
 	for _, test := range table {
@@ -493,6 +526,56 @@ func TestValidTokenQuery(t *testing.T) {
 				ItemQuery, ItemBinding, ItemBinding, ItemBinding, ItemFrom, ItemBinding,
 				ItemWhere, ItemLBracket, ItemBinding, ItemBinding, ItemBinding,
 				ItemRBracket, ItemBefore, ItemTime, ItemLimit, ItemLiteral, ItemSemicolon, ItemEOF,
+			},
+		},
+		{
+			`select ?s ?p ?time ?o
+			from ?foo
+			where {
+				?s ?p at ?time ?o
+			}
+			having ?time < 2010-03-10T00:00:00-08:00;`,
+			[]TokenType{
+				ItemQuery, ItemBinding, ItemBinding, ItemBinding, ItemBinding,
+				ItemFrom, ItemBinding,
+				ItemWhere, ItemLBracket,
+				ItemBinding, ItemBinding, ItemAt, ItemBinding, ItemBinding,
+				ItemRBracket,
+				ItemHaving, ItemBinding, ItemLT, ItemTime, ItemSemicolon, ItemEOF,
+			},
+		},
+		{
+			`select ?s ?p ?time ?o
+			from ?foo
+			where {
+				?s ?p at ?time ?o
+			}
+			having ?time > 2010-03-10T00:00:00-08:00
+			limit "10"^^type:int64;`,
+			[]TokenType{
+				ItemQuery, ItemBinding, ItemBinding, ItemBinding, ItemBinding,
+				ItemFrom, ItemBinding,
+				ItemWhere, ItemLBracket,
+				ItemBinding, ItemBinding, ItemAt, ItemBinding, ItemBinding,
+				ItemRBracket,
+				ItemHaving, ItemBinding, ItemGT, ItemTime,
+				ItemLimit, ItemLiteral, ItemSemicolon, ItemEOF,
+			},
+		},
+		{
+			`select ?s ?p ?time ?o
+			from ?foo
+			where {
+				?s ?p at ?time ?o
+			}
+			having ?time = 2010-03-10T00:00:00-08:00;`,
+			[]TokenType{
+				ItemQuery, ItemBinding, ItemBinding, ItemBinding, ItemBinding,
+				ItemFrom, ItemBinding,
+				ItemWhere, ItemLBracket,
+				ItemBinding, ItemBinding, ItemAt, ItemBinding, ItemBinding,
+				ItemRBracket,
+				ItemHaving, ItemBinding, ItemEQ, ItemTime, ItemSemicolon, ItemEOF,
 			},
 		},
 	}

--- a/bql/planner/planner_test.go
+++ b/bql/planner/planner_test.go
@@ -756,6 +756,57 @@ func TestPlannerQuery(t *testing.T) {
 			nBindings: 1,
 			nRows:     1,
 		},
+		{
+			q: `SELECT ?p, ?time
+				FROM ?test
+				WHERE {
+					/u<peter> ?p AT ?time ?o
+				}
+				HAVING ?time < 2016-03-01T00:00:00-08:00;`,
+			nBindings: 2,
+			nRows:     2,
+		},
+		{
+			q: `SELECT ?p, ?time
+				FROM ?test
+				WHERE {
+					/u<peter> ?p AT ?time ?o
+				}
+				HAVING ?time < 2016-03-01T00:00:00-08:00
+				LIMIT "1"^^type:int64;`,
+			nBindings: 2,
+			nRows:     1,
+		},
+		{
+			q: `SELECT ?s, ?p, ?p_id, ?time
+				FROM ?test
+				WHERE {
+					?s ?p ID ?p_id AT ?time ?o
+				}
+				HAVING (?p_id < "in"^^type:text) AND (?time > 2016-02-01T00:00:00-08:00);`,
+			nBindings: 4,
+			nRows:     2,
+		},
+		{
+			q: `SELECT ?p, ?time
+				FROM ?test
+				WHERE {
+					/u<peter> ?p AT ?time ?o
+				}
+				HAVING ?time = 2016-01-01T01:00:00-07:00;`,
+			nBindings: 2,
+			nRows:     1,
+		},
+		{
+			q: `SELECT ?p, ?time
+				FROM ?test
+				WHERE {
+					/u<peter> ?p AT ?time ?o
+				}
+				HAVING ?time > 2016-02-01T00:00:00-07:00;`,
+			nBindings: 2,
+			nRows:     3,
+		},
 	}
 
 	s, ctx := memory.NewStore(), context.Background()

--- a/bql/semantic/expression_test.go
+++ b/bql/semantic/expression_test.go
@@ -15,7 +15,6 @@
 package semantic
 
 import (
-	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -191,26 +190,26 @@ func TestBooleanEvaluationNode(t *testing.T) {
 	}
 }
 
-func mustBuildLiteral(textLiteral string) *literal.Literal {
+func mustBuildLiteral(t *testing.T, textLiteral string) *literal.Literal {
 	lit, err := literal.DefaultBuilder().Parse(textLiteral)
 	if err != nil {
-		panic(fmt.Sprintf("could not parse text literal %q, got error: %v", textLiteral, err))
+		t.Fatalf("could not parse text literal %q, got error: %v", textLiteral, err)
 	}
 	return lit
 }
 
-func mustBuildNodeFromStrings(nodeType, nodeID string) *node.Node {
+func mustBuildNodeFromStrings(t *testing.T, nodeType, nodeID string) *node.Node {
 	n, err := node.NewNodeFromStrings(nodeType, nodeID)
 	if err != nil {
-		panic(fmt.Sprintf("could not build node from type %q and ID %q, got error: %v", nodeType, nodeID, err))
+		t.Fatalf("could not build node from type %q and ID %q, got error: %v", nodeType, nodeID, err)
 	}
 	return n
 }
 
-func mustBuildTime(timeLiteral string) *time.Time {
+func mustBuildTime(t *testing.T, timeLiteral string) *time.Time {
 	time, err := time.Parse(time.RFC3339Nano, strings.TrimSpace(timeLiteral))
 	if err != nil {
-		panic(fmt.Sprintf("could not parse time literal %q, got error: %v", timeLiteral, err))
+		t.Fatalf("could not parse time literal %q, got error: %v", timeLiteral, err)
 	}
 	return &time
 }
@@ -426,7 +425,7 @@ func TestEvaluatorEvaluate(t *testing.T) {
 			},
 			r: table.Row{
 				"?foo": &table.Cell{
-					L: mustBuildLiteral(`"abc"^^type:text`),
+					L: mustBuildLiteral(t, `"abc"^^type:text`),
 				},
 			},
 			want: true,
@@ -527,7 +526,7 @@ func TestEvaluatorEvaluate(t *testing.T) {
 				}),
 			},
 			r: table.Row{
-				"?foo": &table.Cell{L: mustBuildLiteral(`"99.0"^^type:float64`)},
+				"?foo": &table.Cell{L: mustBuildLiteral(t, `"99.0"^^type:float64`)},
 			},
 			want: true,
 		},
@@ -547,7 +546,7 @@ func TestEvaluatorEvaluate(t *testing.T) {
 				}),
 			},
 			r: table.Row{
-				"?foo": &table.Cell{L: mustBuildLiteral(`"100"^^type:int64`)},
+				"?foo": &table.Cell{L: mustBuildLiteral(t, `"100"^^type:int64`)},
 			},
 			want: true,
 		},
@@ -567,7 +566,7 @@ func TestEvaluatorEvaluate(t *testing.T) {
 				}),
 			},
 			r: table.Row{
-				"?foo": &table.Cell{L: mustBuildLiteral(`"100"^^type:int64`)},
+				"?foo": &table.Cell{L: mustBuildLiteral(t, `"100"^^type:int64`)},
 			},
 			want: false,
 		},
@@ -587,7 +586,7 @@ func TestEvaluatorEvaluate(t *testing.T) {
 				}),
 			},
 			r: table.Row{
-				"?foo": &table.Cell{N: mustBuildNodeFromStrings("/_", "meowth")},
+				"?foo": &table.Cell{N: mustBuildNodeFromStrings(t, "/_", "meowth")},
 			},
 			want: true,
 		},
@@ -607,7 +606,7 @@ func TestEvaluatorEvaluate(t *testing.T) {
 				}),
 			},
 			r: table.Row{
-				"?o": &table.Cell{N: mustBuildNodeFromStrings("/u", "paul")},
+				"?o": &table.Cell{N: mustBuildNodeFromStrings(t, "/u", "paul")},
 			},
 			want: false,
 		},
@@ -627,7 +626,7 @@ func TestEvaluatorEvaluate(t *testing.T) {
 				}),
 			},
 			r: table.Row{
-				"?o": &table.Cell{L: mustBuildLiteral(`"73"^^type:int64`)},
+				"?o": &table.Cell{L: mustBuildLiteral(t, `"73"^^type:int64`)},
 			},
 			want: false,
 		},
@@ -647,7 +646,7 @@ func TestEvaluatorEvaluate(t *testing.T) {
 				}),
 			},
 			r: table.Row{
-				"?foo": &table.Cell{L: mustBuildLiteral(`"10"^^type:int64`)},
+				"?foo": &table.Cell{L: mustBuildLiteral(t, `"10"^^type:int64`)},
 			},
 			want: false,
 		},
@@ -667,7 +666,7 @@ func TestEvaluatorEvaluate(t *testing.T) {
 				}),
 			},
 			r: table.Row{
-				"?time": &table.Cell{T: mustBuildTime(`2012-02-10T00:00:00-08:00`)},
+				"?time": &table.Cell{T: mustBuildTime(t, `2012-02-10T00:00:00-08:00`)},
 			},
 			want: true,
 		},
@@ -687,7 +686,7 @@ func TestEvaluatorEvaluate(t *testing.T) {
 				}),
 			},
 			r: table.Row{
-				"?time": &table.Cell{T: mustBuildTime(`2012-04-10T00:00:00-08:00`)},
+				"?time": &table.Cell{T: mustBuildTime(t, `2012-04-10T00:00:00-08:00`)},
 			},
 			want: true,
 		},
@@ -707,7 +706,7 @@ func TestEvaluatorEvaluate(t *testing.T) {
 				}),
 			},
 			r: table.Row{
-				"?time": &table.Cell{T: mustBuildTime(`2012-03-10T00:00:00-08:00`)},
+				"?time": &table.Cell{T: mustBuildTime(t, `2012-03-10T00:00:00-08:00`)},
 			},
 			want: true,
 		},
@@ -727,7 +726,7 @@ func TestEvaluatorEvaluate(t *testing.T) {
 				}),
 			},
 			r: table.Row{
-				"?time": &table.Cell{T: mustBuildTime(`2012-02-10T00:00:00-08:00`)},
+				"?time": &table.Cell{T: mustBuildTime(t, `2012-02-10T00:00:00-08:00`)},
 			},
 			want: false,
 		},
@@ -747,7 +746,7 @@ func TestEvaluatorEvaluate(t *testing.T) {
 				}),
 			},
 			r: table.Row{
-				"?time": &table.Cell{T: mustBuildTime(`2012-04-10T00:00:00-08:00`)},
+				"?time": &table.Cell{T: mustBuildTime(t, `2012-04-10T00:00:00-08:00`)},
 			},
 			want: false,
 		},
@@ -767,7 +766,7 @@ func TestEvaluatorEvaluate(t *testing.T) {
 				}),
 			},
 			r: table.Row{
-				"?time": &table.Cell{T: mustBuildTime(`2012-03-10T00:00:00-08:00`)},
+				"?time": &table.Cell{T: mustBuildTime(t, `2012-03-10T00:00:00-08:00`)},
 			},
 			want: false,
 		},
@@ -787,7 +786,7 @@ func TestEvaluatorEvaluate(t *testing.T) {
 				}),
 			},
 			r: table.Row{
-				"?time": &table.Cell{T: mustBuildTime(`2015-03-10T00:00:00-08:00`)},
+				"?time": &table.Cell{T: mustBuildTime(t, `2015-03-10T00:00:00-08:00`)},
 			},
 			want: true,
 		},
@@ -807,7 +806,7 @@ func TestEvaluatorEvaluate(t *testing.T) {
 				}),
 			},
 			r: table.Row{
-				"?time": &table.Cell{T: mustBuildTime(`2015-03-10T00:00:00-08:00`)},
+				"?time": &table.Cell{T: mustBuildTime(t, `2015-03-10T00:00:00-08:00`)},
 			},
 			want: false,
 		},
@@ -827,7 +826,7 @@ func TestEvaluatorEvaluate(t *testing.T) {
 				}),
 			},
 			r: table.Row{
-				"?time": &table.Cell{T: mustBuildTime(`2015-03-10T00:00:00-08:00`)},
+				"?time": &table.Cell{T: mustBuildTime(t, `2015-03-10T00:00:00-08:00`)},
 			},
 			want: true,
 		},
@@ -847,7 +846,7 @@ func TestEvaluatorEvaluate(t *testing.T) {
 				}),
 			},
 			r: table.Row{
-				"?time": &table.Cell{T: mustBuildTime(`2015-03-10T01:00:00-07:00`)},
+				"?time": &table.Cell{T: mustBuildTime(t, `2015-03-10T01:00:00-07:00`)},
 			},
 			want: true,
 		},
@@ -867,7 +866,7 @@ func TestEvaluatorEvaluate(t *testing.T) {
 				}),
 			},
 			r: table.Row{
-				"?time": &table.Cell{T: mustBuildTime(`2015-03-10T00:00:00-08:00`)},
+				"?time": &table.Cell{T: mustBuildTime(t, `2015-03-10T00:00:00-08:00`)},
 			},
 			want: true,
 		},

--- a/bql/semantic/expression_test.go
+++ b/bql/semantic/expression_test.go
@@ -672,7 +672,7 @@ func TestEvaluatorEvaluate(t *testing.T) {
 			want: true,
 		},
 		{
-			id: `?time > 2012-04-10T00:00:00-08:00`,
+			id: `?time > 2012-03-10T00:00:00-08:00`,
 			in: []ConsumedElement{
 				NewConsumedToken(&lexer.Token{
 					Type: lexer.ItemBinding,
@@ -683,31 +683,11 @@ func TestEvaluatorEvaluate(t *testing.T) {
 				}),
 				NewConsumedToken(&lexer.Token{
 					Type: lexer.ItemTime,
-					Text: `2012-04-10T00:00:00-08:00`,
-				}),
-			},
-			r: table.Row{
-				"?time": &table.Cell{T: mustBuildTime(`2011-04-10T00:00:00-08:00`)},
-			},
-			want: false,
-		},
-		{
-			id: `?time = 2012-03-10T00:00:00-08:00`,
-			in: []ConsumedElement{
-				NewConsumedToken(&lexer.Token{
-					Type: lexer.ItemBinding,
-					Text: "?time",
-				}),
-				NewConsumedToken(&lexer.Token{
-					Type: lexer.ItemEQ,
-				}),
-				NewConsumedToken(&lexer.Token{
-					Type: lexer.ItemTime,
 					Text: `2012-03-10T00:00:00-08:00`,
 				}),
 			},
 			r: table.Row{
-				"?time": &table.Cell{T: mustBuildTime(`2012-03-10T02:00:00-06:00`)},
+				"?time": &table.Cell{T: mustBuildTime(`2012-04-10T00:00:00-08:00`)},
 			},
 			want: true,
 		},
@@ -727,12 +707,12 @@ func TestEvaluatorEvaluate(t *testing.T) {
 				}),
 			},
 			r: table.Row{
-				"?time": &table.Cell{T: mustBuildTime(`2012-03-10T09:00:00+01:00`)},
+				"?time": &table.Cell{T: mustBuildTime(`2012-03-10T00:00:00-08:00`)},
 			},
 			want: true,
 		},
 		{
-			id: `?time < 2012-03-10T00:00:00-08:00`,
+			id: `?time < 2012-01-10T00:00:00-08:00`,
 			in: []ConsumedElement{
 				NewConsumedToken(&lexer.Token{
 					Type: lexer.ItemBinding,
@@ -743,16 +723,16 @@ func TestEvaluatorEvaluate(t *testing.T) {
 				}),
 				NewConsumedToken(&lexer.Token{
 					Type: lexer.ItemTime,
-					Text: `2012-03-10T00:00:00-08:00`,
+					Text: `2012-01-10T00:00:00-08:00`,
 				}),
 			},
 			r: table.Row{
-				"?time": &table.Cell{T: mustBuildTime(`2012-03-10T01:00:00-06:00`)},
+				"?time": &table.Cell{T: mustBuildTime(`2012-02-10T00:00:00-08:00`)},
 			},
-			want: true,
+			want: false,
 		},
 		{
-			id: `?time > 2012-03-10T01:00:00-07:00`,
+			id: `?time > 2012-05-10T00:00:00-08:00`,
 			in: []ConsumedElement{
 				NewConsumedToken(&lexer.Token{
 					Type: lexer.ItemBinding,
@@ -763,11 +743,131 @@ func TestEvaluatorEvaluate(t *testing.T) {
 				}),
 				NewConsumedToken(&lexer.Token{
 					Type: lexer.ItemTime,
-					Text: `2012-03-10T01:00:00-07:00`,
+					Text: `2012-05-10T00:00:00-08:00`,
 				}),
 			},
 			r: table.Row{
-				"?time": &table.Cell{T: mustBuildTime(`2012-03-10T00:00:00-09:00`)},
+				"?time": &table.Cell{T: mustBuildTime(`2012-04-10T00:00:00-08:00`)},
+			},
+			want: false,
+		},
+		{
+			id: `?time = 2012-09-10T00:00:00-08:00`,
+			in: []ConsumedElement{
+				NewConsumedToken(&lexer.Token{
+					Type: lexer.ItemBinding,
+					Text: "?time",
+				}),
+				NewConsumedToken(&lexer.Token{
+					Type: lexer.ItemEQ,
+				}),
+				NewConsumedToken(&lexer.Token{
+					Type: lexer.ItemTime,
+					Text: `2012-09-10T00:00:00-08:00`,
+				}),
+			},
+			r: table.Row{
+				"?time": &table.Cell{T: mustBuildTime(`2012-03-10T00:00:00-08:00`)},
+			},
+			want: false,
+		},
+		{
+			id: `?time = 2015-03-10T02:00:00-06:00`,
+			in: []ConsumedElement{
+				NewConsumedToken(&lexer.Token{
+					Type: lexer.ItemBinding,
+					Text: "?time",
+				}),
+				NewConsumedToken(&lexer.Token{
+					Type: lexer.ItemEQ,
+				}),
+				NewConsumedToken(&lexer.Token{
+					Type: lexer.ItemTime,
+					Text: `2015-03-10T02:00:00-06:00`,
+				}),
+			},
+			r: table.Row{
+				"?time": &table.Cell{T: mustBuildTime(`2015-03-10T00:00:00-08:00`)},
+			},
+			want: true,
+		},
+		{
+			id: `?time = 2015-03-10T02:00:00-05:00`,
+			in: []ConsumedElement{
+				NewConsumedToken(&lexer.Token{
+					Type: lexer.ItemBinding,
+					Text: "?time",
+				}),
+				NewConsumedToken(&lexer.Token{
+					Type: lexer.ItemEQ,
+				}),
+				NewConsumedToken(&lexer.Token{
+					Type: lexer.ItemTime,
+					Text: `2015-03-10T02:00:00-05:00`,
+				}),
+			},
+			r: table.Row{
+				"?time": &table.Cell{T: mustBuildTime(`2015-03-10T00:00:00-08:00`)},
+			},
+			want: false,
+		},
+		{
+			id: `?time = 2015-03-10T09:00:00+01:00`,
+			in: []ConsumedElement{
+				NewConsumedToken(&lexer.Token{
+					Type: lexer.ItemBinding,
+					Text: "?time",
+				}),
+				NewConsumedToken(&lexer.Token{
+					Type: lexer.ItemEQ,
+				}),
+				NewConsumedToken(&lexer.Token{
+					Type: lexer.ItemTime,
+					Text: `2015-03-10T09:00:00+01:00`,
+				}),
+			},
+			r: table.Row{
+				"?time": &table.Cell{T: mustBuildTime(`2015-03-10T00:00:00-08:00`)},
+			},
+			want: true,
+		},
+		{
+			id: `?time < 2015-03-10T00:00:00-09:00`,
+			in: []ConsumedElement{
+				NewConsumedToken(&lexer.Token{
+					Type: lexer.ItemBinding,
+					Text: "?time",
+				}),
+				NewConsumedToken(&lexer.Token{
+					Type: lexer.ItemLT,
+				}),
+				NewConsumedToken(&lexer.Token{
+					Type: lexer.ItemTime,
+					Text: `2015-03-10T00:00:00-09:00`,
+				}),
+			},
+			r: table.Row{
+				"?time": &table.Cell{T: mustBuildTime(`2015-03-10T01:00:00-07:00`)},
+			},
+			want: true,
+		},
+		{
+			id: `?time > 2015-03-10T01:00:00-06:00`,
+			in: []ConsumedElement{
+				NewConsumedToken(&lexer.Token{
+					Type: lexer.ItemBinding,
+					Text: "?time",
+				}),
+				NewConsumedToken(&lexer.Token{
+					Type: lexer.ItemGT,
+				}),
+				NewConsumedToken(&lexer.Token{
+					Type: lexer.ItemTime,
+					Text: `2015-03-10T01:00:00-06:00`,
+				}),
+			},
+			r: table.Row{
+				"?time": &table.Cell{T: mustBuildTime(`2015-03-10T00:00:00-08:00`)},
 			},
 			want: true,
 		},

--- a/bql/semantic/expression_test.go
+++ b/bql/semantic/expression_test.go
@@ -191,6 +191,7 @@ func TestBooleanEvaluationNode(t *testing.T) {
 }
 
 func mustBuildLiteral(t *testing.T, textLiteral string) *literal.Literal {
+	t.Helper()
 	lit, err := literal.DefaultBuilder().Parse(textLiteral)
 	if err != nil {
 		t.Fatalf("could not parse text literal %q, got error: %v", textLiteral, err)
@@ -199,6 +200,7 @@ func mustBuildLiteral(t *testing.T, textLiteral string) *literal.Literal {
 }
 
 func mustBuildNodeFromStrings(t *testing.T, nodeType, nodeID string) *node.Node {
+	t.Helper()
 	n, err := node.NewNodeFromStrings(nodeType, nodeID)
 	if err != nil {
 		t.Fatalf("could not build node from type %q and ID %q, got error: %v", nodeType, nodeID, err)
@@ -207,6 +209,7 @@ func mustBuildNodeFromStrings(t *testing.T, nodeType, nodeID string) *node.Node 
 }
 
 func mustBuildTime(t *testing.T, timeLiteral string) *time.Time {
+	t.Helper()
 	time, err := time.Parse(time.RFC3339Nano, strings.TrimSpace(timeLiteral))
 	if err != nil {
 		t.Fatalf("could not parse time literal %q, got error: %v", timeLiteral, err)


### PR DESCRIPTION
If we extract a time binding inside the `WHERE` clause it would be useful to be able to use it for comparisons inside the `HAVING` clause, creating conditions around that binding. This PR comes to add support for this.

To illustrate, the query below is now possible:

```
SELECT ?p, ?time
FROM ?test
WHERE {
    /u<peter> ?p AT ?time ?o
}
HAVING ?time < 2016-03-01T00:00:00-08:00;
```

On which the time binding `?time` extracted with the `AT` keyword can now be compared to a time literal (`2016-03-01T00:00:00-08:00` above) inside the HAVING clause.

You can also combine it with `ID` bindings to create more complex conditions inside the `HAVING` clause:

```
SELECT ?s, ?p, ?p_id, ?time
FROM ?test
WHERE {
    ?s ?p ID ?p_id AT ?time ?o
}
HAVING (?p_id < "in"^^type:text) AND (?time > 2016-02-01T00:00:00-08:00);
```

**NB:** The comparisons with a time literal are not lexicographical, they indeed have the semantics of a time comparison: we consider the time zone, for example (as one should expect). 

So, if you use a condition like `?time = 2012-03-10T00:00:00-08:00` in your `HAVING` clause, you may also get triples in your query result with the `?time` binding being `2012-03-10T09:00:00+01:00` (which is equivalent to the timestamp requested in the condition, being in another time zone).

For more examples on this, please refer to the new tests added in `planner_test.go` and `expression_test.go`.