### PR TITLE
FILTER keyword for latest anchor queries (grammar/lexer/hooks)

### DIFF
--- a/bql/grammar/grammar.go
+++ b/bql/grammar/grammar.go
@@ -327,6 +327,7 @@ func moreClauses() []*Clause {
 			Elements: []Element{
 				NewTokenType(lexer.ItemDot),
 				NewSymbol("CLAUSES"),
+				NewSymbol("FILTER_CLAUSES"),
 			},
 		},
 		{},
@@ -359,6 +360,33 @@ func clauses() []*Clause {
 				NewSymbol("PREDICATE"),
 				NewSymbol("OBJECT"),
 				NewSymbol("MORE_CLAUSES"),
+			},
+		},
+		{},
+	}
+}
+
+func moreFilterClauses() []*Clause {
+	return []*Clause{
+		{
+			Elements: []Element{
+				NewTokenType(lexer.ItemDot),
+				NewSymbol("FILTER_CLAUSES"),
+			},
+		},
+		{},
+	}
+}
+func filterClauses() []*Clause {
+	return []*Clause{
+		{
+			Elements: []Element{
+				NewTokenType(lexer.ItemFilter),
+				NewTokenType(lexer.ItemFilterFunction),
+				NewTokenType(lexer.ItemLPar),
+				NewTokenType(lexer.ItemBinding),
+				NewTokenType(lexer.ItemRPar),
+				NewSymbol("MORE_FILTER_CLAUSES"),
 			},
 		},
 		{},
@@ -1266,6 +1294,8 @@ func BQL() *Grammar {
 		"MORE_CLAUSES":                           moreClauses(),
 		"CLAUSES":                                clauses(),
 		"OPTIONAL_CLAUSE":                        optionalClauses(),
+		"FILTER_CLAUSES":                         filterClauses(),
+		"MORE_FILTER_CLAUSES":                    moreFilterClauses(),
 		"SUBJECT_EXTRACT":                        subjectExtractClauses(),
 		"SUBJECT_TYPE":                           subjectTypeClauses(),
 		"SUBJECT_ID":                             subjectIDClauses(),

--- a/bql/grammar/grammar.go
+++ b/bql/grammar/grammar.go
@@ -1430,6 +1430,12 @@ func SemanticBQL() *Grammar {
 	}
 	setElementHook(semanticBQL, objSymbols, semantic.WhereObjectClauseHook(), nil)
 
+	// Filter clause hook.
+	filterSymbols := []semantic.Symbol{
+		"FILTER_CLAUSES",
+	}
+	setElementHook(semanticBQL, filterSymbols, semantic.WhereFilterClauseHook(), nil)
+
 	// Collect binding variables variables.
 	varSymbols := []semantic.Symbol{
 		"VARS", "VARS_AS", "MORE_VARS", "COUNT_DISTINCT",

--- a/bql/lexer/lexer.go
+++ b/bql/lexer/lexer.go
@@ -139,6 +139,8 @@ const (
 	ItemGraphs
 	// ItemOptional identifies optional graph pattern clauses.
 	ItemOptional
+	// ItemFilter represents the filter keyword in BQL.
+	ItemFilter
 )
 
 func (tt TokenType) String() string {
@@ -253,6 +255,8 @@ func (tt TokenType) String() string {
 		return "GRAPHS"
 	case ItemOptional:
 		return "OPTIONAL"
+	case ItemFilter:
+		return "FILTER"
 	default:
 		return "UNKNOWN"
 	}

--- a/bql/lexer/lexer.go
+++ b/bql/lexer/lexer.go
@@ -141,6 +141,8 @@ const (
 	ItemOptional
 	// ItemFilter represents the filter keyword in BQL.
 	ItemFilter
+	// ItemFilterFunction represents a filter function in BQL.
+	ItemFilterFunction
 )
 
 func (tt TokenType) String() string {
@@ -257,6 +259,8 @@ func (tt TokenType) String() string {
 		return "OPTIONAL"
 	case ItemFilter:
 		return "FILTER"
+	case ItemFilterFunction:
+		return "FILTER_FUNCTION"
 	default:
 		return "UNKNOWN"
 	}

--- a/bql/lexer/lexer_test.go
+++ b/bql/lexer/lexer_test.go
@@ -76,6 +76,8 @@ func TestTokenTypeString(t *testing.T) {
 		{ItemShow, "SHOW"},
 		{ItemGraphs, "GRAPHS"},
 		{ItemOptional, "OPTIONAL"},
+		{ItemFilter, "FILTER"},
+		{ItemFilterFunction, "FILTER_FUNCTION"},
 		{TokenType(-1), "UNKNOWN"},
 	}
 
@@ -388,6 +390,29 @@ func TestIndividualTokens(t *testing.T) {
 				{Type: ItemEOF},
 			},
 		},
+		{
+			`FILTER latest(?p)`,
+			[]Token{
+				{Type: ItemFilter, Text: "FILTER"},
+				{Type: ItemFilterFunction, Text: "latest"},
+				{Type: ItemLPar, Text: "("},
+				{Type: ItemBinding, Text: "?p"},
+				{Type: ItemRPar, Text: ")"},
+				{Type: ItemEOF},
+			},
+		},
+		{
+			`FILTER latest(?p) .`,
+			[]Token{
+				{Type: ItemFilter, Text: "FILTER"},
+				{Type: ItemFilterFunction, Text: "latest"},
+				{Type: ItemLPar, Text: "("},
+				{Type: ItemBinding, Text: "?p"},
+				{Type: ItemRPar, Text: ")"},
+				{Type: ItemDot, Text: "."},
+				{Type: ItemEOF},
+			},
+		},
 	}
 
 	for _, test := range table {
@@ -576,6 +601,36 @@ func TestValidTokenQuery(t *testing.T) {
 				ItemBinding, ItemBinding, ItemAt, ItemBinding, ItemBinding,
 				ItemRBracket,
 				ItemHaving, ItemBinding, ItemEQ, ItemTime, ItemSemicolon, ItemEOF,
+			},
+		},
+		{
+			`select ?s ?p ?o
+			from ?foo
+			where {
+				?s ?p ?o .
+				FILTER latest(?p)
+			};`,
+			[]TokenType{
+				ItemQuery, ItemBinding, ItemBinding, ItemBinding, ItemFrom, ItemBinding,
+				ItemWhere, ItemLBracket, ItemBinding, ItemBinding, ItemBinding, ItemDot,
+				ItemFilter, ItemFilterFunction, ItemLPar, ItemBinding, ItemRPar,
+				ItemRBracket, ItemSemicolon, ItemEOF,
+			},
+		},
+		{
+			`select ?s ?p ?o
+			from ?foo
+			where {
+				?s ?p ?o .
+				FILTER latest(?p) .
+				FILTER latest(?o)
+			};`,
+			[]TokenType{
+				ItemQuery, ItemBinding, ItemBinding, ItemBinding, ItemFrom, ItemBinding,
+				ItemWhere, ItemLBracket, ItemBinding, ItemBinding, ItemBinding, ItemDot,
+				ItemFilter, ItemFilterFunction, ItemLPar, ItemBinding, ItemRPar, ItemDot,
+				ItemFilter, ItemFilterFunction, ItemLPar, ItemBinding, ItemRPar,
+				ItemRBracket, ItemSemicolon, ItemEOF,
 			},
 		},
 	}

--- a/bql/semantic/convert.go
+++ b/bql/semantic/convert.go
@@ -69,7 +69,7 @@ func (c ConsumedElement) Token() *lexer.Token {
 	return c.token
 }
 
-// Token returns the boxed token.
+// String returns a string representation of the ConsumedElement.
 func (c ConsumedElement) String() string {
 	return fmt.Sprintf("{isSymbol=%v, symbol=%s, token=%s}", c.isSymbol, c.symbol, c.token)
 }

--- a/bql/semantic/convert.go
+++ b/bql/semantic/convert.go
@@ -69,6 +69,11 @@ func (c ConsumedElement) Token() *lexer.Token {
 	return c.token
 }
 
+// Token returns the boxed token.
+func (c ConsumedElement) String() string {
+	return fmt.Sprintf("{isSymbol=%v, symbol=%s, token=%s}", c.isSymbol, c.symbol, c.token)
+}
+
 // ToNode converts the node found by the lexer and converts it into a BadWolf
 // node.
 func ToNode(ce ConsumedElement) (*node.Node, error) {

--- a/bql/semantic/hooks.go
+++ b/bql/semantic/hooks.go
@@ -92,6 +92,12 @@ func WhereObjectClauseHook() ElementHook {
 	return whereObjectClause()
 }
 
+// WhereFilterClauseHook returns the singleton for the working filter clause hook that
+// populates the filters list.
+func WhereFilterClauseHook() ElementHook {
+	return whereFilterClause()
+}
+
 // VarAccumulatorHook returns the singleton for accumulating variable
 // projections.
 func VarAccumulatorHook() ElementHook {
@@ -336,6 +342,7 @@ func whereInitWorkingClause() ClauseHook {
 	var hook ClauseHook
 	hook = func(s *Statement, _ Symbol) (ClauseHook, error) {
 		s.ResetWorkingGraphClause()
+		s.ResetWorkingFilterClause()
 		return hook, nil
 	}
 	return hook
@@ -661,6 +668,59 @@ func whereObjectClause() ElementHook {
 		lastNopToken = tkn
 		return hook, nil
 	}
+	return hook
+}
+
+// whereFilterClause returns an element hook that updates the working filter clause and,
+// if the filter clause is complete, populates the filters list of the statement.
+func whereFilterClause() ElementHook {
+	var hook ElementHook
+	supportedFilterFunctions := map[string]bool{
+		"latest": true,
+	}
+
+	hook = func(st *Statement, ce ConsumedElement) (ElementHook, error) {
+		if ce.IsSymbol() {
+			return hook, nil
+		}
+
+		tkn := ce.Token()
+		currFilter := st.WorkingFilter()
+		switch tkn.Type {
+		case lexer.ItemFilterFunction:
+			if currFilter == nil {
+				return nil, fmt.Errorf("could not add filter function %q to nil filter clause", tkn.Text)
+			}
+			if currFilter.Operation != "" {
+				return nil, fmt.Errorf("invalid filter function %q on filter clause since already set to %q", tkn.Text, currFilter.Operation)
+			}
+			if !supportedFilterFunctions[tkn.Text] {
+				return nil, fmt.Errorf("filter function %q on filter clause is not supported", tkn.Text)
+			}
+			currFilter.Operation = tkn.Text
+			return hook, nil
+		case lexer.ItemBinding:
+			if currFilter == nil {
+				return nil, fmt.Errorf("could not add binding %q to nil filter clause", tkn.Text)
+			}
+			if currFilter.Operation == "" {
+				return nil, fmt.Errorf("could not add binding %q to a filter clause that does not have a filter function previously set", tkn.Text)
+			}
+			if currFilter.Binding != "" {
+				return nil, fmt.Errorf("invalid binding %q on filter clause since already set to %q", tkn.Text, currFilter.Binding)
+			}
+			currFilter.Binding = tkn.Text
+			return hook, nil
+		case lexer.ItemRPar:
+			if currFilter == nil || currFilter.Operation == "" || currFilter.Binding == "" {
+				return nil, fmt.Errorf("could not add invalid working filter %q to the statement filters list", currFilter)
+			}
+			st.AddWorkingFilterClause()
+		}
+
+		return hook, nil
+	}
+
 	return hook
 }
 

--- a/bql/semantic/semantic.go
+++ b/bql/semantic/semantic.go
@@ -103,6 +103,7 @@ type Statement struct {
 	limitSet                  bool
 	limit                     int64
 	lookupOptions             storage.LookupOptions
+	filters                   []*FilterClause
 }
 
 // GraphClause represents a clause of a graph pattern in a where clause.
@@ -141,6 +142,16 @@ type GraphClause struct {
 	OLowerBoundAlias string
 	OUpperBoundAlias string
 	OTemporal        bool
+}
+
+// FilterClause represents a FILTER clause inside WHERE.
+// Operation below refers to the filter function being applied (eg: "latest"), Binding refers to the binding it
+// will be applied to and Value, when specified, contains the second argument of the filter function (not applicable for all
+// Operations - some like "latest" do not use it while others like "greaterThan" do, see Issue 129).
+type FilterClause struct {
+	Operation string
+	Binding   string
+	Value     string
 }
 
 // ConstructClause represents a singular clause within a construct statement.
@@ -582,6 +593,11 @@ func (s *Statement) Data() []*triple.Triple {
 // GraphPatternClauses returns the list of graph pattern clauses
 func (s *Statement) GraphPatternClauses() []*GraphClause {
 	return s.pattern
+}
+
+// FilterClauses returns the list of FILTER clauses.
+func (s *Statement) FilterClauses() []*FilterClause {
+	return s.filters
 }
 
 // ResetWorkingGraphClause resets the current working graph clause.

--- a/bql/semantic/semantic.go
+++ b/bql/semantic/semantic.go
@@ -104,6 +104,7 @@ type Statement struct {
 	limit                     int64
 	lookupOptions             storage.LookupOptions
 	filters                   []*FilterClause
+	workingFilter             *FilterClause
 }
 
 // GraphClause represents a clause of a graph pattern in a where clause.
@@ -608,6 +609,11 @@ func (s *Statement) ResetWorkingGraphClause() {
 // WorkingClause returns the current working clause.
 func (s *Statement) WorkingClause() *GraphClause {
 	return s.workingClause
+}
+
+// WorkingFilter returns the current working filter.
+func (s *Statement) WorkingFilter() *FilterClause {
+	return s.workingFilter
 }
 
 // AddWorkingGraphClause adds the current working graph clause to the set of

--- a/bql/semantic/semantic.go
+++ b/bql/semantic/semantic.go
@@ -411,6 +411,11 @@ func (c *GraphClause) IsEmpty() bool {
 	return reflect.DeepEqual(c, &GraphClause{})
 }
 
+// IsEmpty will return true if there are no set values in the filter clause.
+func (f *FilterClause) IsEmpty() bool {
+	return reflect.DeepEqual(f, &FilterClause{})
+}
+
 // String returns a readable representation of a construct clause.
 func (c *ConstructClause) String() string {
 	b := bytes.NewBufferString("{ ")
@@ -606,6 +611,11 @@ func (s *Statement) ResetWorkingGraphClause() {
 	s.workingClause = &GraphClause{}
 }
 
+// ResetWorkingFilterClause resets the current working filter clause.
+func (s *Statement) ResetWorkingFilterClause() {
+	s.workingFilter = &FilterClause{}
+}
+
 // WorkingClause returns the current working clause.
 func (s *Statement) WorkingClause() *GraphClause {
 	return s.workingClause
@@ -623,6 +633,12 @@ func (s *Statement) AddWorkingGraphClause() {
 		s.pattern = append(s.pattern, s.workingClause)
 	}
 	s.ResetWorkingGraphClause()
+}
+
+// AddWorkingFilterClause adds the current working filter clause to the filters list.
+func (s *Statement) AddWorkingFilterClause() {
+	s.filters = append(s.filters, s.workingFilter)
+	s.ResetWorkingFilterClause()
 }
 
 // Projection returns the available projections in the statement.

--- a/bql/semantic/semantic.go
+++ b/bql/semantic/semantic.go
@@ -416,6 +416,11 @@ func (f *FilterClause) IsEmpty() bool {
 	return reflect.DeepEqual(f, &FilterClause{})
 }
 
+// String returns a string representation of the filter clause.
+func (f *FilterClause) String() string {
+	return fmt.Sprintf("%+v", *f)
+}
+
 // String returns a readable representation of a construct clause.
 func (c *ConstructClause) String() string {
 	b := bytes.NewBufferString("{ ")

--- a/bql/semantic/semantic_test.go
+++ b/bql/semantic/semantic_test.go
@@ -262,7 +262,7 @@ func TestGraphClauseManipulation(t *testing.T) {
 func TestFilterClauseManipulation(t *testing.T) {
 	st := &Statement{}
 
-	t.Run("test workingFilter initial states", func(t *testing.T) {
+	t.Run("workingFilter initial states ok", func(t *testing.T) {
 		if wf := st.WorkingFilter(); wf != nil {
 			t.Fatalf(`semantic.Statement.WorkingFilter() = %q for statement "%v" without initialization; want nil`, wf, st)
 		}
@@ -272,7 +272,7 @@ func TestFilterClauseManipulation(t *testing.T) {
 		}
 	})
 
-	t.Run("test call to add workingFilter", func(t *testing.T) {
+	t.Run("add workingFilter success", func(t *testing.T) {
 		wf := st.WorkingFilter()
 		*wf = FilterClause{Operation: "latest", Binding: "?p"}
 		st.AddWorkingFilterClause()

--- a/bql/semantic/semantic_test.go
+++ b/bql/semantic/semantic_test.go
@@ -259,6 +259,32 @@ func TestGraphClauseManipulation(t *testing.T) {
 	}
 }
 
+func TestFilterClauseManipulation(t *testing.T) {
+	st := &Statement{}
+
+	t.Run("test workingFilter initial states", func(t *testing.T) {
+		if wf := st.WorkingFilter(); wf != nil {
+			t.Fatalf(`semantic.Statement.WorkingFilter() = %q for statement "%v" without initialization; want nil`, wf, st)
+		}
+		st.ResetWorkingFilterClause()
+		if wf := st.WorkingFilter(); wf == nil || !wf.IsEmpty() {
+			t.Fatalf(`semantic.Statement.WorkingFilter() = %q for statement "%v" after call to ResetWorkingFilterClause; want empty FilterClause`, wf, st)
+		}
+	})
+
+	t.Run("test call to add workingFilter", func(t *testing.T) {
+		wf := st.WorkingFilter()
+		*wf = FilterClause{Operation: "latest", Binding: "?p"}
+		st.AddWorkingFilterClause()
+		if got, want := len(st.FilterClauses()), 1; got != want {
+			t.Fatalf(`len(semantic.Statement.FilterClauses()) = %d for statement "%v"; want %d`, got, st, want)
+		}
+		if wf = st.WorkingFilter(); wf == nil || !wf.IsEmpty() {
+			t.Fatalf(`semantic.Statement.WorkingFilter() = %q for statement "%v"; want empty FilterClause`, wf, st)
+		}
+	})
+}
+
 func TestBindingListing(t *testing.T) {
 	stm := Statement{}
 	stm.ResetWorkingGraphClause()
@@ -322,6 +348,27 @@ func TestIsEmptyClause(t *testing.T) {
 		}
 	}
 
+}
+
+func TestIsEmptyFilterClause(t *testing.T) {
+	testTable := []struct {
+		in   *FilterClause
+		want bool
+	}{
+		{
+			in:   &FilterClause{},
+			want: true,
+		},
+		{
+			in:   &FilterClause{Operation: "latest", Binding: "?p"},
+			want: false,
+		},
+	}
+	for _, entry := range testTable {
+		if got := entry.in.IsEmpty(); got != entry.want {
+			t.Errorf("FilterClause.IsEmpty(%q) = %v; want %v", entry.in, got, entry.want)
+		}
+	}
 }
 
 func TestSortedGraphPatternClauses(t *testing.T) {


### PR DESCRIPTION
This PR comes as the first step on #129, starting to set up a `FILTER` keyword in BadWolf at the grammar, lexer and hooks levels. The first `FILTER` function chosen to be implemented is the `latest` one, to solve what was requested by #86.

It would be very useful to have in BQL a `FILTER` keyword that could allow us to filter out part of the results of a query in a level closer to the storage (closer to the driver), improving performance. This is exactly what this PR starts to introduce, setting up the foundations for this keyword in the grammar, lexer and hooks.

The final objective is to allow the user to specify, inside of `WHERE`, which bindings they want to apply a `FILTER` to, proceeding with a more fine-grained lookup on storage, avoiding unnecessary retrieval of data and optimizing query performance.

To illustrate, queries such as the one below will in the future be possible:

```
SELECT ?s, ?p, ?o
FROM ?test
WHERE {
    ?s ?p ?o .
    FILTER latest(?p)
};
```

That would return all the temporal triples of the `?test` graph that have the latest timestamp of the time series they are part of (a recorrent use case in BadWolf), skipping immutable triples found along the way. 

Regarding their position inside `WHERE`, `FILTER` clauses must come after all the graph pattern clauses, just by the end of the `WHERE` (closer to its closing bracket). Regarding trailing dots, a `FILTER` clause is understood just like any other graph clause inside of `WHERE`: the trailing dot is mandatory at the end of each clause (`FILTER` or graph ones indistinguishably), with the exception of the last one (for which the dot is optional).