### PR TITLE
Add header comments to test_util.go

### DIFF
--- a/tools/testutil/test_util.go
+++ b/tools/testutil/test_util.go
@@ -1,3 +1,18 @@
+// Copyright 2020 Google Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package testutil implements utility functions used in testing.
 package testutil
 
 import (


### PR DESCRIPTION
This lib was implemented in PR #144, but it seems that we forgot to add this header comment on it.