### PR TITLE
Add instructing error messages in the case of node binding inequalities inside HAVING clauses

### DIFF
--- a/bql/planner/planner_test.go
+++ b/bql/planner/planner_test.go
@@ -491,21 +491,6 @@ func TestPlannerQuery(t *testing.T) {
 			nBindings: 2,
 			nRows:     1,
 		},
-		{
-			q:         `select ?s, ?height from ?test where {?s "height_cm"@[] ?height} having ?s > /u<zzzzz>;`,
-			nBindings: 2,
-			nRows:     0,
-		},
-		{
-			q:         `select ?s, ?height from ?test where {?s "height_cm"@[] ?height} having ?s > /u<alice>;`,
-			nBindings: 2,
-			nRows:     3,
-		},
-		{
-			q:         `select ?s, ?height from ?test where {?s "height_cm"@[] ?height} having ?s > /u<bob>;`,
-			nBindings: 2,
-			nRows:     2,
-		},
 		/*
 			/c<model s> "is_a"@[] /t<car>
 			/c<model x> "is_a"@[] /t<car>
@@ -876,6 +861,26 @@ func TestPlannerQuery(t *testing.T) {
 			nBindings: 1,
 			nRows:     4,
 		},
+		{
+			q: `SELECT ?s, ?height
+				FROM ?test
+				WHERE {
+					?s "height_cm"@[] ?height
+				}
+				HAVING ?s = /u<bob>;`,
+			nBindings: 2,
+			nRows:     1,
+		},
+		{
+			q: `SELECT ?s, ?p, ?o
+				FROM ?test
+				WHERE {
+					?s ?p ?o
+				}
+				HAVING (?s = /u<bob>) OR (?o = /t<car>);`,
+			nBindings: 3,
+			nRows:     5,
+		},
 	}
 
 	s, ctx := memory.NewStore(), context.Background()
@@ -944,6 +949,22 @@ func TestPlannerQueryError(t *testing.T) {
 					?s ?p ?o
 				}
 				HAVING ?p > "bought"@[2016-01-01T00:00:00-08:00];`,
+		},
+		{
+			q: `SELECT ?s, ?height
+				FROM ?test
+				WHERE {
+					?s "height_cm"@[] ?height
+				}
+				HAVING ?s < /u<zzzzz>;`,
+		},
+		{
+			q: `SELECT ?s, ?height
+				FROM ?test
+				WHERE {
+					?s "height_cm"@[] ?height
+				}
+				HAVING ?s > /u<alice>;`,
 		},
 	}
 

--- a/bql/semantic/expression.go
+++ b/bql/semantic/expression.go
@@ -240,12 +240,8 @@ func (e *comparisonForNodeLiteral) Evaluate(r table.Row) (bool, error) {
 	switch e.op {
 	case EQ:
 		return csEL == csER, nil
-	case LT:
-		return csEL < csER, nil
-	case GT:
-		return csEL > csER, nil
 	default:
-		return false, fmt.Errorf("boolean evaluation requires a boolean operation; found %q instead", e.op.String())
+		return false, fmt.Errorf(`comparisonForNodeLiteral.Evaluate got operation %q, but it accepts only the "=" operation. For ">" and "<" think about extracting bindings with the keywords ID/TYPE and using them for comparisons`, e.op)
 	}
 }
 

--- a/bql/semantic/expression_test.go
+++ b/bql/semantic/expression_test.go
@@ -943,7 +943,48 @@ func TestEvaluatorEvaluate(t *testing.T) {
 			},
 			want: false,
 		},
+		{
+			id: `?s = /u<paul>`,
+			in: []ConsumedElement{
+				NewConsumedToken(&lexer.Token{
+					Type: lexer.ItemBinding,
+					Text: "?s",
+				}),
+				NewConsumedToken(&lexer.Token{
+					Type: lexer.ItemEQ,
+				}),
+				NewConsumedToken(&lexer.Token{
+					Type: lexer.ItemNode,
+					Text: "/u<paul>",
+				}),
+			},
+			r: table.Row{
+				"?s": &table.Cell{N: mustBuildNodeFromStrings(t, "/u", "paul")},
+			},
+			want: true,
+		},
+		{
+			id: `?s = /u<paul>`,
+			in: []ConsumedElement{
+				NewConsumedToken(&lexer.Token{
+					Type: lexer.ItemBinding,
+					Text: "?s",
+				}),
+				NewConsumedToken(&lexer.Token{
+					Type: lexer.ItemEQ,
+				}),
+				NewConsumedToken(&lexer.Token{
+					Type: lexer.ItemNode,
+					Text: "/u<paul>",
+				}),
+			},
+			r: table.Row{
+				"?s": &table.Cell{N: mustBuildNodeFromStrings(t, "/u", "peter")},
+			},
+			want: false,
+		},
 	}
+
 	for _, entry := range testTable {
 		eval, err := NewEvaluator(entry.in)
 		if err != nil {
@@ -1040,6 +1081,44 @@ func TestEvaluatorEvaluateError(t *testing.T) {
 			},
 			r: table.Row{
 				"?p": &table.Cell{P: mustBuildPredicate(t, `"height_cm"@[2016-01-01T00:00:00-08:00]`)},
+			},
+		},
+		{
+			id: `?s > /u<paul>`,
+			in: []ConsumedElement{
+				NewConsumedToken(&lexer.Token{
+					Type: lexer.ItemBinding,
+					Text: "?s",
+				}),
+				NewConsumedToken(&lexer.Token{
+					Type: lexer.ItemGT,
+				}),
+				NewConsumedToken(&lexer.Token{
+					Type: lexer.ItemNode,
+					Text: "/u<paul>",
+				}),
+			},
+			r: table.Row{
+				"?s": &table.Cell{N: mustBuildNodeFromStrings(t, "/u", "peter")},
+			},
+		},
+		{
+			id: `?s < /u<paul>`,
+			in: []ConsumedElement{
+				NewConsumedToken(&lexer.Token{
+					Type: lexer.ItemBinding,
+					Text: "?s",
+				}),
+				NewConsumedToken(&lexer.Token{
+					Type: lexer.ItemLT,
+				}),
+				NewConsumedToken(&lexer.Token{
+					Type: lexer.ItemNode,
+					Text: "/u<paul>",
+				}),
+			},
+			r: table.Row{
+				"?s": &table.Cell{N: mustBuildNodeFromStrings(t, "/u", "alice")},
 			},
 		},
 	}


### PR DESCRIPTION
From now on, comparisons between a node binding and a node literal inside `HAVING` clauses can only be equalities, such as in:

```
SELECT ?s, ?height
FROM ?test
WHERE {
    ?s "height_cm"@[] ?height
}
HAVING ?s = /u<bob>;
```

Note that node inequalities are not allowed anymore because they may raise confusion with regards to what is indeed being compared (only the `ID`, only the `TYPE`, or both together).

In the case of inequalities an error is prompted orienting the user to extract bindings with the `ID`/`TYPE` keywords and to use these bindings to proceed with the comparisons in a clearer way.