### PR TITLE
Create the file "test_util.go"

### DIFF
--- a/bql/semantic/expression_test.go
+++ b/bql/semantic/expression_test.go
@@ -15,15 +15,11 @@
 package semantic
 
 import (
-	"strings"
 	"testing"
-	"time"
 
 	"github.com/google/badwolf/bql/lexer"
 	"github.com/google/badwolf/bql/table"
-	"github.com/google/badwolf/triple/literal"
-	"github.com/google/badwolf/triple/node"
-	"github.com/google/badwolf/triple/predicate"
+	"github.com/google/badwolf/tools/testutil"
 )
 
 func TestEvaluationNode(t *testing.T) {
@@ -189,42 +185,6 @@ func TestBooleanEvaluationNode(t *testing.T) {
 			t.Errorf("failed to evaluate op %q for %v; got %v, want %v", entry.eval.(*booleanNode).op.String(), entry.eval, got, want)
 		}
 	}
-}
-
-func mustBuildLiteral(t *testing.T, textLiteral string) *literal.Literal {
-	t.Helper()
-	lit, err := literal.DefaultBuilder().Parse(textLiteral)
-	if err != nil {
-		t.Fatalf("could not parse text literal %q, got error: %v", textLiteral, err)
-	}
-	return lit
-}
-
-func mustBuildNodeFromStrings(t *testing.T, nodeType, nodeID string) *node.Node {
-	t.Helper()
-	n, err := node.NewNodeFromStrings(nodeType, nodeID)
-	if err != nil {
-		t.Fatalf("could not build node from type %q and ID %q, got error: %v", nodeType, nodeID, err)
-	}
-	return n
-}
-
-func mustBuildTime(t *testing.T, timeLiteral string) *time.Time {
-	t.Helper()
-	time, err := time.Parse(time.RFC3339Nano, strings.TrimSpace(timeLiteral))
-	if err != nil {
-		t.Fatalf("could not parse time literal %q, got error: %v", timeLiteral, err)
-	}
-	return &time
-}
-
-func mustBuildPredicate(t *testing.T, predicateLiteral string) *predicate.Predicate {
-	t.Helper()
-	p, err := predicate.Parse(predicateLiteral)
-	if err != nil {
-		t.Fatalf("could not parse predicate literal %q, got error: %v", predicateLiteral, err)
-	}
-	return p
 }
 
 func TestEvaluatorEvaluate(t *testing.T) {
@@ -438,7 +398,7 @@ func TestEvaluatorEvaluate(t *testing.T) {
 			},
 			r: table.Row{
 				"?foo": &table.Cell{
-					L: mustBuildLiteral(t, `"abc"^^type:text`),
+					L: testutil.MustBuildLiteral(t, `"abc"^^type:text`),
 				},
 			},
 			want: true,
@@ -539,7 +499,7 @@ func TestEvaluatorEvaluate(t *testing.T) {
 				}),
 			},
 			r: table.Row{
-				"?foo": &table.Cell{L: mustBuildLiteral(t, `"99.0"^^type:float64`)},
+				"?foo": &table.Cell{L: testutil.MustBuildLiteral(t, `"99.0"^^type:float64`)},
 			},
 			want: true,
 		},
@@ -559,7 +519,7 @@ func TestEvaluatorEvaluate(t *testing.T) {
 				}),
 			},
 			r: table.Row{
-				"?foo": &table.Cell{L: mustBuildLiteral(t, `"100"^^type:int64`)},
+				"?foo": &table.Cell{L: testutil.MustBuildLiteral(t, `"100"^^type:int64`)},
 			},
 			want: true,
 		},
@@ -579,7 +539,7 @@ func TestEvaluatorEvaluate(t *testing.T) {
 				}),
 			},
 			r: table.Row{
-				"?foo": &table.Cell{L: mustBuildLiteral(t, `"100"^^type:int64`)},
+				"?foo": &table.Cell{L: testutil.MustBuildLiteral(t, `"100"^^type:int64`)},
 			},
 			want: false,
 		},
@@ -599,7 +559,7 @@ func TestEvaluatorEvaluate(t *testing.T) {
 				}),
 			},
 			r: table.Row{
-				"?foo": &table.Cell{N: mustBuildNodeFromStrings(t, "/_", "meowth")},
+				"?foo": &table.Cell{N: testutil.MustBuildNodeFromStrings(t, "/_", "meowth")},
 			},
 			want: true,
 		},
