### PR TITLE
Make trailing dot optional after the last clause inside WHERE

### DIFF
--- a/bql/grammar/grammar.go
+++ b/bql/grammar/grammar.go
@@ -361,6 +361,7 @@ func clauses() []*Clause {
 				NewSymbol("MORE_CLAUSES"),
 			},
 		},
+		{},
 	}
 }
 

--- a/bql/grammar/grammar_test.go
+++ b/bql/grammar/grammar_test.go
@@ -194,6 +194,41 @@ func TestAcceptByParse(t *testing.T) {
 			?n "_object"@[] ?o};`,
 		// Show the graphs.
 		`show graphs;`,
+		// Test optional trailing dot after the last clause inside WHERE.
+		`select ?a
+		 from ?b
+		 where {
+			?s ?p ?o .
+		 };`,
+		`select ?a
+		 from ?b
+		 where {
+			/u<paul> ?p ?o .
+		 };`,
+		`select ?a
+		 from ?b
+		 where {
+			?s ?p ?o .
+			/u<paul> ?p ?o .
+		 };`,
+		`select ?a
+		 from ?b
+		 where {
+			?s ?p ?o .
+			?ss ?p ?o .
+		 };`,
+		`select ?a
+		 from ?b
+		 where {
+			?s ?p ?o .
+			optional {?x ?w ?z } .
+		 };`,
+		`select ?a
+		 from ?b
+		 where {
+			?s ?p ?o .
+			/u<paul> ?p ?o
+		 };`,
 	}
 	p, err := NewParser(BQL())
 	if err != nil {
@@ -351,6 +386,31 @@ func TestRejectByParse(t *testing.T) {
 		 where {?n "_subject"@[] ?s.
 			?n "_predicate"@[] ?p.
 			?n "_object"@[] ?o};`,
+		// Test invalid trailing dot use inside WHERE.
+		`select ?a
+		 from ?b
+		 where {
+			?s ?p ?o
+			/u<paul> ?p ?o .
+		};`,
+		`select ?a
+		 from ?b
+		 where {
+			?s ?p ?o
+			?ss ?p ?o .
+		};`,
+		`select ?a
+		 from ?b
+		 where {
+			?s ?p ?o
+			optional {?x ?w ?z } .
+		};`,
+		`select ?a
+		 from ?b
+		 where {
+			?s ?p ?o
+			/u<paul> ?p ?o
+		};`,
 	}
 	p, err := NewParser(BQL())
 	if err != nil {

--- a/bql/planner/planner_test.go
+++ b/bql/planner/planner_test.go
@@ -837,6 +837,45 @@ func TestPlannerQuery(t *testing.T) {
 			nBindings: 3,
 			nRows:     2,
 		},
+		{
+			q: `SELECT ?p, ?o
+				FROM ?test
+				WHERE {
+					/u<joe> ?p ?o .
+				};`,
+			nBindings: 2,
+			nRows:     2,
+		},
+		{
+			q: `SELECT ?o
+				FROM ?test
+				WHERE {
+					/u<joe> "parent_of"@[] ?o .
+					?o "parent_of"@[] /u<john> .
+				};`,
+			nBindings: 1,
+			nRows:     1,
+		},
+		{
+			q: `SELECT ?p1, ?p2
+				FROM ?test
+				WHERE {
+					/u<joe> ?p1 /u<mary> .
+					/u<joe> ?p2 /u<peter> .
+				};`,
+			nBindings: 2,
+			nRows:     1,
+		},
+		{
+			q: `SELECT ?car
+				FROM ?test
+				WHERE {
+					?car "is_a"@[] /t<car> .
+					OPTIONAL { /c<model O> "is_a"@[] /t<car> } .
+				};`,
+			nBindings: 1,
+			nRows:     4,
+		},
 	}
 
 	s, ctx := memory.NewStore(), context.Background()


### PR DESCRIPTION
This PR come as a response for the Issue https://github.com/google/badwolf/issues/106.

After testing with the [SPARQL playground](http://sparql-playground.sib.swiss/) and two other online UIs, and looking at the [SPARQL - W3C Recommendation](https://www.w3.org/TR/rdf-sparql-query/), it was noted that with SPARQL the trailing dots are mandatory at the end of each clause inside `WHERE`, with the exception of the last clause (after which the dot is optional).

Then, as it was decided to follow the W3C SPARQL recommendation as close as possible, this PR comes to make BQL have the same behavior pointed above: mandatory trailing dots at the end of each clause inside `WHERE` with the exception of the last one (after which the dot will be optional).

To illustrate, given the query below:

```
SELECT ?o
FROM ?test
WHERE {
    /u<joe> "parent_of"@[] ?o .
    ?o "parent_of"@[] /u<john>
};
```

Now you can also write it as:

```
SELECT ?o
FROM ?test
WHERE {
    /u<joe> "parent_of"@[] ?o .
    ?o "parent_of"@[] /u<john> .
};
```

For more examples on this, please have a look at the new tests added in `planner_test.go` and `grammar_test.go`.