### PR TITLE
Adjust behavior of time bindings for non-predicate objects

### DIFF
--- a/bql/planner/data_access.go
+++ b/bql/planner/data_access.go
@@ -30,6 +30,17 @@ import (
 	"github.com/google/badwolf/triple/predicate"
 )
 
+type skippableError struct {
+	situation string
+	err       error
+}
+
+func (e *skippableError) Error() string {
+	return e.situation + ": " + e.err.Error()
+}
+
+var _ error = (*skippableError)(nil)
+
 // updateTimeBounds updates the time bounds use for the lookup based on the
 // provided graph clause.
 func updateTimeBounds(lo *storage.LookupOptions, cls *semantic.GraphClause) *storage.LookupOptions {
@@ -510,15 +521,6 @@ func objectToCell(o *triple.Object) (*table.Cell, error) {
 		return c, nil
 	}
 	return nil, fmt.Errorf("unknown object type in object %q", o)
-}
-
-type skippableError struct {
-	situation string
-	err       error
-}
-
-func (e *skippableError) Error() string {
-	return e.situation + ": " + e.err.Error()
 }
 
 // tripleToRow converts a triple into a row using the binndings specidfied

--- a/bql/planner/data_access.go
+++ b/bql/planner/data_access.go
@@ -475,6 +475,10 @@ func addTriples(ts <-chan *triple.Triple, cls *semantic.GraphClause, tbl *table.
 		var r table.Row
 		r, err = tripleToRow(t, cls)
 		if err != nil {
+			if _, ok := err.(*skippableError); ok {
+				err = nil
+				continue
+			}
 			break
 		}
 		if r == nil {
@@ -506,6 +510,15 @@ func objectToCell(o *triple.Object) (*table.Cell, error) {
 		return c, nil
 	}
 	return nil, fmt.Errorf("unknown object type in object %q", o)
+}
+
+type skippableError struct {
+	situation string
+	err       error
+}
+
+func (e *skippableError) Error() string {
+	return e.situation + ": " + e.err.Error()
 }
 
 // tripleToRow converts a triple into a row using the binndings specidfied
@@ -662,30 +675,42 @@ func tripleToRow(t *triple.Triple, cls *semantic.GraphClause) (table.Row, error)
 		}
 	}
 	if cls.OAnchorBinding != "" {
+		var c *table.Cell
 		p, err := o.Predicate()
 		if err != nil {
-			return nil, err
+			// In the case of time anchor bindings for non-predicate objects we skip the triple if the clause is not optional, otherwise we provide an empty Cell as we want <NULL> to appear in the query result.
+			if !cls.Optional {
+				return nil, &skippableError{"cls.OAnchorBinding in non-optional clause", err}
+			}
+			c = &table.Cell{}
+		} else {
+			ts, err := p.TimeAnchor()
+			if err != nil {
+				return nil, err
+			}
+			c = &table.Cell{T: ts}
 		}
-		ts, err := p.TimeAnchor()
-		if err != nil {
-			return nil, err
-		}
-		c := &table.Cell{T: ts}
 		r[cls.OAnchorBinding] = c
 		if !validBinding(cls.OAnchorBinding, c) {
 			return nil, nil
 		}
 	}
 	if cls.OAnchorAlias != "" {
+		var c *table.Cell
 		p, err := o.Predicate()
 		if err != nil {
-			return nil, err
+			// In the case of AT bindings for non-predicate objects we skip the triple if the clause is not optional, otherwise we provide an empty Cell as we want <NULL> to appear in the query result.
+			if !cls.Optional {
+				return nil, &skippableError{"cls.OAnchorAlias in non-optional clause", err}
+			}
+			c = &table.Cell{}
+		} else {
+			ts, err := p.TimeAnchor()
+			if err != nil {
+				return nil, err
+			}
+			c = &table.Cell{T: ts}
 		}
-		ts, err := p.TimeAnchor()
-		if err != nil {
-			return nil, err
-		}
-		c := &table.Cell{T: ts}
 		r[cls.OAnchorAlias] = c
 		if !validBinding(cls.OAnchorAlias, c) {
 			return nil, nil

--- a/bql/planner/planner_test.go
+++ b/bql/planner/planner_test.go
@@ -881,6 +881,35 @@ func TestPlannerQuery(t *testing.T) {
 			nBindings: 3,
 			nRows:     5,
 		},
+		{
+			q: `SELECT ?s, ?o, ?o_time
+				FROM ?test
+				WHERE {
+					?s ?p ?o AT ?o_time
+				};`,
+			nBindings: 3,
+			nRows:     4,
+		},
+		{
+			q: `SELECT ?s, ?o, ?o_time
+				FROM ?test
+				WHERE {
+					?s ?p ?o .
+					OPTIONAL { ?s ?p ?o AT ?o_time }
+				}
+				HAVING (?s = /l<barcelona>) OR (?s = /u<joe>) OR (?s = /u<bob>);`,
+			nBindings: 3,
+			nRows:     7,
+		},
+		{
+			q: `SELECT ?s, ?o_time
+				FROM ?test
+				WHERE {
+					?s ?p "turned"@[?o_time]
+				};`,
+			nBindings: 2,
+			nRows:     4,
+		},
 	}
 
 	s, ctx := memory.NewStore(), context.Background()


### PR DESCRIPTION
We have two types of time bindings: `AT` bindings (using the `AT` keyword) and time anchor bindings (eg: `"bought"@[?time]`). 

In both cases, if a graph pattern tries to extract the time anchor from a non-predicate object (like when the object is a node such as `/u<eve>` or a literal such as `"174"^^type:int64`) we want to skip this triple and do not show it in the query result (as it does not precisely match the exact graph pattern specified - the pattern required a time anchor in a predicate object). 

Nevertheless, there is one exception: if this graph pattern is marked as `OPTIONAL` we expect to see `<NULL>` in the query result for that time binding. 

This PR, then, comes to enforce this behavior.

To illustrate for the case of an `AT` binding, take the query below:

```
SELECT ?s, ?o, ?o_time
FROM ?test
WHERE {
    ?s ?p ?o AT ?o_time
};
```

In a `?test` graph having only the three following triples:

```
/u<peter>       "parent_of"@[]                            /u<eve>
/_<blank_node>  "_predicate"@[2016-04-01T00:00:00-08:00]  "bought"@[2016-04-01T00:00:00-08:00]
/u<alice>       "height_cm"@[]                            "174"^^type:int64
```

We expect as result:

```
Result:
?s              ?o                                    ?o_time
/_<blank_node>  "bought"@[2016-04-01T00:00:00-08:00]  2016-04-01T00:00:00-08:00
```

Note how the triples with the non-predicate objects `/u<eve>` and `"174"^^type:int64` were skipped and not shown in the query result as they did not precisely match the exact graph pattern specified in the `WHERE` clause (they had no time anchor to be extracted by the `AT` binding).

On the other hand, if the query was:

```
SELECT ?s, ?o, ?o_time
FROM ?test
WHERE {
    ?s ?p ?o .
    OPTIONAL { ?s ?p ?o AT ?o_time }
};
```

We would expect as result:

```
Result:
?s              ?o                                    ?o_time
/u<peter>       /u<eve>                               <NULL>
/_<blank_node>  "bought"@[2016-04-01T00:00:00-08:00]  2016-04-01T00:00:00-08:00
/u<alice>       "174"^^type:int64                     <NULL>
```

Note how the triples with the non-predicate objects appeared in the query result this time, with the `?o_time` binding indeed shown as `<NULL>` in the result table. This happened because the clause with the `AT` binding was marked as `OPTIONAL` in the `WHERE` above.

For time anchor bindings such as `"bought"@[?time]` the expected behavior enforced by this PR is analogous, as better detailed by the new tests added in `data_access_test.go` and `planner_test.go`.