@@ -619,7 +579,7 @@ func TestEvaluatorEvaluate(t *testing.T) {
 				}),
 			},
 			r: table.Row{
-				"?o": &table.Cell{N: mustBuildNodeFromStrings(t, "/u", "paul")},
+				"?o": &table.Cell{N: testutil.MustBuildNodeFromStrings(t, "/u", "paul")},
 			},
 			want: false,
 		},
@@ -639,7 +599,7 @@ func TestEvaluatorEvaluate(t *testing.T) {
 				}),
 			},
 			r: table.Row{
-				"?o": &table.Cell{L: mustBuildLiteral(t, `"73"^^type:int64`)},
+				"?o": &table.Cell{L: testutil.MustBuildLiteral(t, `"73"^^type:int64`)},
 			},
 			want: false,
 		},
@@ -659,7 +619,7 @@ func TestEvaluatorEvaluate(t *testing.T) {
 				}),
 			},
 			r: table.Row{
-				"?foo": &table.Cell{L: mustBuildLiteral(t, `"10"^^type:int64`)},
+				"?foo": &table.Cell{L: testutil.MustBuildLiteral(t, `"10"^^type:int64`)},
 			},
 			want: false,
 		},
@@ -679,7 +639,7 @@ func TestEvaluatorEvaluate(t *testing.T) {
 				}),
 			},
 			r: table.Row{
-				"?time": &table.Cell{T: mustBuildTime(t, `2012-02-10T00:00:00-08:00`)},
+				"?time": &table.Cell{T: testutil.MustBuildTime(t, `2012-02-10T00:00:00-08:00`)},
 			},
 			want: true,
 		},
@@ -699,7 +659,7 @@ func TestEvaluatorEvaluate(t *testing.T) {
 				}),
 			},
 			r: table.Row{
-				"?time": &table.Cell{T: mustBuildTime(t, `2012-04-10T00:00:00-08:00`)},
+				"?time": &table.Cell{T: testutil.MustBuildTime(t, `2012-04-10T00:00:00-08:00`)},
 			},
 			want: true,
 		},
@@ -719,7 +679,7 @@ func TestEvaluatorEvaluate(t *testing.T) {
 				}),
 			},
 			r: table.Row{
-				"?time": &table.Cell{T: mustBuildTime(t, `2012-03-10T00:00:00-08:00`)},
+				"?time": &table.Cell{T: testutil.MustBuildTime(t, `2012-03-10T00:00:00-08:00`)},
 			},
 			want: true,
 		},
@@ -739,7 +699,7 @@ func TestEvaluatorEvaluate(t *testing.T) {
 				}),
 			},
 			r: table.Row{
-				"?time": &table.Cell{T: mustBuildTime(t, `2012-02-10T00:00:00-08:00`)},
+				"?time": &table.Cell{T: testutil.MustBuildTime(t, `2012-02-10T00:00:00-08:00`)},
 			},
 			want: false,
 		},
@@ -759,7 +719,7 @@ func TestEvaluatorEvaluate(t *testing.T) {
 				}),
 			},
 			r: table.Row{
-				"?time": &table.Cell{T: mustBuildTime(t, `2012-04-10T00:00:00-08:00`)},
+				"?time": &table.Cell{T: testutil.MustBuildTime(t, `2012-04-10T00:00:00-08:00`)},
 			},
 			want: false,
 		},
@@ -779,7 +739,7 @@ func TestEvaluatorEvaluate(t *testing.T) {
 				}),
 			},
 			r: table.Row{
-				"?time": &table.Cell{T: mustBuildTime(t, `2012-03-10T00:00:00-08:00`)},
+				"?time": &table.Cell{T: testutil.MustBuildTime(t, `2012-03-10T00:00:00-08:00`)},
 			},
 			want: false,
 		},
@@ -799,7 +759,7 @@ func TestEvaluatorEvaluate(t *testing.T) {
 				}),
 			},
 			r: table.Row{
-				"?time": &table.Cell{T: mustBuildTime(t, `2015-03-10T00:00:00-08:00`)},
+				"?time": &table.Cell{T: testutil.MustBuildTime(t, `2015-03-10T00:00:00-08:00`)},
 			},
 			want: true,
 		},
@@ -819,7 +779,7 @@ func TestEvaluatorEvaluate(t *testing.T) {
 				}),
 			},
 			r: table.Row{
-				"?time": &table.Cell{T: mustBuildTime(t, `2015-03-10T00:00:00-08:00`)},
+				"?time": &table.Cell{T: testutil.MustBuildTime(t, `2015-03-10T00:00:00-08:00`)},
 			},
 			want: false,
 		},
