### PR TITLE
Support predicate binding equalities inside HAVING clauses

### DIFF
--- a/bql/grammar/grammar.go
+++ b/bql/grammar/grammar.go
@@ -941,6 +941,12 @@ func havingClauses() []*Clause {
 		},
 		{
 			Elements: []Element{
+				NewTokenType(lexer.ItemPredicate),
+				NewSymbol("HAVING_CLAUSE_BINARY_COMPOSITE"),
+			},
+		},
+		{
+			Elements: []Element{
 				NewTokenType(lexer.ItemNot),
 				NewSymbol("HAVING_CLAUSE"),
 			},

--- a/bql/grammar/grammar_test.go
+++ b/bql/grammar/grammar_test.go
@@ -100,6 +100,8 @@ func TestAcceptByParse(t *testing.T) {
 		`select ?a from ?b where {?a ?p ?o} having ?b = 2014-03-10T00:00:00-08:00 limit "10"^^type:int64;`,
 		`select ?a from ?b where {?a ?p ?o} having (?b and ?b) or not (?b = ?b);`,
 		`select ?a from ?b where {?a ?p ?o} having ((?b and ?b) or not (?b = ?b));`,
+		`select ?a from ?b where {?a ?p ?o} having ?b = "foo"@[];`,
+		`select ?a from ?b where {?a ?p ?o} having ?b = "foo"@[2016-04-01T00:00:00-08:00];`,
 		// Test global time bounds.
 		`select ?a from ?b where {?s ?p ?o} before 2006-01-01T15:04:05.999999999Z07:00;`,
 		`select ?a from ?b where {?s ?p ?o} after 2006-02-03T15:04:05.999999999Z07:00;`,

--- a/bql/planner/planner_test.go
+++ b/bql/planner/planner_test.go
@@ -859,7 +859,7 @@ func TestPlannerQuery(t *testing.T) {
 		// Actual test:
 		tbl, err := plnr.Execute(ctx)
 		if err != nil {
-			t.Fatalf("planner.Execute(%s)\n= _, %v; want _, nil error", entry.q, err)
+			t.Fatalf("planner.Execute(%s)\n= _, %v; want _, nil", entry.q, err)
 		}
 		if got, want := len(tbl.Bindings()), entry.nBindings; got != want {
 			t.Errorf("planner.Execute(%s)\n= a Table with %d bindings; want %d", entry.q, got, want)
@@ -928,7 +928,7 @@ func TestPlannerQueryError(t *testing.T) {
 		// Actual test:
 		_, err = plnr.Execute(ctx)
 		if err == nil {
-			t.Errorf("planner.Execute(%s)\n= _, nil; want _, non-nil error", entry.q)
+			t.Errorf("planner.Execute(%s)\n= _, nil; want _, error", entry.q)
 		}
 	}
 }

--- a/bql/planner/planner_test.go
+++ b/bql/planner/planner_test.go
@@ -859,7 +859,7 @@ func TestPlannerQuery(t *testing.T) {
 		// Actual test:
 		tbl, err := plnr.Execute(ctx)
 		if err != nil {
-			t.Fatalf("planner.Execute(%s)\n= _, %v; want nil error", entry.q, err)
+			t.Fatalf("planner.Execute(%s)\n= _, %v; want _, nil error", entry.q, err)
 		}
 		if got, want := len(tbl.Bindings()), entry.nBindings; got != want {
 			t.Errorf("planner.Execute(%s)\n= a Table with %d bindings; want %d", entry.q, got, want)
@@ -928,7 +928,7 @@ func TestPlannerQueryError(t *testing.T) {
 		// Actual test:
 		_, err = plnr.Execute(ctx)
 		if err == nil {
-			t.Errorf("planner.Execute(%s)\n= _, nil; want non-nil error", entry.q)
+			t.Errorf("planner.Execute(%s)\n= _, nil; want _, non-nil error", entry.q)
 		}
 	}
 }

--- a/bql/planner/planner_test.go
+++ b/bql/planner/planner_test.go
@@ -807,6 +807,36 @@ func TestPlannerQuery(t *testing.T) {
 			nBindings: 2,
 			nRows:     3,
 		},
+		{
+			q: `SELECT ?s, ?p, ?o
+				FROM ?test
+				WHERE {
+					?s ?p ?o
+				}
+				HAVING ?p = "height_cm"@[];`,
+			nBindings: 3,
+			nRows:     4,
+		},
+		{
+			q: `SELECT ?s, ?p, ?o
+				FROM ?test
+				WHERE {
+					?s ?p ?o
+				}
+				HAVING ?p = "bought"@[2016-03-01T00:00:00-08:00];`,
+			nBindings: 3,
+			nRows:     1,
+		},
+		{
+			q: `SELECT ?s, ?p, ?o
+				FROM ?test
+				WHERE {
+					?s ?p ?o
+				}
+				HAVING (?p = "tag"@[]) OR (?p = "bought"@[2016-02-01T00:00:00-08:00]);`,
+			nBindings: 3,
+			nRows:     2,
+		},
 	}
 
 	s, ctx := memory.NewStore(), context.Background()
@@ -859,6 +889,22 @@ func TestPlannerQueryError(t *testing.T) {
 					?s ID ?s_id "height_cm"@[] ?height
 				}
 				HAVING ?s_id = /u<alice>;`,
+		},
+		{
+			q: `SELECT ?s, ?p, ?o
+				FROM ?test
+				WHERE {
+					?s ?p ?o
+				}
+				HAVING ?p < "height_cm"@[];`,
+		},
+		{
+			q: `SELECT ?s, ?p, ?o
+				FROM ?test
+				WHERE {
+					?s ?p ?o
+				}
+				HAVING ?p > "bought"@[2016-01-01T00:00:00-08:00];`,
 		},
 	}
 

--- a/bql/semantic/expression.go
+++ b/bql/semantic/expression.go
@@ -17,7 +17,6 @@ package semantic
 import (
 	"errors"
 	"fmt"
-	"reflect"
 	"strings"
 	"time"
 
@@ -140,7 +139,7 @@ func (e *evaluationNode) Evaluate(r table.Row) (bool, error) {
 
 	switch e.op {
 	case EQ:
-		return reflect.DeepEqual(csEL, csER), nil
+		return csEL == csER, nil
 	case LT:
 		return csEL < csER, nil
 	case GT:
@@ -240,7 +239,7 @@ func (e *comparisonForNodeLiteral) Evaluate(r table.Row) (bool, error) {
 
 	switch e.op {
 	case EQ:
-		return reflect.DeepEqual(csEL, csER), nil
+		return csEL == csER, nil
 	case LT:
 		return csEL < csER, nil
 	case GT:
@@ -316,7 +315,7 @@ func (e *comparisonForPredicateLiteral) Evaluate(r table.Row) (bool, error) {
 
 	switch e.op {
 	case EQ:
-		return reflect.DeepEqual(csEL, csER), nil
+		return csEL == csER, nil
 	default:
 		return false, fmt.Errorf(`comparisonForPredicateLiteral.Evaluate got operation %q, but it accepts only the "=" operation. For ">" and "<" think about extracting bindings with the keywords ID/AT and using them for comparisons`, e.op)
 	}

--- a/bql/semantic/expression_test.go
+++ b/bql/semantic/expression_test.go
@@ -962,10 +962,9 @@ func TestEvaluatorEvaluate(t *testing.T) {
 
 func TestEvaluatorEvaluateError(t *testing.T) {
 	testTable := []struct {
-		id   string
-		in   []ConsumedElement
-		r    table.Row
-		want bool
+		id string
+		in []ConsumedElement
+		r  table.Row
 	}{
 		{
 			id: `?s ID ?id > "37"^^type:int64`,
@@ -985,7 +984,6 @@ func TestEvaluatorEvaluateError(t *testing.T) {
 			r: table.Row{
 				"?id": &table.Cell{S: table.CellString("peter")},
 			},
-			want: false,
 		},
 		{
 			id: `?s ID ?id = /u<peter>`,
@@ -1005,7 +1003,6 @@ func TestEvaluatorEvaluateError(t *testing.T) {
 			r: table.Row{
 				"?id": &table.Cell{S: table.CellString("peter")},
 			},
-			want: false,
 		},
 		{
 			id: `?p < "height_cm"@[]`,
@@ -1025,7 +1022,6 @@ func TestEvaluatorEvaluateError(t *testing.T) {
 			r: table.Row{
 				"?p": &table.Cell{P: mustBuildPredicate(t, `"bought"@[]`)},
 			},
-			want: false,
 		},
 		{
 			id: `?p > "bought"@[2016-01-01T00:00:00-08:00]`,
@@ -1045,7 +1041,6 @@ func TestEvaluatorEvaluateError(t *testing.T) {
 			r: table.Row{
 				"?p": &table.Cell{P: mustBuildPredicate(t, `"height_cm"@[2016-01-01T00:00:00-08:00]`)},
 			},
-			want: false,
 		},
 	}
 
@@ -1059,7 +1054,7 @@ func TestEvaluatorEvaluateError(t *testing.T) {
 		if err == nil {
 			t.Errorf("%s: eval.Evaluate(%v) = _, nil; want _, non-nil error", entry.id, entry.r)
 		}
-		if want := entry.want; got != want {
+		if want := false; got != want {
 			t.Errorf("%s: eval.Evaluate(%v) = %v, _; want %v, _", entry.id, entry.r, got, want)
 		}
 	}

--- a/bql/semantic/expression_test.go
+++ b/bql/semantic/expression_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/google/badwolf/bql/table"
 	"github.com/google/badwolf/triple/literal"
 	"github.com/google/badwolf/triple/node"
+	"github.com/google/badwolf/triple/predicate"
 )
 
 func TestEvaluationNode(t *testing.T) {
@@ -215,6 +216,15 @@ func mustBuildTime(t *testing.T, timeLiteral string) *time.Time {
 		t.Fatalf("could not parse time literal %q, got error: %v", timeLiteral, err)
 	}
 	return &time
+}
+
+func mustBuildPredicate(t *testing.T, predicateLiteral string) *predicate.Predicate {
+	t.Helper()
+	p, err := predicate.Parse(predicateLiteral)
+	if err != nil {
+		t.Fatalf("could not parse predicate literal %q, got error: %v", predicateLiteral, err)
+	}
+	return p
 }
 
 func TestEvaluatorEvaluate(t *testing.T) {
@@ -873,6 +883,66 @@ func TestEvaluatorEvaluate(t *testing.T) {
 			},
 			want: true,
 		},
+		{
+			id: `?p = "height_cm"@[]`,
+			in: []ConsumedElement{
+				NewConsumedToken(&lexer.Token{
+					Type: lexer.ItemBinding,
+					Text: "?p",
+				}),
+				NewConsumedToken(&lexer.Token{
+					Type: lexer.ItemEQ,
+				}),
+				NewConsumedToken(&lexer.Token{
+					Type: lexer.ItemPredicate,
+					Text: `"height_cm"@[]`,
+				}),
+			},
+			r: table.Row{
+				"?p": &table.Cell{P: mustBuildPredicate(t, `"height_cm"@[]`)},
+			},
+			want: true,
+		},
+		{
+			id: `?p = "bought"@[2016-01-01T00:00:00-08:00]`,
+			in: []ConsumedElement{
+				NewConsumedToken(&lexer.Token{
+					Type: lexer.ItemBinding,
+					Text: "?p",
+				}),
+				NewConsumedToken(&lexer.Token{
+					Type: lexer.ItemEQ,
+				}),
+				NewConsumedToken(&lexer.Token{
+					Type: lexer.ItemPredicate,
+					Text: `"bought"@[2016-01-01T00:00:00-08:00]`,
+				}),
+			},
+			r: table.Row{
+				"?p": &table.Cell{P: mustBuildPredicate(t, `"bought"@[2016-01-01T00:00:00-08:00]`)},
+			},
+			want: true,
+		},
+		{
+			id: `?p = "height_cm"@[]`,
+			in: []ConsumedElement{
+				NewConsumedToken(&lexer.Token{
+					Type: lexer.ItemBinding,
+					Text: "?p",
+				}),
+				NewConsumedToken(&lexer.Token{
+					Type: lexer.ItemEQ,
+				}),
+				NewConsumedToken(&lexer.Token{
+					Type: lexer.ItemPredicate,
+					Text: `"height_cm"@[]`,
+				}),
+			},
+			r: table.Row{
+				"?p": &table.Cell{P: mustBuildPredicate(t, `"bought"@[2016-01-01T00:00:00-08:00]`)},
+			},
+			want: false,
+		},
 	}
 	for _, entry := range testTable {
 		eval, err := NewEvaluator(entry.in)
@@ -934,6 +1004,46 @@ func TestEvaluatorEvaluateError(t *testing.T) {
 			},
 			r: table.Row{
 				"?id": &table.Cell{S: table.CellString("peter")},
+			},
+			want: false,
+		},
+		{
+			id: `?p < "height_cm"@[]`,
+			in: []ConsumedElement{
+				NewConsumedToken(&lexer.Token{
+					Type: lexer.ItemBinding,
+					Text: "?p",
+				}),
+				NewConsumedToken(&lexer.Token{
+					Type: lexer.ItemLT,
+				}),
+				NewConsumedToken(&lexer.Token{
+					Type: lexer.ItemPredicate,
+					Text: `"height_cm"@[]`,
+				}),
+			},
+			r: table.Row{
+				"?p": &table.Cell{P: mustBuildPredicate(t, `"bought"@[]`)},
+			},
+			want: false,
+		},
+		{
+			id: `?p > "bought"@[2016-01-01T00:00:00-08:00]`,
+			in: []ConsumedElement{
+				NewConsumedToken(&lexer.Token{
+					Type: lexer.ItemBinding,
+					Text: "?p",
+				}),
+				NewConsumedToken(&lexer.Token{
+					Type: lexer.ItemGT,
+				}),
+				NewConsumedToken(&lexer.Token{
+					Type: lexer.ItemPredicate,
+					Text: `"bought"@[2016-01-01T00:00:00-08:00]`,
+				}),
+			},
+			r: table.Row{
+				"?p": &table.Cell{P: mustBuildPredicate(t, `"height_cm"@[2016-01-01T00:00:00-08:00]`)},
 			},
 			want: false,
 		},

--- a/bql/semantic/expression_test.go
+++ b/bql/semantic/expression_test.go
@@ -952,7 +952,7 @@ func TestEvaluatorEvaluate(t *testing.T) {
 
 		got, err := eval.Evaluate(entry.r)
 		if err != nil {
-			t.Errorf("%s: eval.Evaluate(%v) = _, %v; want nil error", entry.id, entry.r, err)
+			t.Errorf("%s: eval.Evaluate(%v) = _, %v; want _, nil error", entry.id, entry.r, err)
 		}
 		if want := entry.want; got != want {
 			t.Errorf("%s: eval.Evaluate(%v) = %v, _; want %v, _", entry.id, entry.r, got, want)
@@ -1057,7 +1057,7 @@ func TestEvaluatorEvaluateError(t *testing.T) {
 
 		got, err := eval.Evaluate(entry.r)
 		if err == nil {
-			t.Errorf("%s: eval.Evaluate(%v) = _, nil; want non-nil error", entry.id, entry.r)
+			t.Errorf("%s: eval.Evaluate(%v) = _, nil; want _, non-nil error", entry.id, entry.r)
 		}
 		if want := entry.want; got != want {
 			t.Errorf("%s: eval.Evaluate(%v) = %v, _; want %v, _", entry.id, entry.r, got, want)


### PR DESCRIPTION
We can now compare a predicate binding to a predicate literal inside the `HAVING` clause (only equalities allowed) to filter the results of our query.

To illustrate, the following query is now possible:

```
SELECT ?s, ?p, ?o
FROM ?test
WHERE {
    ?s ?p ?o
}
HAVING ?p = "height_cm"@[];
```

Note that predicate inequalities are not allowed because their behavior may become confusing for the user (especially when time anchors come on stage). In this case an error is prompted orienting to extract bindings with the `ID`/`AT` keywords and to use these bindings to proceed with the comparisons in a clearer way.