@@ -839,7 +799,7 @@ func TestEvaluatorEvaluate(t *testing.T) {
 				}),
 			},
 			r: table.Row{
-				"?time": &table.Cell{T: mustBuildTime(t, `2015-03-10T00:00:00-08:00`)},
+				"?time": &table.Cell{T: testutil.MustBuildTime(t, `2015-03-10T00:00:00-08:00`)},
 			},
 			want: true,
 		},
@@ -859,7 +819,7 @@ func TestEvaluatorEvaluate(t *testing.T) {
 				}),
 			},
 			r: table.Row{
-				"?time": &table.Cell{T: mustBuildTime(t, `2015-03-10T01:00:00-07:00`)},
+				"?time": &table.Cell{T: testutil.MustBuildTime(t, `2015-03-10T01:00:00-07:00`)},
 			},
 			want: true,
 		},
@@ -879,7 +839,7 @@ func TestEvaluatorEvaluate(t *testing.T) {
 				}),
 			},
 			r: table.Row{
-				"?time": &table.Cell{T: mustBuildTime(t, `2015-03-10T00:00:00-08:00`)},
+				"?time": &table.Cell{T: testutil.MustBuildTime(t, `2015-03-10T00:00:00-08:00`)},
 			},
 			want: true,
 		},
@@ -899,7 +859,7 @@ func TestEvaluatorEvaluate(t *testing.T) {
 				}),
 			},
 			r: table.Row{
-				"?p": &table.Cell{P: mustBuildPredicate(t, `"height_cm"@[]`)},
+				"?p": &table.Cell{P: testutil.MustBuildPredicate(t, `"height_cm"@[]`)},
 			},
 			want: true,
 		},
@@ -919,7 +879,7 @@ func TestEvaluatorEvaluate(t *testing.T) {
 				}),
 			},
 			r: table.Row{
-				"?p": &table.Cell{P: mustBuildPredicate(t, `"bought"@[2016-01-01T00:00:00-08:00]`)},
+				"?p": &table.Cell{P: testutil.MustBuildPredicate(t, `"bought"@[2016-01-01T00:00:00-08:00]`)},
 			},
 			want: true,
 		},
@@ -939,7 +899,7 @@ func TestEvaluatorEvaluate(t *testing.T) {
 				}),
 			},
 			r: table.Row{
-				"?p": &table.Cell{P: mustBuildPredicate(t, `"bought"@[2016-01-01T00:00:00-08:00]`)},
+				"?p": &table.Cell{P: testutil.MustBuildPredicate(t, `"bought"@[2016-01-01T00:00:00-08:00]`)},
 			},
 			want: false,
 		},
@@ -959,7 +919,7 @@ func TestEvaluatorEvaluate(t *testing.T) {
 				}),
 			},
 			r: table.Row{
-				"?s": &table.Cell{N: mustBuildNodeFromStrings(t, "/u", "paul")},
+				"?s": &table.Cell{N: testutil.MustBuildNodeFromStrings(t, "/u", "paul")},
 			},
 			want: true,
 		},
@@ -979,7 +939,7 @@ func TestEvaluatorEvaluate(t *testing.T) {
 				}),
 			},
 			r: table.Row{
-				"?s": &table.Cell{N: mustBuildNodeFromStrings(t, "/u", "peter")},
+				"?s": &table.Cell{N: testutil.MustBuildNodeFromStrings(t, "/u", "peter")},
 			},
 			want: false,
 		},
@@ -1061,7 +1021,7 @@ func TestEvaluatorEvaluateError(t *testing.T) {
 				}),
 			},
 			r: table.Row{
-				"?p": &table.Cell{P: mustBuildPredicate(t, `"bought"@[]`)},
+				"?p": &table.Cell{P: testutil.MustBuildPredicate(t, `"bought"@[]`)},
 			},
 		},
 		{
@@ -1080,7 +1040,7 @@ func TestEvaluatorEvaluateError(t *testing.T) {
 				}),
 			},
 			r: table.Row{
-				"?p": &table.Cell{P: mustBuildPredicate(t, `"height_cm"@[2016-01-01T00:00:00-08:00]`)},
+				"?p": &table.Cell{P: testutil.MustBuildPredicate(t, `"height_cm"@[2016-01-01T00:00:00-08:00]`)},
 			},
 		},
 		{
@@ -1099,7 +1059,7 @@ func TestEvaluatorEvaluateError(t *testing.T) {
 				}),
 			},
 			r: table.Row{
-				"?s": &table.Cell{N: mustBuildNodeFromStrings(t, "/u", "peter")},
+				"?s": &table.Cell{N: testutil.MustBuildNodeFromStrings(t, "/u", "peter")},
 			},
 		},
 		{
@@ -1118,7 +1078,7 @@ func TestEvaluatorEvaluateError(t *testing.T) {
 				}),
 			},
 			r: table.Row{
-				"?s": &table.Cell{N: mustBuildNodeFromStrings(t, "/u", "alice")},
+				"?s": &table.Cell{N: testutil.MustBuildNodeFromStrings(t, "/u", "alice")},
 			},
 		},
 	}

--- a/storage/memory/memory_test.go
+++ b/storage/memory/memory_test.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/google/badwolf/storage"
+	"github.com/google/badwolf/tools/testutil"
 	"github.com/google/badwolf/triple"
 	"github.com/google/badwolf/triple/literal"
 	"github.com/google/badwolf/triple/node"
@@ -649,14 +650,6 @@ func TestTriplesForObjectLatestTemporal(t *testing.T) {
 	}
 }
 
-func mustParse(t string) *time.Time {
-	r, err := time.Parse(time.RFC3339Nano, t)
-	if err != nil {
-		panic(err)
-	}
-	return &r
-}
-
 func TestTriplesForObjectWithLimit(t *testing.T) {
 	ts := createTriples(t, []string{
 		"/u<bob>\t\"kissed\"@[2015-01-01T00:00:00-09:00]\t/u<mary>",
@@ -677,8 +670,8 @@ func TestTriplesForObjectWithLimit(t *testing.T) {
 	trpls := make(chan *triple.Triple, 100)
 	lo := &storage.LookupOptions{
 		MaxElements: 2,
-		LowerAnchor: mustParse("2015-04-01T00:00:00-08:00"),
-		UpperAnchor: mustParse("2015-06-01T00:00:00-10:00"),
+		LowerAnchor: testutil.MustBuildTime(t, "2015-04-01T00:00:00-08:00"),
+		UpperAnchor: testutil.MustBuildTime(t, "2015-06-01T00:00:00-10:00"),
 	}
 	if err := g.TriplesForObject(ctx, ts[0].Object(), lo, trpls); err != nil {
 		t.Errorf("g.TriplesForObject(%s) failed with error %v", ts[0].Object(), err)

--- a/tools/testutil/test_util.go
+++ b/tools/testutil/test_util.go
@@ -1,0 +1,51 @@
+package testutil
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/badwolf/triple/literal"
+	"github.com/google/badwolf/triple/node"
+	"github.com/google/badwolf/triple/predicate"
+)
+
+// MustBuildLiteral builds a Literal out of textLiteral or makes the given test to fail.
+func MustBuildLiteral(t *testing.T, textLiteral string) *literal.Literal {
+	t.Helper()
+	lit, err := literal.DefaultBuilder().Parse(textLiteral)
+	if err != nil {
+		t.Fatalf("could not parse text literal %q, got error: %v", textLiteral, err)
+	}
+	return lit
+}
+
+// MustBuildNodeFromStrings builds a Node out of nodeType and nodeID or makes the given test to fail.
+func MustBuildNodeFromStrings(t *testing.T, nodeType, nodeID string) *node.Node {
+	t.Helper()
+	n, err := node.NewNodeFromStrings(nodeType, nodeID)
+	if err != nil {
+		t.Fatalf("could not build node from type %q and ID %q, got error: %v", nodeType, nodeID, err)
+	}
+	return n
+}
+
+// MustBuildTime builds a Time out of timeLiteral or makes the given test to fail.
+func MustBuildTime(t *testing.T, timeLiteral string) *time.Time {
+	t.Helper()
+	time, err := time.Parse(time.RFC3339Nano, strings.TrimSpace(timeLiteral))
+	if err != nil {
+		t.Fatalf("could not parse time literal %q, got error: %v", timeLiteral, err)
+	}
+	return &time
+}
+
+// MustBuildPredicate builds a Predicate out of predicateLiteral or makes the given test to fail.
+func MustBuildPredicate(t *testing.T, predicateLiteral string) *predicate.Predicate {
+	t.Helper()
+	p, err := predicate.Parse(predicateLiteral)
+	if err != nil {
+		t.Fatalf("could not parse predicate literal %q, got error: %v", predicateLiteral, err)
+	}
+	return p
+}


### PR DESCRIPTION
Some functions like `mustBuildLiteral` and `mustBuildPredicate`, previously defined inside "expression_test.go", are useful for other test files as well.

Then, this PR comes to isolate these useful functions in one unique file, "test_util.go", and refactor "expression_test.go" to import these functions from there.