### PR TITLE
FILTER keyword for latest anchor queries (planner/memory)

### DIFF
--- a/bql/planner/data_access.go
+++ b/bql/planner/data_access.go
@@ -45,9 +45,10 @@ var _ error = (*skippableError)(nil)
 // provided graph clause.
 func updateTimeBounds(lo *storage.LookupOptions, cls *semantic.GraphClause) *storage.LookupOptions {
 	nlo := &storage.LookupOptions{
-		MaxElements: lo.MaxElements,
-		LowerAnchor: lo.LowerAnchor,
-		UpperAnchor: lo.UpperAnchor,
+		MaxElements:   lo.MaxElements,
+		LowerAnchor:   lo.LowerAnchor,
+		UpperAnchor:   lo.UpperAnchor,
+		FilterOptions: lo.FilterOptions,
 	}
 	if cls.PLowerBound != nil {
 		if lo.LowerAnchor == nil || (lo.LowerAnchor != nil && cls.PLowerBound.After(*lo.LowerAnchor)) {

--- a/bql/planner/filter/filter.go
+++ b/bql/planner/filter/filter.go
@@ -27,6 +27,16 @@ const (
 	Latest Operation = iota + 1
 )
 
+// Field represents the position of the semantic.GraphClause that will be operated by the filter at storage level.
+type Field int
+
+// List of filter fields.
+const (
+	SubjectField Field = iota + 1
+	PredicateField
+	ObjectField
+)
+
 // SupportedOperations maps suported filter operation strings to their correspondant Operation.
 // Note that the string keys here must be in lowercase letters only (for compatibility with the WhereFilterClauseHook).
 var SupportedOperations = map[string]Operation{
@@ -39,7 +49,7 @@ var SupportedOperations = map[string]Operation{
 // function (not applicable for all Operations - some like "latest" do not use it while others like "greaterThan" do, see Issue 129).
 type StorageOptions struct {
 	Operation Operation
-	Field     string
+	Field     Field
 	Value     string
 }
 
@@ -50,6 +60,20 @@ func (op Operation) String() string {
 		return "latest"
 	default:
 		return fmt.Sprintf(`not defined filter operation "%d"`, op)
+	}
+}
+
+// String returns the string representation of Field.
+func (f Field) String() string {
+	switch f {
+	case SubjectField:
+		return "subject field"
+	case PredicateField:
+		return "predicate field"
+	case ObjectField:
+		return "object field"
+	default:
+		return fmt.Sprintf(`not defined filter field "%d"`, f)
 	}
 }
 

--- a/bql/planner/filter/filter.go
+++ b/bql/planner/filter/filter.go
@@ -33,6 +33,16 @@ var SupportedOperations = map[string]Operation{
 	"latest": Latest,
 }
 
+// StorageOptions represent the storage level specifications for the filtering to be executed.
+// Operation below refers to the filter function being applied (eg: "latest"), Field refers to the position of the graph clause it
+// will be applied to ("subject", "predicate" or "object") and Value, when specified, contains the second argument of the filter
+// function (not applicable for all Operations - some like "latest" do not use it while others like "greaterThan" do, see Issue 129).
+type StorageOptions struct {
+	Operation Operation
+	Field     string
+	Value     string
+}
+
 // String returns the string representation of Operation.
 func (op Operation) String() string {
 	switch op {

--- a/bql/planner/filter/filter.go
+++ b/bql/planner/filter/filter.go
@@ -44,9 +44,9 @@ var SupportedOperations = map[string]Operation{
 }
 
 // StorageOptions represent the storage level specifications for the filtering to be executed.
-// Operation below refers to the filter function being applied (eg: "latest"), Field refers to the position of the graph clause it
-// will be applied to ("subject", "predicate" or "object") and Value, when specified, contains the second argument of the filter
-// function (not applicable for all Operations - some like "latest" do not use it while others like "greaterThan" do, see Issue 129).
+// Operation below refers to the filter function being applied (eg: Latest), Field refers to the position of the graph clause it
+// will be applied to (subject, predicate, or object) and Value, when specified, contains the second argument of the filter
+// function (not applicable for all Operations - some like Latest do not use it while others like GreaterThan do, see Issue 129).
 type StorageOptions struct {
 	Operation Operation
 	Field     Field

--- a/bql/planner/filter/filter.go
+++ b/bql/planner/filter/filter.go
@@ -63,6 +63,11 @@ func (op Operation) String() string {
 	}
 }
 
+// IsEmpty returns true if the Operation was not set yet.
+func (op Operation) IsEmpty() bool {
+	return op == Operation(0)
+}
+
 // String returns the string representation of Field.
 func (f Field) String() string {
 	switch f {

--- a/bql/planner/filter/filter.go
+++ b/bql/planner/filter/filter.go
@@ -1,0 +1,44 @@
+// Copyright 2020 Google Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package filter isolates core FILTER related implementation.
+package filter
+
+import (
+	"fmt"
+)
+
+// Operation represents a filter operation supported in BadWolf.
+type Operation int
+
+// List of supported filter operations.
+const (
+	Latest Operation = iota + 1
+)
+
+// SupportedOperations maps suported filter operation strings to their correspondant Operation.
+// Note that the string keys here must be in lowercase letters only (for compatibility with the WhereFilterClauseHook).
+var SupportedOperations = map[string]Operation{
+	"latest": Latest,
+}
+
+// String returns the string representation of Operation.
+func (op Operation) String() string {
+	switch op {
+	case Latest:
+		return "latest"
+	default:
+		return fmt.Sprintf(`not defined filter operation "%d"`, op)
+	}
+}

--- a/bql/planner/filter/filter.go
+++ b/bql/planner/filter/filter.go
@@ -52,3 +52,8 @@ func (op Operation) String() string {
 		return fmt.Sprintf(`not defined filter operation "%d"`, op)
 	}
 }
+
+// String returns the string representation of StorageOptions.
+func (so *StorageOptions) String() string {
+	return fmt.Sprintf("%+v", *so)
+}

--- a/bql/planner/planner.go
+++ b/bql/planner/planner.go
@@ -676,9 +676,9 @@ func compatibleBindingsInClauseForFilterOperation(operation filter.Operation) (c
 
 // organizeFilterOptionsByClause processes all the given filters and organize them in a map that has as keys the
 // clauses to which they must be applied.
-func organizeFilterOptionsByClause(filters []*semantic.FilterClause, clauses []*semantic.GraphClause) (map[*semantic.GraphClause]*storage.FilteringOptions, error) {
+func organizeFilterOptionsByClause(filters []*semantic.FilterClause, clauses []*semantic.GraphClause) (map[*semantic.GraphClause]*filter.StorageOptions, error) {
 	clausesByBinding := organizeClausesByBinding(clauses)
-	filterOptionsByClause := map[*semantic.GraphClause]*storage.FilteringOptions{}
+	filterOptionsByClause := map[*semantic.GraphClause]*filter.StorageOptions{}
 
 	for _, f := range filters {
 		if _, ok := clausesByBinding[f.Binding]; !ok {
@@ -699,7 +699,7 @@ func organizeFilterOptionsByClause(filters []*semantic.FilterClause, clauses []*
 			for field, bndgs := range compatibleBindingsByField {
 				if bndgs[f.Binding] {
 					filterBindingIsCompatible = true
-					filterOptionsByClause[cls] = &storage.FilteringOptions{
+					filterOptionsByClause[cls] = &filter.StorageOptions{
 						Operation: f.Operation,
 						Field:     field,
 						Value:     f.Value,
@@ -718,7 +718,7 @@ func organizeFilterOptionsByClause(filters []*semantic.FilterClause, clauses []*
 
 // addFilterOptions adds FilterOptions to lookup options if the given clause has bindings for which
 // filters were defined (organized in filterOptionsByClause).
-func addFilterOptions(lo *storage.LookupOptions, cls *semantic.GraphClause, filterOptionsByClause map[*semantic.GraphClause]*storage.FilteringOptions) {
+func addFilterOptions(lo *storage.LookupOptions, cls *semantic.GraphClause, filterOptionsByClause map[*semantic.GraphClause]*filter.StorageOptions) {
 	if _, ok := filterOptionsByClause[cls]; ok {
 		lo.FilterOptions = filterOptionsByClause[cls]
 	}
@@ -726,7 +726,7 @@ func addFilterOptions(lo *storage.LookupOptions, cls *semantic.GraphClause, filt
 
 // resetFilterOptions resets FilterOptions in lookup options to nil.
 func resetFilterOptions(lo *storage.LookupOptions) {
-	lo.FilterOptions = (*storage.FilteringOptions)(nil)
+	lo.FilterOptions = (*filter.StorageOptions)(nil)
 }
 
 // processGraphPattern process the query graph pattern to retrieve the

--- a/bql/planner/planner.go
+++ b/bql/planner/planner.go
@@ -267,6 +267,7 @@ type queryPlan struct {
 	grfsNames []string
 	grfs      []storage.Graph
 	cls       []*semantic.GraphClause
+	filters   []*semantic.FilterClause
 	tbl       *table.Table
 	chanSize  int
 	tracer    io.Writer
@@ -293,6 +294,7 @@ func newQueryPlan(ctx context.Context, store storage.Store, stm *semantic.Statem
 		bndgs:     bs,
 		grfsNames: stm.InputGraphNames(),
 		cls:       stm.GraphPatternClauses(),
+		filters:   stm.FilterClauses(),
 		tbl:       t,
 		chanSize:  chanSize,
 		tracer:    w,

--- a/bql/planner/planner.go
+++ b/bql/planner/planner.go
@@ -667,11 +667,10 @@ func compatibleBindingsInClauseForFilterOperation(operation filter.Operation) (c
 			}
 			return bindingsByField
 		}
+		return compatibleBindingsInClause, nil
 	default:
 		return nil, fmt.Errorf("filter function %q has no bindings in clause specified for it (planner level)", operation)
 	}
-
-	return compatibleBindingsInClause, nil
 }
 
 // organizeFilterOptionsByClause processes all the given filters and organize them in a map that has as keys the

--- a/bql/planner/planner.go
+++ b/bql/planner/planner.go
@@ -883,6 +883,12 @@ func (p *queryPlan) String(ctx context.Context) string {
 		b.WriteString(c.String())
 		b.WriteString("\n")
 	}
+	b.WriteString("with filters\n")
+	for _, f := range p.filters {
+		b.WriteString("\t")
+		b.WriteString(f.String())
+		b.WriteString("\n")
+	}
 	b.WriteString("project results using\n")
 	for _, p := range p.stm.Projection() {
 		b.WriteString("\t")

--- a/bql/planner/planner.go
+++ b/bql/planner/planner.go
@@ -28,6 +28,7 @@ import (
 	"sync"
 
 	"github.com/google/badwolf/bql/lexer"
+	"github.com/google/badwolf/bql/planner/filter"
 	"github.com/google/badwolf/bql/planner/tracer"
 	"github.com/google/badwolf/bql/semantic"
 	"github.com/google/badwolf/bql/table"
@@ -656,9 +657,9 @@ func organizeClausesByBinding(clauses []*semantic.GraphClause) map[string][]*sem
 
 // compatibleBindingsInClauseForFilterOperation returns a function that, for each given clause, returns the bindings that are
 // compatible with the specified filter operation.
-func compatibleBindingsInClauseForFilterOperation(operation string) (compatibleBindingsInClause func(cls *semantic.GraphClause) (bindingsByField map[string]map[string]bool), err error) {
+func compatibleBindingsInClauseForFilterOperation(operation filter.Operation) (compatibleBindingsInClause func(cls *semantic.GraphClause) (bindingsByField map[string]map[string]bool), err error) {
 	switch operation {
-	case "latest":
+	case filter.Latest:
 		compatibleBindingsInClause = func(cls *semantic.GraphClause) (bindingsByField map[string]map[string]bool) {
 			bindingsByField = map[string]map[string]bool{
 				"predicate": {cls.PBinding: true, cls.PAlias: true},
@@ -667,7 +668,7 @@ func compatibleBindingsInClauseForFilterOperation(operation string) (compatibleB
 			return
 		}
 	default:
-		err = fmt.Errorf("filter function %q on filter clause is not supported", operation)
+		err = fmt.Errorf("filter function %q has no bindings in clause specified for it (planner level)", operation)
 	}
 
 	return

--- a/bql/planner/planner.go
+++ b/bql/planner/planner.go
@@ -665,13 +665,13 @@ func compatibleBindingsInClauseForFilterOperation(operation filter.Operation) (c
 				filter.PredicateField: {cls.PBinding: true, cls.PAlias: true},
 				filter.ObjectField:    {cls.OBinding: true, cls.OAlias: true},
 			}
-			return
+			return bindingsByField
 		}
 	default:
-		err = fmt.Errorf("filter function %q has no bindings in clause specified for it (planner level)", operation)
+		return nil, fmt.Errorf("filter function %q has no bindings in clause specified for it (planner level)", operation)
 	}
 
-	return
+	return compatibleBindingsInClause, nil
 }
 
 // organizeFilterOptionsByClause processes all the given filters and organize them in a map that has as keys the

--- a/bql/planner/planner.go
+++ b/bql/planner/planner.go
@@ -657,13 +657,13 @@ func organizeClausesByBinding(clauses []*semantic.GraphClause) map[string][]*sem
 
 // compatibleBindingsInClauseForFilterOperation returns a function that, for each given clause, returns the bindings that are
 // compatible with the specified filter operation.
-func compatibleBindingsInClauseForFilterOperation(operation filter.Operation) (compatibleBindingsInClause func(cls *semantic.GraphClause) (bindingsByField map[string]map[string]bool), err error) {
+func compatibleBindingsInClauseForFilterOperation(operation filter.Operation) (compatibleBindingsInClause func(cls *semantic.GraphClause) (bindingsByField map[filter.Field]map[string]bool), err error) {
 	switch operation {
 	case filter.Latest:
-		compatibleBindingsInClause = func(cls *semantic.GraphClause) (bindingsByField map[string]map[string]bool) {
-			bindingsByField = map[string]map[string]bool{
-				"predicate": {cls.PBinding: true, cls.PAlias: true},
-				"object":    {cls.OBinding: true, cls.OAlias: true},
+		compatibleBindingsInClause = func(cls *semantic.GraphClause) (bindingsByField map[filter.Field]map[string]bool) {
+			bindingsByField = map[filter.Field]map[string]bool{
+				filter.PredicateField: {cls.PBinding: true, cls.PAlias: true},
+				filter.ObjectField:    {cls.OBinding: true, cls.OAlias: true},
 			}
 			return
 		}

--- a/bql/planner/planner_test.go
+++ b/bql/planner/planner_test.go
@@ -39,6 +39,8 @@ const (
 		/u<peter> "bought"@[2016-02-01T00:00:00-08:00] /c<model s>
 		/u<peter> "bought"@[2016-03-01T00:00:00-08:00] /c<model x>
 		/u<peter> "bought"@[2016-04-01T00:00:00-08:00] /c<model y>
+		/u<paul> "bought"@[2016-01-01T00:00:00-08:00] /c<model n>
+		/u<paul> "bought"@[2016-04-01T00:00:00-08:00] /c<model r>
 		/c<mini> "is_a"@[] /t<car>
 		/c<model s> "is_a"@[] /t<car>
 		/c<model x> "is_a"@[] /t<car>
@@ -48,6 +50,7 @@ const (
 		/l<barcelona> "predicate"@[] "turned"@[2016-03-01T00:00:00-08:00]
 		/l<barcelona> "predicate"@[] "turned"@[2016-04-01T00:00:00-08:00]
 		/l<barcelona> "predicate"@[] "immutable_predicate"@[]
+		/l<paris> "predicate"@[] "turned"@[2016-04-01T00:00:00-08:00]
 		/u<alice> "height_cm"@[] "174"^^type:int64
 		/u<alice> "tag"@[] "abc"^^type:text
 		/u<bob> "height_cm"@[] "151"^^type:int64
@@ -840,7 +843,7 @@ func TestPlannerQuery(t *testing.T) {
 				}
 				HAVING (?p_id < "in"^^type:text) AND (?time > 2016-02-01T00:00:00-08:00);`,
 			nBindings: 4,
-			nRows:     2,
+			nRows:     3,
 		},
 		{
 			q: `SELECT ?p, ?time
@@ -958,7 +961,7 @@ func TestPlannerQuery(t *testing.T) {
 					?s ?p ?o AT ?o_time
 				};`,
 			nBindings: 3,
-			nRows:     4,
+			nRows:     5,
 		},
 		{
 			q: `SELECT ?s, ?o, ?o_time
@@ -978,7 +981,7 @@ func TestPlannerQuery(t *testing.T) {
 					?s ?p "turned"@[?o_time]
 				};`,
 			nBindings: 2,
-			nRows:     4,
+			nRows:     5,
 		},
 	}
 

--- a/bql/planner/planner_test.go
+++ b/bql/planner/planner_test.go
@@ -983,6 +983,130 @@ func TestPlannerQuery(t *testing.T) {
 			nBindings: 2,
 			nRows:     5,
 		},
+		{
+			q: `SELECT ?p, ?o
+				FROM ?test
+				WHERE {
+					/u<peter> ?p ?o .
+					FILTER latest(?p)
+				};`,
+			nBindings: 2,
+			nRows:     1,
+		},
+		{
+			q: `SELECT ?p_alias, ?o
+				FROM ?test
+				WHERE {
+					/u<peter> ?p AS ?p_alias ?o .
+					FILTER latest(?p_alias)
+				};`,
+			nBindings: 2,
+			nRows:     1,
+		},
+		{
+			q: `SELECT ?p, ?o
+				FROM ?test
+				WHERE {
+					/l<barcelona> ?p ?o .
+					FILTER latest(?o)
+				};`,
+			nBindings: 2,
+			nRows:     1,
+		},
+		{
+			q: `SELECT ?p, ?o_alias
+				FROM ?test
+				WHERE {
+					/l<barcelona> ?p ?o AS ?o_alias .
+					FILTER latest(?o_alias)
+				};`,
+			nBindings: 2,
+			nRows:     1,
+		},
+		{
+			q: `SELECT ?p1, ?p2
+				FROM ?test
+				WHERE {
+					/u<peter> ?p1 ?o1 .
+					/item/book<000> ?p2 ?o2 .
+					FILTER latest(?p1) .
+					FILTER latest(?p2)
+				};`,
+			nBindings: 2,
+			nRows:     1,
+		},
+		{
+			q: `SELECT ?s, ?p, ?o
+				FROM ?test
+				WHERE {
+					?s ?p ?o .
+					FILTER latest(?p)
+				};`,
+			nBindings: 3,
+			nRows:     3,
+		},
+		{
+			q: `SELECT ?s, ?p, ?o
+				FROM ?test
+				WHERE {
+					?s ?p ?o .
+					FILTER latest(?o)
+				};`,
+			nBindings: 3,
+			nRows:     2,
+		},
+		{
+			q: `SELECT ?s, ?p_alias, ?o
+				FROM ?test
+				WHERE {
+					?s "bought"@[2016-03-01T00:00:00-08:00] AS ?p_alias ?o .
+					FILTER latest(?p_alias)
+				};`,
+			nBindings: 3,
+			nRows:     1,
+		},
+		{
+			q: `SELECT ?s, ?p, ?o_alias
+				FROM ?test
+				WHERE {
+					?s ?p "turned"@[2016-03-01T00:00:00-08:00] AS ?o_alias .
+					FILTER latest(?o_alias)
+				};`,
+			nBindings: 3,
+			nRows:     1,
+		},
+		{
+			q: `SELECT ?s, ?p, ?o
+				FROM ?test
+				WHERE {
+					?s "bought"@[?time] ?o .
+					OPTIONAL { ?s ?p ?o } .
+					FILTER latest(?p)
+				};`,
+			nBindings: 3,
+			nRows:     6,
+		},
+		{
+			q: `SELECT ?p
+				FROM ?test
+				WHERE {
+					/u<peter> ?p ?o1 .
+					/u<paul> ?p ?o2 .
+					FILTER latest(?p)
+				};`,
+			nBindings: 1,
+			nRows:     1,
+		},
+		{
+			q: `SELECT ?p, ?o
+				FROM ?test
+				WHERE {
+					/u<peter> ?p ?o .
+					FILTER lAtEsT(?p) .
+				};`,
+			nBindings: 2,
+			nRows:     1,
+		},
 	}
 
 	s, ctx := memory.NewStore(), context.Background()
@@ -1067,6 +1191,40 @@ func TestPlannerQueryError(t *testing.T) {
 					?s "height_cm"@[] ?height
 				}
 				HAVING ?s > /u<alice>;`,
+		},
+		{
+			q: `SELECT ?p, ?o
+				FROM ?test
+				WHERE {
+					/u<peter> ?p ?o .
+					FILTER latest(?p) .
+					FILTER latest(?p)
+				};`,
+		},
+		{
+			q: `SELECT ?p, ?o
+				FROM ?test
+				WHERE {
+					/l<barcelona> ?p ?o .
+					FILTER latest(?p) .
+					FILTER latest(?o)
+				};`,
+		},
+		{
+			q: `SELECT ?p, ?o
+				FROM ?test
+				WHERE {
+					/u<peter> ?p ?o .
+					FILTER latest(?b_not_exist)
+				};`,
+		},
+		{
+			q: `SELECT ?s, ?p, ?o
+				FROM ?test
+				WHERE {
+					?s ID ?sID ?p ?o .
+					FILTER latest(?sID)
+				};`,
 		},
 	}
 

--- a/bql/semantic/hooks.go
+++ b/bql/semantic/hooks.go
@@ -675,9 +675,6 @@ func whereObjectClause() ElementHook {
 // if the filter clause is complete, populates the filters list of the statement.
 func whereFilterClause() ElementHook {
 	var hook ElementHook
-	supportedFilterFunctions := map[string]bool{
-		"latest": true,
-	}
 
 	hook = func(st *Statement, ce ConsumedElement) (ElementHook, error) {
 		if ce.IsSymbol() {
@@ -693,9 +690,6 @@ func whereFilterClause() ElementHook {
 			}
 			if currFilter.Operation != "" {
 				return nil, fmt.Errorf("invalid filter function %q on filter clause since already set to %q", tkn.Text, currFilter.Operation)
-			}
-			if !supportedFilterFunctions[tkn.Text] {
-				return nil, fmt.Errorf("filter function %q on filter clause is not supported", tkn.Text)
 			}
 			currFilter.Operation = tkn.Text
 			return hook, nil

--- a/bql/semantic/hooks.go
+++ b/bql/semantic/hooks.go
@@ -689,7 +689,7 @@ func whereFilterClause() ElementHook {
 			if currFilter == nil {
 				return nil, fmt.Errorf("could not add filter function %q to nil filter clause", tkn.Text)
 			}
-			if currFilter.Operation != filter.Operation(0) {
+			if !currFilter.Operation.IsEmpty() {
 				return nil, fmt.Errorf("invalid filter function %q on filter clause since already set to %q", tkn.Text, currFilter.Operation)
 			}
 			lowercaseFilter := strings.ToLower(tkn.Text)
@@ -702,7 +702,7 @@ func whereFilterClause() ElementHook {
 			if currFilter == nil {
 				return nil, fmt.Errorf("could not add binding %q to nil filter clause", tkn.Text)
 			}
-			if currFilter.Operation == filter.Operation(0) {
+			if currFilter.Operation.IsEmpty() {
 				return nil, fmt.Errorf("could not add binding %q to a filter clause that does not have a filter function previously set", tkn.Text)
 			}
 			if currFilter.Binding != "" {
@@ -711,7 +711,7 @@ func whereFilterClause() ElementHook {
 			currFilter.Binding = tkn.Text
 			return hook, nil
 		case lexer.ItemRPar:
-			if currFilter == nil || currFilter.Operation == filter.Operation(0) || currFilter.Binding == "" {
+			if currFilter == nil || currFilter.Operation.IsEmpty() || currFilter.Binding == "" {
 				return nil, fmt.Errorf("could not add invalid working filter %q to the statement filters list", currFilter)
 			}
 			st.AddWorkingFilterClause()

--- a/bql/semantic/hooks_test.go
+++ b/bql/semantic/hooks_test.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/google/badwolf/bql/lexer"
+	"github.com/google/badwolf/bql/planner/filter"
 	"github.com/google/badwolf/bql/table"
 	"github.com/google/badwolf/storage"
 	"github.com/google/badwolf/triple"
@@ -223,7 +224,7 @@ func TestWhereFilterClauseHook(t *testing.T) {
 				NewConsumedSymbol("FOO"),
 			},
 			want: &FilterClause{
-				Operation: "latest",
+				Operation: filter.Latest,
 				Binding:   "?p",
 			},
 		},
@@ -253,7 +254,7 @@ func TestWhereFilterClauseHook(t *testing.T) {
 				NewConsumedSymbol("FOO"),
 			},
 			want: &FilterClause{
-				Operation: "latest",
+				Operation: filter.Latest,
 				Binding:   "?o",
 			},
 		},

--- a/bql/semantic/semantic.go
+++ b/bql/semantic/semantic.go
@@ -27,6 +27,7 @@ import (
 	"time"
 
 	"github.com/google/badwolf/bql/lexer"
+	"github.com/google/badwolf/bql/planner/filter"
 	"github.com/google/badwolf/bql/table"
 	"github.com/google/badwolf/storage"
 	"github.com/google/badwolf/triple"
@@ -150,7 +151,7 @@ type GraphClause struct {
 // will be applied to and Value, when specified, contains the second argument of the filter function (not applicable for all
 // Operations - some like "latest" do not use it while others like "greaterThan" do, see Issue 129).
 type FilterClause struct {
-	Operation string
+	Operation filter.Operation
 	Binding   string
 	Value     string
 }

--- a/bql/semantic/semantic.go
+++ b/bql/semantic/semantic.go
@@ -147,9 +147,9 @@ type GraphClause struct {
 }
 
 // FilterClause represents a FILTER clause inside WHERE.
-// Operation below refers to the filter function being applied (eg: "latest"), Binding refers to the binding it
+// Operation below refers to the filter function being applied (eg: Latest), Binding refers to the binding it
 // will be applied to and Value, when specified, contains the second argument of the filter function (not applicable for all
-// Operations - some like "latest" do not use it while others like "greaterThan" do, see Issue 129).
+// Operations - some like Latest do not use it while others like GreaterThan do, see Issue 129).
 type FilterClause struct {
 	Operation filter.Operation
 	Binding   string

--- a/bql/semantic/semantic_test.go
+++ b/bql/semantic/semantic_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/badwolf/bql/planner/filter"
 	"github.com/google/badwolf/triple"
 	"github.com/google/badwolf/triple/literal"
 	"github.com/google/badwolf/triple/node"
@@ -274,7 +275,7 @@ func TestFilterClauseManipulation(t *testing.T) {
 
 	t.Run("add workingFilter success", func(t *testing.T) {
 		wf := st.WorkingFilter()
-		*wf = FilterClause{Operation: "latest", Binding: "?p"}
+		*wf = FilterClause{Operation: filter.Latest, Binding: "?p"}
 		st.AddWorkingFilterClause()
 		if got, want := len(st.FilterClauses()), 1; got != want {
 			t.Fatalf(`len(semantic.Statement.FilterClauses()) = %d for statement "%v"; want %d`, got, st, want)
@@ -360,7 +361,7 @@ func TestIsEmptyFilterClause(t *testing.T) {
 			want: true,
 		},
 		{
-			in:   &FilterClause{Operation: "latest", Binding: "?p"},
+			in:   &FilterClause{Operation: filter.Latest, Binding: "?p"},
 			want: false,
 		},
 	}

--- a/storage/memoization/memoization_test.go
+++ b/storage/memoization/memoization_test.go
@@ -31,7 +31,7 @@ import (
 )
 
 func TestCombinedUUID(t *testing.T) {
-	want := "op:9dae52f4-9b35-5d5f-bd8e-195d4b16fc30:00000000-0000-0000-0000-000000000000:00000000-0000-0000-0000-000000000000"
+	want := "op:420c34d3-9f56-5191-89de-57468c3e6a93:00000000-0000-0000-0000-000000000000:00000000-0000-0000-0000-000000000000"
 	if got := combinedUUID("op", storage.DefaultLookup, uuid.NIL, uuid.NIL); got != want {
 		t.Errorf("combinedUUID returned the wrong value; got %v, want %v", got, want)
 	}

--- a/storage/memory/memory.go
+++ b/storage/memory/memory.go
@@ -276,7 +276,7 @@ func (c *checker) CheckAndUpdate(p *predicate.Predicate) bool {
 }
 
 // latestFilter executes the latest filter operation over memoryTriples following filterOptions.
-func latestFilter(memoryTriples map[string]*triple.Triple, pQuery *predicate.Predicate, filterOptions *storage.FilteringOptions) (map[string]*triple.Triple, error) {
+func latestFilter(memoryTriples map[string]*triple.Triple, pQuery *predicate.Predicate, filterOptions *filter.StorageOptions) (map[string]*triple.Triple, error) {
 	if filterOptions.Field != "predicate" && filterOptions.Field != "object" {
 		return nil, fmt.Errorf(`invalid field %q for "latest" filter operation, can accept only "predicate" or "object"`, filterOptions.Field)
 	}
@@ -323,7 +323,7 @@ func latestFilter(memoryTriples map[string]*triple.Triple, pQuery *predicate.Pre
 }
 
 // executeFilter executes the proper filter operation over memoryTriples following the specifications given in filterOptions.
-func executeFilter(memoryTriples map[string]*triple.Triple, pQuery *predicate.Predicate, filterOptions *storage.FilteringOptions) (map[string]*triple.Triple, error) {
+func executeFilter(memoryTriples map[string]*triple.Triple, pQuery *predicate.Predicate, filterOptions *filter.StorageOptions) (map[string]*triple.Triple, error) {
 	switch filterOptions.Operation {
 	case filter.Latest:
 		return latestFilter(memoryTriples, pQuery, filterOptions)
@@ -350,13 +350,13 @@ func (m *memory) Objects(ctx context.Context, s *node.Node, p *predicate.Predica
 		if lo.FilterOptions != nil {
 			return fmt.Errorf("cannot have LatestAnchor and FilterOptions used at the same time inside lookup options")
 		}
-		lo.FilterOptions = &storage.FilteringOptions{
+		lo.FilterOptions = &filter.StorageOptions{
 			Operation: filter.Latest,
 			Field:     "predicate",
 		}
 		// To guarantee that "lo.FilterOptions" will be cleaned at the driver level, since it was artificially created at the driver level for "LatestAnchor".
 		defer func() {
-			lo.FilterOptions = (*storage.FilteringOptions)(nil)
+			lo.FilterOptions = (*filter.StorageOptions)(nil)
 		}()
 	}
 	if lo.FilterOptions != nil {
@@ -399,13 +399,13 @@ func (m *memory) Subjects(ctx context.Context, p *predicate.Predicate, o *triple
 		if lo.FilterOptions != nil {
 			return fmt.Errorf("cannot have LatestAnchor and FilterOptions used at the same time inside lookup options")
 		}
-		lo.FilterOptions = &storage.FilteringOptions{
+		lo.FilterOptions = &filter.StorageOptions{
 			Operation: filter.Latest,
 			Field:     "predicate",
 		}
 		// To guarantee that "lo.FilterOptions" will be cleaned at the driver level, since it was artificially created at the driver level for "LatestAnchor".
 		defer func() {
-			lo.FilterOptions = (*storage.FilteringOptions)(nil)
+			lo.FilterOptions = (*filter.StorageOptions)(nil)
 		}()
 	}
 	if lo.FilterOptions != nil {
@@ -448,13 +448,13 @@ func (m *memory) PredicatesForSubjectAndObject(ctx context.Context, s *node.Node
 		if lo.FilterOptions != nil {
 			return fmt.Errorf("cannot have LatestAnchor and FilterOptions used at the same time inside lookup options")
 		}
-		lo.FilterOptions = &storage.FilteringOptions{
+		lo.FilterOptions = &filter.StorageOptions{
 			Operation: filter.Latest,
 			Field:     "predicate",
 		}
 		// To guarantee that "lo.FilterOptions" will be cleaned at the driver level, since it was artificially created at the driver level for "LatestAnchor".
 		defer func() {
-			lo.FilterOptions = (*storage.FilteringOptions)(nil)
+			lo.FilterOptions = (*filter.StorageOptions)(nil)
 		}()
 	}
 	if lo.FilterOptions != nil {
@@ -495,13 +495,13 @@ func (m *memory) PredicatesForSubject(ctx context.Context, s *node.Node, lo *sto
 		if lo.FilterOptions != nil {
 			return fmt.Errorf("cannot have LatestAnchor and FilterOptions used at the same time inside lookup options")
 		}
-		lo.FilterOptions = &storage.FilteringOptions{
+		lo.FilterOptions = &filter.StorageOptions{
 			Operation: filter.Latest,
 			Field:     "predicate",
 		}
 		// To guarantee that "lo.FilterOptions" will be cleaned at the driver level, since it was artificially created at the driver level for "LatestAnchor".
 		defer func() {
-			lo.FilterOptions = (*storage.FilteringOptions)(nil)
+			lo.FilterOptions = (*filter.StorageOptions)(nil)
 		}()
 	}
 	if lo.FilterOptions != nil {
@@ -542,13 +542,13 @@ func (m *memory) PredicatesForObject(ctx context.Context, o *triple.Object, lo *
 		if lo.FilterOptions != nil {
 			return fmt.Errorf("cannot have LatestAnchor and FilterOptions used at the same time inside lookup options")
 		}
-		lo.FilterOptions = &storage.FilteringOptions{
+		lo.FilterOptions = &filter.StorageOptions{
 			Operation: filter.Latest,
 			Field:     "predicate",
 		}
 		// To guarantee that "lo.FilterOptions" will be cleaned at the driver level, since it was artificially created at the driver level for "LatestAnchor".
 		defer func() {
-			lo.FilterOptions = (*storage.FilteringOptions)(nil)
+			lo.FilterOptions = (*filter.StorageOptions)(nil)
 		}()
 	}
 	if lo.FilterOptions != nil {
@@ -589,13 +589,13 @@ func (m *memory) TriplesForSubject(ctx context.Context, s *node.Node, lo *storag
 		if lo.FilterOptions != nil {
 			return fmt.Errorf("cannot have LatestAnchor and FilterOptions used at the same time inside lookup options")
 		}
-		lo.FilterOptions = &storage.FilteringOptions{
+		lo.FilterOptions = &filter.StorageOptions{
 			Operation: filter.Latest,
 			Field:     "predicate",
 		}
 		// To guarantee that "lo.FilterOptions" will be cleaned at the driver level, since it was artificially created at the driver level for "LatestAnchor".
 		defer func() {
-			lo.FilterOptions = (*storage.FilteringOptions)(nil)
+			lo.FilterOptions = (*filter.StorageOptions)(nil)
 		}()
 	}
 	if lo.FilterOptions != nil {
@@ -636,13 +636,13 @@ func (m *memory) TriplesForPredicate(ctx context.Context, p *predicate.Predicate
 		if lo.FilterOptions != nil {
 			return fmt.Errorf("cannot have LatestAnchor and FilterOptions used at the same time inside lookup options")
 		}
-		lo.FilterOptions = &storage.FilteringOptions{
+		lo.FilterOptions = &filter.StorageOptions{
 			Operation: filter.Latest,
 			Field:     "predicate",
 		}
 		// To guarantee that "lo.FilterOptions" will be cleaned at the driver level, since it was artificially created at the driver level for "LatestAnchor".
 		defer func() {
-			lo.FilterOptions = (*storage.FilteringOptions)(nil)
+			lo.FilterOptions = (*filter.StorageOptions)(nil)
 		}()
 	}
 	if lo.FilterOptions != nil {
@@ -683,13 +683,13 @@ func (m *memory) TriplesForObject(ctx context.Context, o *triple.Object, lo *sto
 		if lo.FilterOptions != nil {
 			return fmt.Errorf("cannot have LatestAnchor and FilterOptions used at the same time inside lookup options")
 		}
-		lo.FilterOptions = &storage.FilteringOptions{
+		lo.FilterOptions = &filter.StorageOptions{
 			Operation: filter.Latest,
 			Field:     "predicate",
 		}
 		// To guarantee that "lo.FilterOptions" will be cleaned at the driver level, since it was artificially created at the driver level for "LatestAnchor".
 		defer func() {
-			lo.FilterOptions = (*storage.FilteringOptions)(nil)
+			lo.FilterOptions = (*filter.StorageOptions)(nil)
 		}()
 	}
 	if lo.FilterOptions != nil {
@@ -732,13 +732,13 @@ func (m *memory) TriplesForSubjectAndPredicate(ctx context.Context, s *node.Node
 		if lo.FilterOptions != nil {
 			return fmt.Errorf("cannot have LatestAnchor and FilterOptions used at the same time inside lookup options")
 		}
-		lo.FilterOptions = &storage.FilteringOptions{
+		lo.FilterOptions = &filter.StorageOptions{
 			Operation: filter.Latest,
 			Field:     "predicate",
 		}
 		// To guarantee that "lo.FilterOptions" will be cleaned at the driver level, since it was artificially created at the driver level for "LatestAnchor".
 		defer func() {
-			lo.FilterOptions = (*storage.FilteringOptions)(nil)
+			lo.FilterOptions = (*filter.StorageOptions)(nil)
 		}()
 	}
 	if lo.FilterOptions != nil {
@@ -781,13 +781,13 @@ func (m *memory) TriplesForPredicateAndObject(ctx context.Context, p *predicate.
 		if lo.FilterOptions != nil {
 			return fmt.Errorf("cannot have LatestAnchor and FilterOptions used at the same time inside lookup options")
 		}
-		lo.FilterOptions = &storage.FilteringOptions{
+		lo.FilterOptions = &filter.StorageOptions{
 			Operation: filter.Latest,
 			Field:     "predicate",
 		}
 		// To guarantee that "lo.FilterOptions" will be cleaned at the driver level, since it was artificially created at the driver level for "LatestAnchor".
 		defer func() {
-			lo.FilterOptions = (*storage.FilteringOptions)(nil)
+			lo.FilterOptions = (*filter.StorageOptions)(nil)
 		}()
 	}
 	if lo.FilterOptions != nil {
@@ -836,13 +836,13 @@ func (m *memory) Triples(ctx context.Context, lo *storage.LookupOptions, trpls c
 		if lo.FilterOptions != nil {
 			return fmt.Errorf("cannot have LatestAnchor and FilterOptions used at the same time inside lookup options")
 		}
-		lo.FilterOptions = &storage.FilteringOptions{
+		lo.FilterOptions = &filter.StorageOptions{
 			Operation: filter.Latest,
 			Field:     "predicate",
 		}
 		// To guarantee that "lo.FilterOptions" will be cleaned at the driver level, since it was artificially created at the driver level for "LatestAnchor".
 		defer func() {
-			lo.FilterOptions = (*storage.FilteringOptions)(nil)
+			lo.FilterOptions = (*filter.StorageOptions)(nil)
 		}()
 	}
 	if lo.FilterOptions != nil {

--- a/storage/memory/memory.go
+++ b/storage/memory/memory.go
@@ -22,6 +22,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/google/badwolf/bql/planner/filter"
 	"github.com/google/badwolf/storage"
 	"github.com/google/badwolf/triple"
 	"github.com/google/badwolf/triple/node"
@@ -324,7 +325,7 @@ func latestFilter(memoryTriples map[string]*triple.Triple, pQuery *predicate.Pre
 // executeFilter executes the proper filter operation over memoryTriples following the specifications given in filterOptions.
 func executeFilter(memoryTriples map[string]*triple.Triple, pQuery *predicate.Predicate, filterOptions *storage.FilteringOptions) (map[string]*triple.Triple, error) {
 	switch filterOptions.Operation {
-	case "latest":
+	case filter.Latest:
 		return latestFilter(memoryTriples, pQuery, filterOptions)
 	default:
 		return nil, fmt.Errorf("filter operation %q not supported in the driver", filterOptions.Operation)
@@ -350,7 +351,7 @@ func (m *memory) Objects(ctx context.Context, s *node.Node, p *predicate.Predica
 			return fmt.Errorf("cannot have LatestAnchor and FilterOptions used at the same time inside lookup options")
 		}
 		lo.FilterOptions = &storage.FilteringOptions{
-			Operation: "latest",
+			Operation: filter.Latest,
 			Field:     "predicate",
 		}
 		// To guarantee that "lo.FilterOptions" will be cleaned at the driver level, since it was artificially created at the driver level for "LatestAnchor".
@@ -399,7 +400,7 @@ func (m *memory) Subjects(ctx context.Context, p *predicate.Predicate, o *triple
 			return fmt.Errorf("cannot have LatestAnchor and FilterOptions used at the same time inside lookup options")
 		}
 		lo.FilterOptions = &storage.FilteringOptions{
-			Operation: "latest",
+			Operation: filter.Latest,
 			Field:     "predicate",
 		}
 		// To guarantee that "lo.FilterOptions" will be cleaned at the driver level, since it was artificially created at the driver level for "LatestAnchor".
@@ -448,7 +449,7 @@ func (m *memory) PredicatesForSubjectAndObject(ctx context.Context, s *node.Node
 			return fmt.Errorf("cannot have LatestAnchor and FilterOptions used at the same time inside lookup options")
 		}
 		lo.FilterOptions = &storage.FilteringOptions{
-			Operation: "latest",
+			Operation: filter.Latest,
 			Field:     "predicate",
 		}
 		// To guarantee that "lo.FilterOptions" will be cleaned at the driver level, since it was artificially created at the driver level for "LatestAnchor".
@@ -495,7 +496,7 @@ func (m *memory) PredicatesForSubject(ctx context.Context, s *node.Node, lo *sto
 			return fmt.Errorf("cannot have LatestAnchor and FilterOptions used at the same time inside lookup options")
 		}
 		lo.FilterOptions = &storage.FilteringOptions{
-			Operation: "latest",
+			Operation: filter.Latest,
 			Field:     "predicate",
 		}
 		// To guarantee that "lo.FilterOptions" will be cleaned at the driver level, since it was artificially created at the driver level for "LatestAnchor".
@@ -542,7 +543,7 @@ func (m *memory) PredicatesForObject(ctx context.Context, o *triple.Object, lo *
 			return fmt.Errorf("cannot have LatestAnchor and FilterOptions used at the same time inside lookup options")
 		}
 		lo.FilterOptions = &storage.FilteringOptions{
-			Operation: "latest",
+			Operation: filter.Latest,
 			Field:     "predicate",
 		}
 		// To guarantee that "lo.FilterOptions" will be cleaned at the driver level, since it was artificially created at the driver level for "LatestAnchor".
@@ -589,7 +590,7 @@ func (m *memory) TriplesForSubject(ctx context.Context, s *node.Node, lo *storag
 			return fmt.Errorf("cannot have LatestAnchor and FilterOptions used at the same time inside lookup options")
 		}
 		lo.FilterOptions = &storage.FilteringOptions{
-			Operation: "latest",
+			Operation: filter.Latest,
 			Field:     "predicate",
 		}
 		// To guarantee that "lo.FilterOptions" will be cleaned at the driver level, since it was artificially created at the driver level for "LatestAnchor".
@@ -636,7 +637,7 @@ func (m *memory) TriplesForPredicate(ctx context.Context, p *predicate.Predicate
 			return fmt.Errorf("cannot have LatestAnchor and FilterOptions used at the same time inside lookup options")
 		}
 		lo.FilterOptions = &storage.FilteringOptions{
-			Operation: "latest",
+			Operation: filter.Latest,
 			Field:     "predicate",
 		}
 		// To guarantee that "lo.FilterOptions" will be cleaned at the driver level, since it was artificially created at the driver level for "LatestAnchor".
@@ -683,7 +684,7 @@ func (m *memory) TriplesForObject(ctx context.Context, o *triple.Object, lo *sto
 			return fmt.Errorf("cannot have LatestAnchor and FilterOptions used at the same time inside lookup options")
 		}
 		lo.FilterOptions = &storage.FilteringOptions{
-			Operation: "latest",
+			Operation: filter.Latest,
 			Field:     "predicate",
 		}
 		// To guarantee that "lo.FilterOptions" will be cleaned at the driver level, since it was artificially created at the driver level for "LatestAnchor".
@@ -732,7 +733,7 @@ func (m *memory) TriplesForSubjectAndPredicate(ctx context.Context, s *node.Node
 			return fmt.Errorf("cannot have LatestAnchor and FilterOptions used at the same time inside lookup options")
 		}
 		lo.FilterOptions = &storage.FilteringOptions{
-			Operation: "latest",
+			Operation: filter.Latest,
 			Field:     "predicate",
 		}
 		// To guarantee that "lo.FilterOptions" will be cleaned at the driver level, since it was artificially created at the driver level for "LatestAnchor".
@@ -781,7 +782,7 @@ func (m *memory) TriplesForPredicateAndObject(ctx context.Context, p *predicate.
 			return fmt.Errorf("cannot have LatestAnchor and FilterOptions used at the same time inside lookup options")
 		}
 		lo.FilterOptions = &storage.FilteringOptions{
-			Operation: "latest",
+			Operation: filter.Latest,
 			Field:     "predicate",
 		}
 		// To guarantee that "lo.FilterOptions" will be cleaned at the driver level, since it was artificially created at the driver level for "LatestAnchor".
@@ -836,7 +837,7 @@ func (m *memory) Triples(ctx context.Context, lo *storage.LookupOptions, trpls c
 			return fmt.Errorf("cannot have LatestAnchor and FilterOptions used at the same time inside lookup options")
 		}
 		lo.FilterOptions = &storage.FilteringOptions{
-			Operation: "latest",
+			Operation: filter.Latest,
 			Field:     "predicate",
 		}
 		// To guarantee that "lo.FilterOptions" will be cleaned at the driver level, since it was artificially created at the driver level for "LatestAnchor".

--- a/storage/memory/memory.go
+++ b/storage/memory/memory.go
@@ -277,8 +277,8 @@ func (c *checker) CheckAndUpdate(p *predicate.Predicate) bool {
 
 // latestFilter executes the latest filter operation over memoryTriples following filterOptions.
 func latestFilter(memoryTriples map[string]*triple.Triple, pQuery *predicate.Predicate, filterOptions *filter.StorageOptions) (map[string]*triple.Triple, error) {
-	if filterOptions.Field != "predicate" && filterOptions.Field != "object" {
-		return nil, fmt.Errorf(`invalid field %q for "latest" filter operation, can accept only "predicate" or "object"`, filterOptions.Field)
+	if filterOptions.Field != filter.PredicateField && filterOptions.Field != filter.ObjectField {
+		return nil, fmt.Errorf("invalid field %q for %q filter operation, can accept only %q or %q", filterOptions.Field, filter.Latest, filter.PredicateField, filter.ObjectField)
 	}
 
 	lastTA := make(map[string]*time.Time)
@@ -289,9 +289,9 @@ func latestFilter(memoryTriples map[string]*triple.Triple, pQuery *predicate.Pre
 		}
 
 		var p *predicate.Predicate
-		if filterOptions.Field == "predicate" {
+		if filterOptions.Field == filter.PredicateField {
 			p = t.Predicate()
-		} else if pObj, err := t.Object().Predicate(); filterOptions.Field == "object" && err == nil {
+		} else if pObj, err := t.Object().Predicate(); filterOptions.Field == filter.ObjectField && err == nil {
 			p = pObj
 		} else {
 			continue
@@ -352,7 +352,7 @@ func (m *memory) Objects(ctx context.Context, s *node.Node, p *predicate.Predica
 		}
 		lo.FilterOptions = &filter.StorageOptions{
 			Operation: filter.Latest,
-			Field:     "predicate",
+			Field:     filter.PredicateField,
 		}
 		// To guarantee that "lo.FilterOptions" will be cleaned at the driver level, since it was artificially created at the driver level for "LatestAnchor".
 		defer func() {
@@ -401,7 +401,7 @@ func (m *memory) Subjects(ctx context.Context, p *predicate.Predicate, o *triple
 		}
 		lo.FilterOptions = &filter.StorageOptions{
 			Operation: filter.Latest,
-			Field:     "predicate",
+			Field:     filter.PredicateField,
 		}
 		// To guarantee that "lo.FilterOptions" will be cleaned at the driver level, since it was artificially created at the driver level for "LatestAnchor".
 		defer func() {
@@ -450,7 +450,7 @@ func (m *memory) PredicatesForSubjectAndObject(ctx context.Context, s *node.Node
 		}
 		lo.FilterOptions = &filter.StorageOptions{
 			Operation: filter.Latest,
-			Field:     "predicate",
+			Field:     filter.PredicateField,
 		}
 		// To guarantee that "lo.FilterOptions" will be cleaned at the driver level, since it was artificially created at the driver level for "LatestAnchor".
 		defer func() {
@@ -497,7 +497,7 @@ func (m *memory) PredicatesForSubject(ctx context.Context, s *node.Node, lo *sto
 		}
 		lo.FilterOptions = &filter.StorageOptions{
 			Operation: filter.Latest,
-			Field:     "predicate",
+			Field:     filter.PredicateField,
 		}
 		// To guarantee that "lo.FilterOptions" will be cleaned at the driver level, since it was artificially created at the driver level for "LatestAnchor".
 		defer func() {
@@ -544,7 +544,7 @@ func (m *memory) PredicatesForObject(ctx context.Context, o *triple.Object, lo *
 		}
 		lo.FilterOptions = &filter.StorageOptions{
 			Operation: filter.Latest,
-			Field:     "predicate",
+			Field:     filter.PredicateField,
 		}
 		// To guarantee that "lo.FilterOptions" will be cleaned at the driver level, since it was artificially created at the driver level for "LatestAnchor".
 		defer func() {
@@ -591,7 +591,7 @@ func (m *memory) TriplesForSubject(ctx context.Context, s *node.Node, lo *storag
 		}
 		lo.FilterOptions = &filter.StorageOptions{
 			Operation: filter.Latest,
-			Field:     "predicate",
+			Field:     filter.PredicateField,
 		}
 		// To guarantee that "lo.FilterOptions" will be cleaned at the driver level, since it was artificially created at the driver level for "LatestAnchor".
 		defer func() {
@@ -638,7 +638,7 @@ func (m *memory) TriplesForPredicate(ctx context.Context, p *predicate.Predicate
 		}
 		lo.FilterOptions = &filter.StorageOptions{
 			Operation: filter.Latest,
-			Field:     "predicate",
+			Field:     filter.PredicateField,
 		}
 		// To guarantee that "lo.FilterOptions" will be cleaned at the driver level, since it was artificially created at the driver level for "LatestAnchor".
 		defer func() {
@@ -685,7 +685,7 @@ func (m *memory) TriplesForObject(ctx context.Context, o *triple.Object, lo *sto
 		}
 		lo.FilterOptions = &filter.StorageOptions{
 			Operation: filter.Latest,
-			Field:     "predicate",
+			Field:     filter.PredicateField,
 		}
 		// To guarantee that "lo.FilterOptions" will be cleaned at the driver level, since it was artificially created at the driver level for "LatestAnchor".
 		defer func() {
@@ -734,7 +734,7 @@ func (m *memory) TriplesForSubjectAndPredicate(ctx context.Context, s *node.Node
 		}
 		lo.FilterOptions = &filter.StorageOptions{
 			Operation: filter.Latest,
-			Field:     "predicate",
+			Field:     filter.PredicateField,
 		}
 		// To guarantee that "lo.FilterOptions" will be cleaned at the driver level, since it was artificially created at the driver level for "LatestAnchor".
 		defer func() {
@@ -783,7 +783,7 @@ func (m *memory) TriplesForPredicateAndObject(ctx context.Context, p *predicate.
 		}
 		lo.FilterOptions = &filter.StorageOptions{
 			Operation: filter.Latest,
-			Field:     "predicate",
+			Field:     filter.PredicateField,
 		}
 		// To guarantee that "lo.FilterOptions" will be cleaned at the driver level, since it was artificially created at the driver level for "LatestAnchor".
 		defer func() {
@@ -838,7 +838,7 @@ func (m *memory) Triples(ctx context.Context, lo *storage.LookupOptions, trpls c
 		}
 		lo.FilterOptions = &filter.StorageOptions{
 			Operation: filter.Latest,
-			Field:     "predicate",
+			Field:     filter.PredicateField,
 		}
 		// To guarantee that "lo.FilterOptions" will be cleaned at the driver level, since it was artificially created at the driver level for "LatestAnchor".
 		defer func() {

--- a/storage/memory/memory_test.go
+++ b/storage/memory/memory_test.go
@@ -275,7 +275,7 @@ func TestObjects(t *testing.T) {
 	}
 }
 
-func TestObjectsLastestTemporal(t *testing.T) {
+func TestObjectsLatestAnchor(t *testing.T) {
 	ts, ctx := getTestTemporalTriples(t), context.Background()
 	g, _ := NewStore().NewGraph(ctx, "test")
 	if err := g.AddTriples(ctx, ts); err != nil {
@@ -329,7 +329,7 @@ func TestSubjects(t *testing.T) {
 	}
 }
 
-func TestSubjectsLatestTemporal(t *testing.T) {
+func TestSubjectsLatestAnchor(t *testing.T) {
 	ts, ctx := getTestTemporalTriples(t), context.Background()
 	g, _ := NewStore().NewGraph(ctx, "test")
 	if err := g.AddTriples(ctx, ts); err != nil {
@@ -380,7 +380,7 @@ func TestPredicatesForSubjectAndObject(t *testing.T) {
 		t.Errorf("g.PredicatesForSubjectAndObject(%s, %s) failed to retrieve 1 predicate, got %d instead", ts[0].Subject(), ts[0].Object(), cnt)
 	}
 }
-func TestPredicatesForSubjectAndObjectLatestTemporal(t *testing.T) {
+func TestPredicatesForSubjectAndObjectLatestAnchor(t *testing.T) {
 	ts, ctx := getTestTemporalTriples(t), context.Background()
 	g, _ := NewStore().NewGraph(ctx, "test")
 	if err := g.AddTriples(ctx, ts); err != nil {
@@ -431,7 +431,7 @@ func TestPredicatesForSubject(t *testing.T) {
 	}
 }
 
-func TestPredicatesForSubjectLatestTemporal(t *testing.T) {
+func TestPredicatesForSubjectLatestAnchor(t *testing.T) {
 	ts, ctx := getTestTemporalTriples(t), context.Background()
 	g, _ := NewStore().NewGraph(ctx, "test")
 	if err := g.AddTriples(ctx, ts); err != nil {
@@ -481,7 +481,7 @@ func TestPredicatesForObject(t *testing.T) {
 		t.Errorf("g.PredicatesForObject(%s) failed to retrieve 1 predicate, got %d instead", ts[0].Object(), cnt)
 	}
 }
-func TestPredicatesForObjectLatestTemporal(t *testing.T) {
+func TestPredicatesForObjectLatestAnchor(t *testing.T) {
 	ts, ctx := getTestTemporalTriples(t), context.Background()
 	g, _ := NewStore().NewGraph(ctx, "test")
 	if err := g.AddTriples(ctx, ts); err != nil {
@@ -529,7 +529,7 @@ func TestTriplesForSubject(t *testing.T) {
 	}
 }
 
-func TestTriplesForSubjectLatestTemporal(t *testing.T) {
+func TestTriplesForSubjectLatestAnchor(t *testing.T) {
 	ts, ctx := getTestTemporalTriples(t), context.Background()
 	g, _ := NewStore().NewGraph(ctx, "test")
 	if err := g.AddTriples(ctx, ts); err != nil {
@@ -576,7 +576,7 @@ func TestTriplesForPredicate(t *testing.T) {
 		t.Errorf("g.triplesForPredicate(%s) failed to retrieve 3 predicates, got %d instead", ts[0].Predicate(), cnt)
 	}
 }
-func TestTriplesForPredicateLatestTemporal(t *testing.T) {
+func TestTriplesForPredicateLatestAnchor(t *testing.T) {
 	ts, ctx := getTestTemporalTriples(t), context.Background()
 	g, _ := NewStore().NewGraph(ctx, "test")
 	if err := g.AddTriples(ctx, ts); err != nil {
@@ -624,7 +624,7 @@ func TestTriplesForObject(t *testing.T) {
 	}
 }
 
-func TestTriplesForObjectLatestTemporal(t *testing.T) {
+func TestTriplesForObjectLatestAnchor(t *testing.T) {
 	ts, ctx := getTestTemporalTriples(t), context.Background()
 	g, _ := NewStore().NewGraph(ctx, "test")
 	if err := g.AddTriples(ctx, ts); err != nil {
@@ -714,7 +714,7 @@ func TestTriplesForSubjectAndPredicate(t *testing.T) {
 		t.Errorf("g.TriplesForSubjectAndPredicate(%s, %s) failed to retrieve 3 predicates, got %d instead", ts[0].Subject(), ts[0].Predicate(), cnt)
 	}
 }
-func TestTriplesForSubjectAndPredicateLatestTemporal(t *testing.T) {
+func TestTriplesForSubjectAndPredicateLatestAnchor(t *testing.T) {
 	ts, ctx := getTestTemporalTriples(t), context.Background()
 	g, _ := NewStore().NewGraph(ctx, "test")
 	if err := g.AddTriples(ctx, ts); err != nil {
@@ -762,7 +762,7 @@ func TestTriplesForPredicateAndObject(t *testing.T) {
 	}
 }
 
-func TestTriplesForPredicateAndObjectLatestTemporal(t *testing.T) {
+func TestTriplesForPredicateAndObjectLatestAnchor(t *testing.T) {
 	ts, ctx := getTestTemporalTriples(t), context.Background()
 	g, _ := NewStore().NewGraph(ctx, "test")
 	if err := g.AddTriples(ctx, ts); err != nil {
@@ -827,7 +827,7 @@ func TestTriples(t *testing.T) {
 	}
 }
 
-func TestTriplesLastestTemporal(t *testing.T) {
+func TestTriplesLatestAnchor(t *testing.T) {
 	ts, ctx := getTestTemporalTriples(t), context.Background()
 	g, _ := NewStore().NewGraph(ctx, "test")
 	if err := g.AddTriples(ctx, ts); err != nil {

--- a/storage/memory/memory_test.go
+++ b/storage/memory/memory_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/badwolf/bql/planner/filter"
 	"github.com/google/badwolf/storage"
 	"github.com/google/badwolf/tools/testutil"
 	"github.com/google/badwolf/triple"
@@ -330,19 +331,19 @@ func TestObjectsFilter(t *testing.T) {
 		want map[string]int
 	}{
 		{
-			lo:   &storage.LookupOptions{FilterOptions: &storage.FilteringOptions{Operation: "latest", Field: "predicate"}},
+			lo:   &storage.LookupOptions{FilterOptions: &storage.FilteringOptions{Operation: filter.Latest, Field: "predicate"}},
 			s:    testutil.MustBuildNodeFromStrings(t, "/u", "john"),
 			p:    testutil.MustBuildPredicate(t, `"meet"@[2012-04-10T04:21:00Z]`),
 			want: map[string]int{"/u<mary>": 1},
 		},
 		{
-			lo:   &storage.LookupOptions{FilterOptions: &storage.FilteringOptions{Operation: "latest", Field: "predicate"}},
+			lo:   &storage.LookupOptions{FilterOptions: &storage.FilteringOptions{Operation: filter.Latest, Field: "predicate"}},
 			s:    testutil.MustBuildNodeFromStrings(t, "/u", "john"),
 			p:    testutil.MustBuildPredicate(t, `"meet"@[2014-04-10T04:21:00Z]`),
 			want: map[string]int{"/u<mary>": 1, "/u<bob>": 1},
 		},
 		{
-			lo:   &storage.LookupOptions{FilterOptions: &storage.FilteringOptions{Operation: "latest", Field: "object"}},
+			lo:   &storage.LookupOptions{FilterOptions: &storage.FilteringOptions{Operation: filter.Latest, Field: "object"}},
 			s:    testutil.MustBuildNodeFromStrings(t, "/_", "bn"),
 			p:    testutil.MustBuildPredicate(t, `"_predicate"@[]`),
 			want: map[string]int{`"meet"@[2021-04-10T04:21:00Z]`: 1},
@@ -442,19 +443,19 @@ func TestSubjectsFilter(t *testing.T) {
 		want map[string]int
 	}{
 		{
-			lo:   &storage.LookupOptions{FilterOptions: &storage.FilteringOptions{Operation: "latest", Field: "predicate"}},
+			lo:   &storage.LookupOptions{FilterOptions: &storage.FilteringOptions{Operation: filter.Latest, Field: "predicate"}},
 			p:    testutil.MustBuildPredicate(t, `"meet"@[2012-04-10T04:21:00Z]`),
 			o:    triple.NewNodeObject(testutil.MustBuildNodeFromStrings(t, "/u", "mary")),
 			want: map[string]int{"/u<john>": 1},
 		},
 		{
-			lo:   &storage.LookupOptions{FilterOptions: &storage.FilteringOptions{Operation: "latest", Field: "predicate"}},
+			lo:   &storage.LookupOptions{FilterOptions: &storage.FilteringOptions{Operation: filter.Latest, Field: "predicate"}},
 			p:    testutil.MustBuildPredicate(t, `"meet"@[2014-04-10T04:21:00Z]`),
 			o:    triple.NewNodeObject(testutil.MustBuildNodeFromStrings(t, "/u", "mary")),
 			want: map[string]int{"/u<john>": 1},
 		},
 		{
-			lo:   &storage.LookupOptions{FilterOptions: &storage.FilteringOptions{Operation: "latest", Field: "object"}},
+			lo:   &storage.LookupOptions{FilterOptions: &storage.FilteringOptions{Operation: filter.Latest, Field: "object"}},
 			p:    testutil.MustBuildPredicate(t, `"_predicate"@[]`),
 			o:    triple.NewPredicateObject(testutil.MustBuildPredicate(t, `"meet"@[2020-04-10T04:21:00Z]`)),
 			want: map[string]int{"/_<bn>": 1},
@@ -552,19 +553,19 @@ func TestPredicatesForSubjectAndObjectFilter(t *testing.T) {
 		want map[string]int
 	}{
 		{
-			lo:   &storage.LookupOptions{FilterOptions: &storage.FilteringOptions{Operation: "latest", Field: "predicate"}},
+			lo:   &storage.LookupOptions{FilterOptions: &storage.FilteringOptions{Operation: filter.Latest, Field: "predicate"}},
 			s:    testutil.MustBuildNodeFromStrings(t, "/u", "john"),
 			o:    triple.NewNodeObject(testutil.MustBuildNodeFromStrings(t, "/u", "mary")),
 			want: map[string]int{`"meet"@[2014-04-10T04:21:00Z]`: 1},
 		},
 		{
-			lo:   &storage.LookupOptions{FilterOptions: &storage.FilteringOptions{Operation: "latest", Field: "predicate"}},
+			lo:   &storage.LookupOptions{FilterOptions: &storage.FilteringOptions{Operation: filter.Latest, Field: "predicate"}},
 			s:    testutil.MustBuildNodeFromStrings(t, "/u", "john"),
 			o:    triple.NewNodeObject(testutil.MustBuildNodeFromStrings(t, "/u", "bob")),
 			want: map[string]int{`"meet"@[2014-04-10T04:21:00Z]`: 1},
 		},
 		{
-			lo:   &storage.LookupOptions{FilterOptions: &storage.FilteringOptions{Operation: "latest", Field: "object"}},
+			lo:   &storage.LookupOptions{FilterOptions: &storage.FilteringOptions{Operation: filter.Latest, Field: "object"}},
 			s:    testutil.MustBuildNodeFromStrings(t, "/_", "bn"),
 			o:    triple.NewPredicateObject(testutil.MustBuildPredicate(t, `"meet"@[2020-04-10T04:21:00Z]`)),
 			want: map[string]int{`"_predicate"@[]`: 1},
@@ -661,12 +662,12 @@ func TestPredicatesForSubjectFilter(t *testing.T) {
 		want map[string]int
 	}{
 		{
-			lo:   &storage.LookupOptions{FilterOptions: &storage.FilteringOptions{Operation: "latest", Field: "predicate"}},
+			lo:   &storage.LookupOptions{FilterOptions: &storage.FilteringOptions{Operation: filter.Latest, Field: "predicate"}},
 			s:    testutil.MustBuildNodeFromStrings(t, "/u", "john"),
 			want: map[string]int{`"meet"@[2014-04-10T04:21:00Z]`: 2},
 		},
 		{
-			lo:   &storage.LookupOptions{FilterOptions: &storage.FilteringOptions{Operation: "latest", Field: "object"}},
+			lo:   &storage.LookupOptions{FilterOptions: &storage.FilteringOptions{Operation: filter.Latest, Field: "object"}},
 			s:    testutil.MustBuildNodeFromStrings(t, "/_", "bn"),
 			want: map[string]int{`"_predicate"@[]`: 1},
 		},
@@ -761,17 +762,17 @@ func TestPredicatesForObjectFilter(t *testing.T) {
 		want map[string]int
 	}{
 		{
-			lo:   &storage.LookupOptions{FilterOptions: &storage.FilteringOptions{Operation: "latest", Field: "predicate"}},
+			lo:   &storage.LookupOptions{FilterOptions: &storage.FilteringOptions{Operation: filter.Latest, Field: "predicate"}},
 			o:    triple.NewNodeObject(testutil.MustBuildNodeFromStrings(t, "/u", "mary")),
 			want: map[string]int{`"meet"@[2014-04-10T04:21:00Z]`: 1},
 		},
 		{
-			lo:   &storage.LookupOptions{FilterOptions: &storage.FilteringOptions{Operation: "latest", Field: "predicate"}},
+			lo:   &storage.LookupOptions{FilterOptions: &storage.FilteringOptions{Operation: filter.Latest, Field: "predicate"}},
 			o:    triple.NewNodeObject(testutil.MustBuildNodeFromStrings(t, "/u", "bob")),
 			want: map[string]int{`"meet"@[2014-04-10T04:21:00Z]`: 1},
 		},
 		{
-			lo:   &storage.LookupOptions{FilterOptions: &storage.FilteringOptions{Operation: "latest", Field: "object"}},
+			lo:   &storage.LookupOptions{FilterOptions: &storage.FilteringOptions{Operation: filter.Latest, Field: "object"}},
 			o:    triple.NewPredicateObject(testutil.MustBuildPredicate(t, `"meet"@[2020-04-10T04:21:00Z]`)),
 			want: map[string]int{`"_predicate"@[]`: 1},
 		},
@@ -863,12 +864,12 @@ func TestTriplesForSubjectFilter(t *testing.T) {
 		want map[string]int
 	}{
 		{
-			lo: &storage.LookupOptions{FilterOptions: &storage.FilteringOptions{Operation: "latest", Field: "predicate"}},
+			lo: &storage.LookupOptions{FilterOptions: &storage.FilteringOptions{Operation: filter.Latest, Field: "predicate"}},
 			s:  testutil.MustBuildNodeFromStrings(t, "/u", "john"),
 			want: map[string]int{`/u<john>	"meet"@[2014-04-10T04:21:00Z]	/u<mary>`: 1, `/u<john>	"meet"@[2014-04-10T04:21:00Z]	/u<bob>`: 1},
 		},
 		{
-			lo: &storage.LookupOptions{FilterOptions: &storage.FilteringOptions{Operation: "latest", Field: "object"}},
+			lo: &storage.LookupOptions{FilterOptions: &storage.FilteringOptions{Operation: filter.Latest, Field: "object"}},
 			s:  testutil.MustBuildNodeFromStrings(t, "/_", "bn"),
 			want: map[string]int{`/_<bn>	"_predicate"@[]	"meet"@[2021-04-10T04:21:00Z]`: 1},
 		},
@@ -960,17 +961,17 @@ func TestTriplesForPredicateFilter(t *testing.T) {
 		want map[string]int
 	}{
 		{
-			lo: &storage.LookupOptions{FilterOptions: &storage.FilteringOptions{Operation: "latest", Field: "predicate"}},
+			lo: &storage.LookupOptions{FilterOptions: &storage.FilteringOptions{Operation: filter.Latest, Field: "predicate"}},
 			p:  testutil.MustBuildPredicate(t, `"meet"@[2012-04-10T04:21:00Z]`),
 			want: map[string]int{`/u<john>	"meet"@[2012-04-10T04:21:00Z]	/u<mary>`: 1},
 		},
 		{
-			lo: &storage.LookupOptions{FilterOptions: &storage.FilteringOptions{Operation: "latest", Field: "predicate"}},
+			lo: &storage.LookupOptions{FilterOptions: &storage.FilteringOptions{Operation: filter.Latest, Field: "predicate"}},
 			p:  testutil.MustBuildPredicate(t, `"meet"@[2014-04-10T04:21:00Z]`),
 			want: map[string]int{`/u<john>	"meet"@[2014-04-10T04:21:00Z]	/u<mary>`: 1, `/u<john>	"meet"@[2014-04-10T04:21:00Z]	/u<bob>`: 1},
 		},
 		{
-			lo: &storage.LookupOptions{FilterOptions: &storage.FilteringOptions{Operation: "latest", Field: "object"}},
+			lo: &storage.LookupOptions{FilterOptions: &storage.FilteringOptions{Operation: filter.Latest, Field: "object"}},
 			p:  testutil.MustBuildPredicate(t, `"_predicate"@[]`),
 			want: map[string]int{`/_<bn>	"_predicate"@[]	"meet"@[2021-04-10T04:21:00Z]`: 1},
 		},
@@ -1062,17 +1063,17 @@ func TestTriplesForObjectFilter(t *testing.T) {
 		want map[string]int
 	}{
 		{
-			lo: &storage.LookupOptions{FilterOptions: &storage.FilteringOptions{Operation: "latest", Field: "predicate"}},
+			lo: &storage.LookupOptions{FilterOptions: &storage.FilteringOptions{Operation: filter.Latest, Field: "predicate"}},
 			o:  triple.NewNodeObject(testutil.MustBuildNodeFromStrings(t, "/u", "mary")),
 			want: map[string]int{`/u<john>	"meet"@[2014-04-10T04:21:00Z]	/u<mary>`: 1},
 		},
 		{
-			lo: &storage.LookupOptions{FilterOptions: &storage.FilteringOptions{Operation: "latest", Field: "predicate"}},
+			lo: &storage.LookupOptions{FilterOptions: &storage.FilteringOptions{Operation: filter.Latest, Field: "predicate"}},
 			o:  triple.NewNodeObject(testutil.MustBuildNodeFromStrings(t, "/u", "bob")),
 			want: map[string]int{`/u<john>	"meet"@[2014-04-10T04:21:00Z]	/u<bob>`: 1},
 		},
 		{
-			lo: &storage.LookupOptions{FilterOptions: &storage.FilteringOptions{Operation: "latest", Field: "object"}},
+			lo: &storage.LookupOptions{FilterOptions: &storage.FilteringOptions{Operation: filter.Latest, Field: "object"}},
 			o:  triple.NewPredicateObject(testutil.MustBuildPredicate(t, `"meet"@[2020-04-10T04:21:00Z]`)),
 			want: map[string]int{`/_<bn>	"_predicate"@[]	"meet"@[2020-04-10T04:21:00Z]`: 1},
 		},
@@ -1208,19 +1209,19 @@ func TestTriplesForSubjectAndPredicateFilter(t *testing.T) {
 		want map[string]int
 	}{
 		{
-			lo: &storage.LookupOptions{FilterOptions: &storage.FilteringOptions{Operation: "latest", Field: "predicate"}},
+			lo: &storage.LookupOptions{FilterOptions: &storage.FilteringOptions{Operation: filter.Latest, Field: "predicate"}},
 			s:  testutil.MustBuildNodeFromStrings(t, "/u", "john"),
 			p:  testutil.MustBuildPredicate(t, `"meet"@[2012-04-10T04:21:00Z]`),
 			want: map[string]int{`/u<john>	"meet"@[2012-04-10T04:21:00Z]	/u<mary>`: 1},
 		},
 		{
-			lo: &storage.LookupOptions{FilterOptions: &storage.FilteringOptions{Operation: "latest", Field: "predicate"}},
+			lo: &storage.LookupOptions{FilterOptions: &storage.FilteringOptions{Operation: filter.Latest, Field: "predicate"}},
 			s:  testutil.MustBuildNodeFromStrings(t, "/u", "john"),
 			p:  testutil.MustBuildPredicate(t, `"meet"@[2014-04-10T04:21:00Z]`),
 			want: map[string]int{`/u<john>	"meet"@[2014-04-10T04:21:00Z]	/u<mary>`: 1, `/u<john>	"meet"@[2014-04-10T04:21:00Z]	/u<bob>`: 1},
 		},
 		{
-			lo: &storage.LookupOptions{FilterOptions: &storage.FilteringOptions{Operation: "latest", Field: "object"}},
+			lo: &storage.LookupOptions{FilterOptions: &storage.FilteringOptions{Operation: filter.Latest, Field: "object"}},
 			s:  testutil.MustBuildNodeFromStrings(t, "/_", "bn"),
 			p:  testutil.MustBuildPredicate(t, `"_predicate"@[]`),
 			want: map[string]int{`/_<bn>	"_predicate"@[]	"meet"@[2021-04-10T04:21:00Z]`: 1},
@@ -1315,19 +1316,19 @@ func TestTriplesForPredicateAndObjectFilter(t *testing.T) {
 		want map[string]int
 	}{
 		{
-			lo: &storage.LookupOptions{FilterOptions: &storage.FilteringOptions{Operation: "latest", Field: "predicate"}},
+			lo: &storage.LookupOptions{FilterOptions: &storage.FilteringOptions{Operation: filter.Latest, Field: "predicate"}},
 			p:  testutil.MustBuildPredicate(t, `"meet"@[2012-04-10T04:21:00Z]`),
 			o:  triple.NewNodeObject(testutil.MustBuildNodeFromStrings(t, "/u", "mary")),
 			want: map[string]int{`/u<john>	"meet"@[2012-04-10T04:21:00Z]	/u<mary>`: 1},
 		},
 		{
-			lo: &storage.LookupOptions{FilterOptions: &storage.FilteringOptions{Operation: "latest", Field: "predicate"}},
+			lo: &storage.LookupOptions{FilterOptions: &storage.FilteringOptions{Operation: filter.Latest, Field: "predicate"}},
 			p:  testutil.MustBuildPredicate(t, `"meet"@[2014-04-10T04:21:00Z]`),
 			o:  triple.NewNodeObject(testutil.MustBuildNodeFromStrings(t, "/u", "mary")),
 			want: map[string]int{`/u<john>	"meet"@[2014-04-10T04:21:00Z]	/u<mary>`: 1},
 		},
 		{
-			lo: &storage.LookupOptions{FilterOptions: &storage.FilteringOptions{Operation: "latest", Field: "object"}},
+			lo: &storage.LookupOptions{FilterOptions: &storage.FilteringOptions{Operation: filter.Latest, Field: "object"}},
 			p:  testutil.MustBuildPredicate(t, `"_predicate"@[]`),
 			o:  triple.NewPredicateObject(testutil.MustBuildPredicate(t, `"meet"@[2020-04-10T04:21:00Z]`)),
 			want: map[string]int{`/_<bn>	"_predicate"@[]	"meet"@[2020-04-10T04:21:00Z]`: 1},
@@ -1437,11 +1438,11 @@ func TestTriplesFilter(t *testing.T) {
 		want map[string]int
 	}{
 		{
-			lo: &storage.LookupOptions{FilterOptions: &storage.FilteringOptions{Operation: "latest", Field: "predicate"}},
+			lo: &storage.LookupOptions{FilterOptions: &storage.FilteringOptions{Operation: filter.Latest, Field: "predicate"}},
 			want: map[string]int{`/u<john>	"meet"@[2014-04-10T04:21:00Z]	/u<mary>`: 1, `/u<john>	"meet"@[2014-04-10T04:21:00Z]	/u<bob>`: 1},
 		},
 		{
-			lo: &storage.LookupOptions{FilterOptions: &storage.FilteringOptions{Operation: "latest", Field: "object"}},
+			lo: &storage.LookupOptions{FilterOptions: &storage.FilteringOptions{Operation: filter.Latest, Field: "object"}},
 			want: map[string]int{`/_<bn>	"_predicate"@[]	"meet"@[2021-04-10T04:21:00Z]`: 1},
 		},
 	}

--- a/storage/memory/memory_test.go
+++ b/storage/memory/memory_test.go
@@ -331,19 +331,19 @@ func TestObjectsFilter(t *testing.T) {
 		want map[string]int
 	}{
 		{
-			lo:   &storage.LookupOptions{FilterOptions: &filter.StorageOptions{Operation: filter.Latest, Field: "predicate"}},
+			lo:   &storage.LookupOptions{FilterOptions: &filter.StorageOptions{Operation: filter.Latest, Field: filter.PredicateField}},
 			s:    testutil.MustBuildNodeFromStrings(t, "/u", "john"),
 			p:    testutil.MustBuildPredicate(t, `"meet"@[2012-04-10T04:21:00Z]`),
 			want: map[string]int{"/u<mary>": 1},
 		},
 		{
-			lo:   &storage.LookupOptions{FilterOptions: &filter.StorageOptions{Operation: filter.Latest, Field: "predicate"}},
+			lo:   &storage.LookupOptions{FilterOptions: &filter.StorageOptions{Operation: filter.Latest, Field: filter.PredicateField}},
 			s:    testutil.MustBuildNodeFromStrings(t, "/u", "john"),
 			p:    testutil.MustBuildPredicate(t, `"meet"@[2014-04-10T04:21:00Z]`),
 			want: map[string]int{"/u<mary>": 1, "/u<bob>": 1},
 		},
 		{
-			lo:   &storage.LookupOptions{FilterOptions: &filter.StorageOptions{Operation: filter.Latest, Field: "object"}},
+			lo:   &storage.LookupOptions{FilterOptions: &filter.StorageOptions{Operation: filter.Latest, Field: filter.ObjectField}},
 			s:    testutil.MustBuildNodeFromStrings(t, "/_", "bn"),
 			p:    testutil.MustBuildPredicate(t, `"_predicate"@[]`),
 			want: map[string]int{`"meet"@[2021-04-10T04:21:00Z]`: 1},
@@ -443,19 +443,19 @@ func TestSubjectsFilter(t *testing.T) {
 		want map[string]int
 	}{
 		{
-			lo:   &storage.LookupOptions{FilterOptions: &filter.StorageOptions{Operation: filter.Latest, Field: "predicate"}},
+			lo:   &storage.LookupOptions{FilterOptions: &filter.StorageOptions{Operation: filter.Latest, Field: filter.PredicateField}},
 			p:    testutil.MustBuildPredicate(t, `"meet"@[2012-04-10T04:21:00Z]`),
 			o:    triple.NewNodeObject(testutil.MustBuildNodeFromStrings(t, "/u", "mary")),
 			want: map[string]int{"/u<john>": 1},
 		},
 		{
-			lo:   &storage.LookupOptions{FilterOptions: &filter.StorageOptions{Operation: filter.Latest, Field: "predicate"}},
+			lo:   &storage.LookupOptions{FilterOptions: &filter.StorageOptions{Operation: filter.Latest, Field: filter.PredicateField}},
 			p:    testutil.MustBuildPredicate(t, `"meet"@[2014-04-10T04:21:00Z]`),
 			o:    triple.NewNodeObject(testutil.MustBuildNodeFromStrings(t, "/u", "mary")),
 			want: map[string]int{"/u<john>": 1},
 		},
 		{
-			lo:   &storage.LookupOptions{FilterOptions: &filter.StorageOptions{Operation: filter.Latest, Field: "object"}},
+			lo:   &storage.LookupOptions{FilterOptions: &filter.StorageOptions{Operation: filter.Latest, Field: filter.ObjectField}},
 			p:    testutil.MustBuildPredicate(t, `"_predicate"@[]`),
 			o:    triple.NewPredicateObject(testutil.MustBuildPredicate(t, `"meet"@[2020-04-10T04:21:00Z]`)),
 			want: map[string]int{"/_<bn>": 1},
@@ -553,19 +553,19 @@ func TestPredicatesForSubjectAndObjectFilter(t *testing.T) {
 		want map[string]int
 	}{
 		{
-			lo:   &storage.LookupOptions{FilterOptions: &filter.StorageOptions{Operation: filter.Latest, Field: "predicate"}},
+			lo:   &storage.LookupOptions{FilterOptions: &filter.StorageOptions{Operation: filter.Latest, Field: filter.PredicateField}},
 			s:    testutil.MustBuildNodeFromStrings(t, "/u", "john"),
 			o:    triple.NewNodeObject(testutil.MustBuildNodeFromStrings(t, "/u", "mary")),
 			want: map[string]int{`"meet"@[2014-04-10T04:21:00Z]`: 1},
 		},
 		{
-			lo:   &storage.LookupOptions{FilterOptions: &filter.StorageOptions{Operation: filter.Latest, Field: "predicate"}},
+			lo:   &storage.LookupOptions{FilterOptions: &filter.StorageOptions{Operation: filter.Latest, Field: filter.PredicateField}},
 			s:    testutil.MustBuildNodeFromStrings(t, "/u", "john"),
 			o:    triple.NewNodeObject(testutil.MustBuildNodeFromStrings(t, "/u", "bob")),
 			want: map[string]int{`"meet"@[2014-04-10T04:21:00Z]`: 1},
 		},
 		{
-			lo:   &storage.LookupOptions{FilterOptions: &filter.StorageOptions{Operation: filter.Latest, Field: "object"}},
+			lo:   &storage.LookupOptions{FilterOptions: &filter.StorageOptions{Operation: filter.Latest, Field: filter.ObjectField}},
 			s:    testutil.MustBuildNodeFromStrings(t, "/_", "bn"),
 			o:    triple.NewPredicateObject(testutil.MustBuildPredicate(t, `"meet"@[2020-04-10T04:21:00Z]`)),
 			want: map[string]int{`"_predicate"@[]`: 1},
@@ -662,12 +662,12 @@ func TestPredicatesForSubjectFilter(t *testing.T) {
 		want map[string]int
 	}{
 		{
-			lo:   &storage.LookupOptions{FilterOptions: &filter.StorageOptions{Operation: filter.Latest, Field: "predicate"}},
+			lo:   &storage.LookupOptions{FilterOptions: &filter.StorageOptions{Operation: filter.Latest, Field: filter.PredicateField}},
 			s:    testutil.MustBuildNodeFromStrings(t, "/u", "john"),
 			want: map[string]int{`"meet"@[2014-04-10T04:21:00Z]`: 2},
 		},
 		{
-			lo:   &storage.LookupOptions{FilterOptions: &filter.StorageOptions{Operation: filter.Latest, Field: "object"}},
+			lo:   &storage.LookupOptions{FilterOptions: &filter.StorageOptions{Operation: filter.Latest, Field: filter.ObjectField}},
 			s:    testutil.MustBuildNodeFromStrings(t, "/_", "bn"),
 			want: map[string]int{`"_predicate"@[]`: 1},
 		},
@@ -762,17 +762,17 @@ func TestPredicatesForObjectFilter(t *testing.T) {
 		want map[string]int
 	}{
 		{
-			lo:   &storage.LookupOptions{FilterOptions: &filter.StorageOptions{Operation: filter.Latest, Field: "predicate"}},
+			lo:   &storage.LookupOptions{FilterOptions: &filter.StorageOptions{Operation: filter.Latest, Field: filter.PredicateField}},
 			o:    triple.NewNodeObject(testutil.MustBuildNodeFromStrings(t, "/u", "mary")),
 			want: map[string]int{`"meet"@[2014-04-10T04:21:00Z]`: 1},
 		},
 		{
-			lo:   &storage.LookupOptions{FilterOptions: &filter.StorageOptions{Operation: filter.Latest, Field: "predicate"}},
+			lo:   &storage.LookupOptions{FilterOptions: &filter.StorageOptions{Operation: filter.Latest, Field: filter.PredicateField}},
 			o:    triple.NewNodeObject(testutil.MustBuildNodeFromStrings(t, "/u", "bob")),
 			want: map[string]int{`"meet"@[2014-04-10T04:21:00Z]`: 1},
 		},
 		{
-			lo:   &storage.LookupOptions{FilterOptions: &filter.StorageOptions{Operation: filter.Latest, Field: "object"}},
+			lo:   &storage.LookupOptions{FilterOptions: &filter.StorageOptions{Operation: filter.Latest, Field: filter.ObjectField}},
 			o:    triple.NewPredicateObject(testutil.MustBuildPredicate(t, `"meet"@[2020-04-10T04:21:00Z]`)),
 			want: map[string]int{`"_predicate"@[]`: 1},
 		},
@@ -864,12 +864,12 @@ func TestTriplesForSubjectFilter(t *testing.T) {
 		want map[string]int
 	}{
 		{
-			lo: &storage.LookupOptions{FilterOptions: &filter.StorageOptions{Operation: filter.Latest, Field: "predicate"}},
+			lo: &storage.LookupOptions{FilterOptions: &filter.StorageOptions{Operation: filter.Latest, Field: filter.PredicateField}},
 			s:  testutil.MustBuildNodeFromStrings(t, "/u", "john"),
 			want: map[string]int{`/u<john>	"meet"@[2014-04-10T04:21:00Z]	/u<mary>`: 1, `/u<john>	"meet"@[2014-04-10T04:21:00Z]	/u<bob>`: 1},
 		},
 		{
-			lo: &storage.LookupOptions{FilterOptions: &filter.StorageOptions{Operation: filter.Latest, Field: "object"}},
+			lo: &storage.LookupOptions{FilterOptions: &filter.StorageOptions{Operation: filter.Latest, Field: filter.ObjectField}},
 			s:  testutil.MustBuildNodeFromStrings(t, "/_", "bn"),
 			want: map[string]int{`/_<bn>	"_predicate"@[]	"meet"@[2021-04-10T04:21:00Z]`: 1},
 		},
@@ -961,17 +961,17 @@ func TestTriplesForPredicateFilter(t *testing.T) {
 		want map[string]int
 	}{
 		{
-			lo: &storage.LookupOptions{FilterOptions: &filter.StorageOptions{Operation: filter.Latest, Field: "predicate"}},
+			lo: &storage.LookupOptions{FilterOptions: &filter.StorageOptions{Operation: filter.Latest, Field: filter.PredicateField}},
 			p:  testutil.MustBuildPredicate(t, `"meet"@[2012-04-10T04:21:00Z]`),
 			want: map[string]int{`/u<john>	"meet"@[2012-04-10T04:21:00Z]	/u<mary>`: 1},
 		},
 		{
-			lo: &storage.LookupOptions{FilterOptions: &filter.StorageOptions{Operation: filter.Latest, Field: "predicate"}},
+			lo: &storage.LookupOptions{FilterOptions: &filter.StorageOptions{Operation: filter.Latest, Field: filter.PredicateField}},
 			p:  testutil.MustBuildPredicate(t, `"meet"@[2014-04-10T04:21:00Z]`),
 			want: map[string]int{`/u<john>	"meet"@[2014-04-10T04:21:00Z]	/u<mary>`: 1, `/u<john>	"meet"@[2014-04-10T04:21:00Z]	/u<bob>`: 1},
 		},
 		{
-			lo: &storage.LookupOptions{FilterOptions: &filter.StorageOptions{Operation: filter.Latest, Field: "object"}},
+			lo: &storage.LookupOptions{FilterOptions: &filter.StorageOptions{Operation: filter.Latest, Field: filter.ObjectField}},
 			p:  testutil.MustBuildPredicate(t, `"_predicate"@[]`),
 			want: map[string]int{`/_<bn>	"_predicate"@[]	"meet"@[2021-04-10T04:21:00Z]`: 1},
 		},
@@ -1063,17 +1063,17 @@ func TestTriplesForObjectFilter(t *testing.T) {
 		want map[string]int
 	}{
 		{
-			lo: &storage.LookupOptions{FilterOptions: &filter.StorageOptions{Operation: filter.Latest, Field: "predicate"}},
+			lo: &storage.LookupOptions{FilterOptions: &filter.StorageOptions{Operation: filter.Latest, Field: filter.PredicateField}},
 			o:  triple.NewNodeObject(testutil.MustBuildNodeFromStrings(t, "/u", "mary")),
 			want: map[string]int{`/u<john>	"meet"@[2014-04-10T04:21:00Z]	/u<mary>`: 1},
 		},
 		{
-			lo: &storage.LookupOptions{FilterOptions: &filter.StorageOptions{Operation: filter.Latest, Field: "predicate"}},
+			lo: &storage.LookupOptions{FilterOptions: &filter.StorageOptions{Operation: filter.Latest, Field: filter.PredicateField}},
 			o:  triple.NewNodeObject(testutil.MustBuildNodeFromStrings(t, "/u", "bob")),
 			want: map[string]int{`/u<john>	"meet"@[2014-04-10T04:21:00Z]	/u<bob>`: 1},
 		},
 		{
-			lo: &storage.LookupOptions{FilterOptions: &filter.StorageOptions{Operation: filter.Latest, Field: "object"}},
+			lo: &storage.LookupOptions{FilterOptions: &filter.StorageOptions{Operation: filter.Latest, Field: filter.ObjectField}},
 			o:  triple.NewPredicateObject(testutil.MustBuildPredicate(t, `"meet"@[2020-04-10T04:21:00Z]`)),
 			want: map[string]int{`/_<bn>	"_predicate"@[]	"meet"@[2020-04-10T04:21:00Z]`: 1},
 		},
@@ -1209,19 +1209,19 @@ func TestTriplesForSubjectAndPredicateFilter(t *testing.T) {
 		want map[string]int
 	}{
 		{
-			lo: &storage.LookupOptions{FilterOptions: &filter.StorageOptions{Operation: filter.Latest, Field: "predicate"}},
+			lo: &storage.LookupOptions{FilterOptions: &filter.StorageOptions{Operation: filter.Latest, Field: filter.PredicateField}},
 			s:  testutil.MustBuildNodeFromStrings(t, "/u", "john"),
 			p:  testutil.MustBuildPredicate(t, `"meet"@[2012-04-10T04:21:00Z]`),
 			want: map[string]int{`/u<john>	"meet"@[2012-04-10T04:21:00Z]	/u<mary>`: 1},
 		},
 		{
-			lo: &storage.LookupOptions{FilterOptions: &filter.StorageOptions{Operation: filter.Latest, Field: "predicate"}},
+			lo: &storage.LookupOptions{FilterOptions: &filter.StorageOptions{Operation: filter.Latest, Field: filter.PredicateField}},
 			s:  testutil.MustBuildNodeFromStrings(t, "/u", "john"),
 			p:  testutil.MustBuildPredicate(t, `"meet"@[2014-04-10T04:21:00Z]`),
 			want: map[string]int{`/u<john>	"meet"@[2014-04-10T04:21:00Z]	/u<mary>`: 1, `/u<john>	"meet"@[2014-04-10T04:21:00Z]	/u<bob>`: 1},
 		},
 		{
-			lo: &storage.LookupOptions{FilterOptions: &filter.StorageOptions{Operation: filter.Latest, Field: "object"}},
+			lo: &storage.LookupOptions{FilterOptions: &filter.StorageOptions{Operation: filter.Latest, Field: filter.ObjectField}},
 			s:  testutil.MustBuildNodeFromStrings(t, "/_", "bn"),
 			p:  testutil.MustBuildPredicate(t, `"_predicate"@[]`),
 			want: map[string]int{`/_<bn>	"_predicate"@[]	"meet"@[2021-04-10T04:21:00Z]`: 1},
@@ -1316,19 +1316,19 @@ func TestTriplesForPredicateAndObjectFilter(t *testing.T) {
 		want map[string]int
 	}{
 		{
-			lo: &storage.LookupOptions{FilterOptions: &filter.StorageOptions{Operation: filter.Latest, Field: "predicate"}},
+			lo: &storage.LookupOptions{FilterOptions: &filter.StorageOptions{Operation: filter.Latest, Field: filter.PredicateField}},
 			p:  testutil.MustBuildPredicate(t, `"meet"@[2012-04-10T04:21:00Z]`),
 			o:  triple.NewNodeObject(testutil.MustBuildNodeFromStrings(t, "/u", "mary")),
 			want: map[string]int{`/u<john>	"meet"@[2012-04-10T04:21:00Z]	/u<mary>`: 1},
 		},
 		{
-			lo: &storage.LookupOptions{FilterOptions: &filter.StorageOptions{Operation: filter.Latest, Field: "predicate"}},
+			lo: &storage.LookupOptions{FilterOptions: &filter.StorageOptions{Operation: filter.Latest, Field: filter.PredicateField}},
 			p:  testutil.MustBuildPredicate(t, `"meet"@[2014-04-10T04:21:00Z]`),
 			o:  triple.NewNodeObject(testutil.MustBuildNodeFromStrings(t, "/u", "mary")),
 			want: map[string]int{`/u<john>	"meet"@[2014-04-10T04:21:00Z]	/u<mary>`: 1},
 		},
 		{
-			lo: &storage.LookupOptions{FilterOptions: &filter.StorageOptions{Operation: filter.Latest, Field: "object"}},
+			lo: &storage.LookupOptions{FilterOptions: &filter.StorageOptions{Operation: filter.Latest, Field: filter.ObjectField}},
 			p:  testutil.MustBuildPredicate(t, `"_predicate"@[]`),
 			o:  triple.NewPredicateObject(testutil.MustBuildPredicate(t, `"meet"@[2020-04-10T04:21:00Z]`)),
 			want: map[string]int{`/_<bn>	"_predicate"@[]	"meet"@[2020-04-10T04:21:00Z]`: 1},
@@ -1438,11 +1438,11 @@ func TestTriplesFilter(t *testing.T) {
 		want map[string]int
 	}{
 		{
-			lo: &storage.LookupOptions{FilterOptions: &filter.StorageOptions{Operation: filter.Latest, Field: "predicate"}},
+			lo: &storage.LookupOptions{FilterOptions: &filter.StorageOptions{Operation: filter.Latest, Field: filter.PredicateField}},
 			want: map[string]int{`/u<john>	"meet"@[2014-04-10T04:21:00Z]	/u<mary>`: 1, `/u<john>	"meet"@[2014-04-10T04:21:00Z]	/u<bob>`: 1},
 		},
 		{
-			lo: &storage.LookupOptions{FilterOptions: &filter.StorageOptions{Operation: filter.Latest, Field: "object"}},
+			lo: &storage.LookupOptions{FilterOptions: &filter.StorageOptions{Operation: filter.Latest, Field: filter.ObjectField}},
 			want: map[string]int{`/_<bn>	"_predicate"@[]	"meet"@[2021-04-10T04:21:00Z]`: 1},
 		},
 	}

--- a/storage/memory/memory_test.go
+++ b/storage/memory/memory_test.go
@@ -593,12 +593,12 @@ func TestTriplesForPredicateLatestAnchor(t *testing.T) {
 	cnt := 0
 	for rts := range trpls {
 		cnt++
-		if !reflect.DeepEqual(rts.Predicate().UUID(), ts[len(ts)-1].Predicate().UUID()) {
-			t.Errorf("g.PredicatesForObject(%s) failed to return a valid predicate; returned %s instead", ts[0].Object(), rts.Predicate())
+		if !reflect.DeepEqual(rts.Predicate().UUID(), ts[0].Predicate().UUID()) {
+			t.Errorf("g.TriplesForPredicate(%s) = %s for LatestAnchor; want %s", ts[0].Predicate(), rts.Predicate(), ts[0].Predicate())
 		}
 	}
 	if cnt != 1 {
-		t.Errorf("g.triplesForPredicate(%s) failed to retrieve 3 predicates, got %d instead", ts[0].Predicate(), cnt)
+		t.Errorf("g.triplesForPredicate(%s) retrieved %d predicates; want 1", ts[0].Predicate(), cnt)
 	}
 }
 
@@ -731,12 +731,12 @@ func TestTriplesForSubjectAndPredicateLatestAnchor(t *testing.T) {
 	cnt := 0
 	for rts := range trpls {
 		cnt++
-		if !reflect.DeepEqual(rts.Predicate().UUID(), ts[len(ts)-1].Predicate().UUID()) {
-			t.Errorf("g.PredicatesForObject(%s) failed to return a valid predicate; returned %s instead", ts[0].Object(), rts.Predicate())
+		if !reflect.DeepEqual(rts.Predicate().UUID(), ts[0].Predicate().UUID()) {
+			t.Errorf("g.TriplesForSubjectAndPredicate(%s, %s) = %s for LatestAnchor; want %s", ts[0].Subject(), ts[0].Predicate(), rts.Predicate(), ts[0].Predicate())
 		}
 	}
 	if cnt != 1 {
-		t.Errorf("g.TriplesForSubjectAndPredicate(%s, %s) failed to retrieve 3 predicates, got %d instead", ts[0].Subject(), ts[0].Predicate(), cnt)
+		t.Errorf("g.TriplesForSubjectAndPredicate(%s, %s) retrieved %d predicates; want 1", ts[0].Subject(), ts[0].Predicate(), cnt)
 	}
 }
 
@@ -779,12 +779,12 @@ func TestTriplesForPredicateAndObjectLatestAnchor(t *testing.T) {
 	cnt := 0
 	for rts := range trpls {
 		cnt++
-		if !reflect.DeepEqual(rts.Predicate().UUID(), ts[len(ts)-1].Predicate().UUID()) {
-			t.Errorf("g.PredicatesForObject(%s) failed to return a valid predicate; returned %s instead", ts[0].Object(), rts.Predicate())
+		if !reflect.DeepEqual(rts.Predicate().UUID(), ts[0].Predicate().UUID()) {
+			t.Errorf("g.TriplesForPredicateAndObject(%s, %s) = %s for LatestAnchor; want %s", ts[0].Predicate(), ts[0].Object(), rts.Predicate(), ts[0].Predicate())
 		}
 	}
 	if cnt != 1 {
-		t.Errorf("g.TriplesForPredicateAndObject(%s, %s) failed to retrieve 1 predicates, got %d instead", ts[0].Predicate(), ts[0].Object(), cnt)
+		t.Errorf("g.TriplesForPredicateAndObject(%s, %s) retrieved %d predicates; want 1", ts[0].Predicate(), ts[0].Object(), cnt)
 	}
 }
 

--- a/storage/memory/memory_test.go
+++ b/storage/memory/memory_test.go
@@ -325,24 +325,28 @@ func TestObjectsFilter(t *testing.T) {
 	}
 
 	testTable := []struct {
+		id   string
 		lo   *storage.LookupOptions
 		s    *node.Node
 		p    *predicate.Predicate
 		want map[string]int
 	}{
 		{
+			id:   "FILTER latest predicate",
 			lo:   &storage.LookupOptions{FilterOptions: &filter.StorageOptions{Operation: filter.Latest, Field: filter.PredicateField}},
 			s:    testutil.MustBuildNodeFromStrings(t, "/u", "john"),
 			p:    testutil.MustBuildPredicate(t, `"meet"@[2012-04-10T04:21:00Z]`),
 			want: map[string]int{"/u<mary>": 1},
 		},
 		{
+			id:   "FILTER latest predicate duplicate timestamp",
 			lo:   &storage.LookupOptions{FilterOptions: &filter.StorageOptions{Operation: filter.Latest, Field: filter.PredicateField}},
 			s:    testutil.MustBuildNodeFromStrings(t, "/u", "john"),
 			p:    testutil.MustBuildPredicate(t, `"meet"@[2014-04-10T04:21:00Z]`),
 			want: map[string]int{"/u<mary>": 1, "/u<bob>": 1},
 		},
 		{
+			id:   "FILTER latest object",
 			lo:   &storage.LookupOptions{FilterOptions: &filter.StorageOptions{Operation: filter.Latest, Field: filter.ObjectField}},
 			s:    testutil.MustBuildNodeFromStrings(t, "/_", "bn"),
 			p:    testutil.MustBuildPredicate(t, `"_predicate"@[]`),
@@ -351,28 +355,30 @@ func TestObjectsFilter(t *testing.T) {
 	}
 
 	for _, entry := range testTable {
-		// To avoid blocking on the test we use a buffered channel of size 100. On a real
-		// usage of the driver you would like to call the graph operation on a separated
-		// goroutine using a sync.WaitGroup to collect the error code eventually.
-		os := make(chan *triple.Object, 100)
-		s := entry.s
-		p := entry.p
-		if err := g.Objects(ctx, s, p, entry.lo, os); err != nil {
-			t.Fatalf("g.Objects(%s, %s, %s) = %v; want nil", s, p, entry.lo, err)
-		}
-		for o := range os {
-			oStr := o.String()
-			if _, ok := entry.want[oStr]; !ok {
-				t.Fatalf("g.Objects(%s, %s, %s) retrieved unexpected %s", s, p, entry.lo, oStr)
+		t.Run(entry.id, func(t *testing.T) {
+			// To avoid blocking on the test we use a buffered channel of size 100. On a real
+			// usage of the driver you would like to call the graph operation on a separated
+			// goroutine using a sync.WaitGroup to collect the error code eventually.
+			os := make(chan *triple.Object, 100)
+			s := entry.s
+			p := entry.p
+			if err := g.Objects(ctx, s, p, entry.lo, os); err != nil {
+				t.Fatalf("g.Objects(%s, %s, %s) = %v; want nil", s, p, entry.lo, err)
 			}
-			entry.want[oStr] = entry.want[oStr] - 1
-			if entry.want[oStr] == 0 {
-				delete(entry.want, oStr)
+			for o := range os {
+				oStr := o.String()
+				if _, ok := entry.want[oStr]; !ok {
+					t.Fatalf("g.Objects(%s, %s, %s) retrieved unexpected %s", s, p, entry.lo, oStr)
+				}
+				entry.want[oStr] = entry.want[oStr] - 1
+				if entry.want[oStr] == 0 {
+					delete(entry.want, oStr)
+				}
 			}
-		}
-		if len(entry.want) != 0 {
-			t.Errorf("g.Objects(%s, %s, %s) failed to retrieve some expected elements: %v", s, p, entry.lo, entry.want)
-		}
+			if len(entry.want) != 0 {
+				t.Errorf("g.Objects(%s, %s, %s) failed to retrieve some expected elements: %v", s, p, entry.lo, entry.want)
+			}
+		})
 	}
 }
 
@@ -437,24 +443,28 @@ func TestSubjectsFilter(t *testing.T) {
 	}
 
 	testTable := []struct {
+		id   string
 		lo   *storage.LookupOptions
 		p    *predicate.Predicate
 		o    *triple.Object
 		want map[string]int
 	}{
 		{
+			id:   "FILTER latest predicate",
 			lo:   &storage.LookupOptions{FilterOptions: &filter.StorageOptions{Operation: filter.Latest, Field: filter.PredicateField}},
 			p:    testutil.MustBuildPredicate(t, `"meet"@[2012-04-10T04:21:00Z]`),
 			o:    triple.NewNodeObject(testutil.MustBuildNodeFromStrings(t, "/u", "mary")),
 			want: map[string]int{"/u<john>": 1},
 		},
 		{
+			id:   "FILTER latest predicate duplicate timestamp",
 			lo:   &storage.LookupOptions{FilterOptions: &filter.StorageOptions{Operation: filter.Latest, Field: filter.PredicateField}},
 			p:    testutil.MustBuildPredicate(t, `"meet"@[2014-04-10T04:21:00Z]`),
 			o:    triple.NewNodeObject(testutil.MustBuildNodeFromStrings(t, "/u", "mary")),
 			want: map[string]int{"/u<john>": 1},
 		},
 		{
+			id:   "FILTER latest object",
 			lo:   &storage.LookupOptions{FilterOptions: &filter.StorageOptions{Operation: filter.Latest, Field: filter.ObjectField}},
 			p:    testutil.MustBuildPredicate(t, `"_predicate"@[]`),
 			o:    triple.NewPredicateObject(testutil.MustBuildPredicate(t, `"meet"@[2020-04-10T04:21:00Z]`)),
@@ -463,28 +473,30 @@ func TestSubjectsFilter(t *testing.T) {
 	}
 
 	for _, entry := range testTable {
-		// To avoid blocking on the test we use a buffered channel of size 100. On a real
-		// usage of the driver you would like to call the graph operation on a separated
-		// goroutine using a sync.WaitGroup to collect the error code eventually.
-		ss := make(chan *node.Node, 100)
-		p := entry.p
-		o := entry.o
-		if err := g.Subjects(ctx, p, o, entry.lo, ss); err != nil {
-			t.Fatalf("g.Subjects(%s, %s, %s) = %v; want nil", p, o, entry.lo, err)
-		}
-		for s := range ss {
-			sStr := s.String()
-			if _, ok := entry.want[sStr]; !ok {
-				t.Fatalf("g.Subjects(%s, %s, %s) retrieved unexpected %s", p, o, entry.lo, sStr)
+		t.Run(entry.id, func(t *testing.T) {
+			// To avoid blocking on the test we use a buffered channel of size 100. On a real
+			// usage of the driver you would like to call the graph operation on a separated
+			// goroutine using a sync.WaitGroup to collect the error code eventually.
+			ss := make(chan *node.Node, 100)
+			p := entry.p
+			o := entry.o
+			if err := g.Subjects(ctx, p, o, entry.lo, ss); err != nil {
+				t.Fatalf("g.Subjects(%s, %s, %s) = %v; want nil", p, o, entry.lo, err)
 			}
-			entry.want[sStr] = entry.want[sStr] - 1
-			if entry.want[sStr] == 0 {
-				delete(entry.want, sStr)
+			for s := range ss {
+				sStr := s.String()
+				if _, ok := entry.want[sStr]; !ok {
+					t.Fatalf("g.Subjects(%s, %s, %s) retrieved unexpected %s", p, o, entry.lo, sStr)
+				}
+				entry.want[sStr] = entry.want[sStr] - 1
+				if entry.want[sStr] == 0 {
+					delete(entry.want, sStr)
+				}
 			}
-		}
-		if len(entry.want) != 0 {
-			t.Errorf("g.Subjects(%s, %s, %s) failed to retrieve some expected elements: %v", p, o, entry.lo, entry.want)
-		}
+			if len(entry.want) != 0 {
+				t.Errorf("g.Subjects(%s, %s, %s) failed to retrieve some expected elements: %v", p, o, entry.lo, entry.want)
+			}
+		})
 	}
 }
 
@@ -547,24 +559,21 @@ func TestPredicatesForSubjectAndObjectFilter(t *testing.T) {
 	}
 
 	testTable := []struct {
+		id   string
 		lo   *storage.LookupOptions
 		s    *node.Node
 		o    *triple.Object
 		want map[string]int
 	}{
 		{
+			id:   "FILTER latest predicate",
 			lo:   &storage.LookupOptions{FilterOptions: &filter.StorageOptions{Operation: filter.Latest, Field: filter.PredicateField}},
 			s:    testutil.MustBuildNodeFromStrings(t, "/u", "john"),
 			o:    triple.NewNodeObject(testutil.MustBuildNodeFromStrings(t, "/u", "mary")),
 			want: map[string]int{`"meet"@[2014-04-10T04:21:00Z]`: 1},
 		},
 		{
-			lo:   &storage.LookupOptions{FilterOptions: &filter.StorageOptions{Operation: filter.Latest, Field: filter.PredicateField}},
-			s:    testutil.MustBuildNodeFromStrings(t, "/u", "john"),
-			o:    triple.NewNodeObject(testutil.MustBuildNodeFromStrings(t, "/u", "bob")),
-			want: map[string]int{`"meet"@[2014-04-10T04:21:00Z]`: 1},
-		},
-		{
+			id:   "FILTER latest object",
 			lo:   &storage.LookupOptions{FilterOptions: &filter.StorageOptions{Operation: filter.Latest, Field: filter.ObjectField}},
 			s:    testutil.MustBuildNodeFromStrings(t, "/_", "bn"),
 			o:    triple.NewPredicateObject(testutil.MustBuildPredicate(t, `"meet"@[2020-04-10T04:21:00Z]`)),
@@ -573,28 +582,30 @@ func TestPredicatesForSubjectAndObjectFilter(t *testing.T) {
 	}
 
 	for _, entry := range testTable {
-		// To avoid blocking on the test we use a buffered channel of size 100. On a real
-		// usage of the driver you would like to call the graph operation on a separated
-		// goroutine using a sync.WaitGroup to collect the error code eventually.
-		pp := make(chan *predicate.Predicate, 100)
-		s := entry.s
-		o := entry.o
-		if err := g.PredicatesForSubjectAndObject(ctx, s, o, entry.lo, pp); err != nil {
-			t.Fatalf("g.PredicatesForSubjectAndObject(%s, %s, %s) = %v; want nil", s, o, entry.lo, err)
-		}
-		for p := range pp {
-			pStr := p.String()
-			if _, ok := entry.want[pStr]; !ok {
-				t.Fatalf("g.PredicatesForSubjectAndObject(%s, %s, %s) retrieved unexpected %s", s, o, entry.lo, pStr)
+		t.Run(entry.id, func(t *testing.T) {
+			// To avoid blocking on the test we use a buffered channel of size 100. On a real
+			// usage of the driver you would like to call the graph operation on a separated
+			// goroutine using a sync.WaitGroup to collect the error code eventually.
+			pp := make(chan *predicate.Predicate, 100)
+			s := entry.s
+			o := entry.o
+			if err := g.PredicatesForSubjectAndObject(ctx, s, o, entry.lo, pp); err != nil {
+				t.Fatalf("g.PredicatesForSubjectAndObject(%s, %s, %s) = %v; want nil", s, o, entry.lo, err)
 			}
-			entry.want[pStr] = entry.want[pStr] - 1
-			if entry.want[pStr] == 0 {
-				delete(entry.want, pStr)
+			for p := range pp {
+				pStr := p.String()
+				if _, ok := entry.want[pStr]; !ok {
+					t.Fatalf("g.PredicatesForSubjectAndObject(%s, %s, %s) retrieved unexpected %s", s, o, entry.lo, pStr)
+				}
+				entry.want[pStr] = entry.want[pStr] - 1
+				if entry.want[pStr] == 0 {
+					delete(entry.want, pStr)
+				}
 			}
-		}
-		if len(entry.want) != 0 {
-			t.Errorf("g.PredicatesForSubjectAndObject(%s, %s, %s) failed to retrieve some expected elements: %v", s, o, entry.lo, entry.want)
-		}
+			if len(entry.want) != 0 {
+				t.Errorf("g.PredicatesForSubjectAndObject(%s, %s, %s) failed to retrieve some expected elements: %v", s, o, entry.lo, entry.want)
+			}
+		})
 	}
 }
 
@@ -657,16 +668,19 @@ func TestPredicatesForSubjectFilter(t *testing.T) {
 	}
 
 	testTable := []struct {
+		id   string
 		lo   *storage.LookupOptions
 		s    *node.Node
 		want map[string]int
 	}{
 		{
+			id:   "FILTER latest predicate",
 			lo:   &storage.LookupOptions{FilterOptions: &filter.StorageOptions{Operation: filter.Latest, Field: filter.PredicateField}},
 			s:    testutil.MustBuildNodeFromStrings(t, "/u", "john"),
 			want: map[string]int{`"meet"@[2014-04-10T04:21:00Z]`: 2},
 		},
 		{
+			id:   "FILTER latest object",
 			lo:   &storage.LookupOptions{FilterOptions: &filter.StorageOptions{Operation: filter.Latest, Field: filter.ObjectField}},
 			s:    testutil.MustBuildNodeFromStrings(t, "/_", "bn"),
 			want: map[string]int{`"_predicate"@[]`: 1},
@@ -674,27 +688,29 @@ func TestPredicatesForSubjectFilter(t *testing.T) {
 	}
 
 	for _, entry := range testTable {
-		// To avoid blocking on the test we use a buffered channel of size 100. On a real
-		// usage of the driver you would like to call the graph operation on a separated
-		// goroutine using a sync.WaitGroup to collect the error code eventually.
-		pp := make(chan *predicate.Predicate, 100)
-		s := entry.s
-		if err := g.PredicatesForSubject(ctx, s, entry.lo, pp); err != nil {
-			t.Fatalf("g.PredicatesForSubject(%s, %s) = %v; want nil", s, entry.lo, err)
-		}
-		for p := range pp {
-			pStr := p.String()
-			if _, ok := entry.want[pStr]; !ok {
-				t.Fatalf("g.PredicatesForSubject(%s, %s) retrieved unexpected %s", s, entry.lo, pStr)
+		t.Run(entry.id, func(t *testing.T) {
+			// To avoid blocking on the test we use a buffered channel of size 100. On a real
+			// usage of the driver you would like to call the graph operation on a separated
+			// goroutine using a sync.WaitGroup to collect the error code eventually.
+			pp := make(chan *predicate.Predicate, 100)
+			s := entry.s
+			if err := g.PredicatesForSubject(ctx, s, entry.lo, pp); err != nil {
+				t.Fatalf("g.PredicatesForSubject(%s, %s) = %v; want nil", s, entry.lo, err)
 			}
-			entry.want[pStr] = entry.want[pStr] - 1
-			if entry.want[pStr] == 0 {
-				delete(entry.want, pStr)
+			for p := range pp {
+				pStr := p.String()
+				if _, ok := entry.want[pStr]; !ok {
+					t.Fatalf("g.PredicatesForSubject(%s, %s) retrieved unexpected %s", s, entry.lo, pStr)
+				}
+				entry.want[pStr] = entry.want[pStr] - 1
+				if entry.want[pStr] == 0 {
+					delete(entry.want, pStr)
+				}
 			}
-		}
-		if len(entry.want) != 0 {
-			t.Errorf("g.PredicatesForSubject(%s, %s) failed to retrieve some expected elements: %v", s, entry.lo, entry.want)
-		}
+			if len(entry.want) != 0 {
+				t.Errorf("g.PredicatesForSubject(%s, %s) failed to retrieve some expected elements: %v", s, entry.lo, entry.want)
+			}
+		})
 	}
 }
 
@@ -757,21 +773,19 @@ func TestPredicatesForObjectFilter(t *testing.T) {
 	}
 
 	testTable := []struct {
+		id   string
 		lo   *storage.LookupOptions
 		o    *triple.Object
 		want map[string]int
 	}{
 		{
+			id:   "FILTER latest predicate",
 			lo:   &storage.LookupOptions{FilterOptions: &filter.StorageOptions{Operation: filter.Latest, Field: filter.PredicateField}},
 			o:    triple.NewNodeObject(testutil.MustBuildNodeFromStrings(t, "/u", "mary")),
 			want: map[string]int{`"meet"@[2014-04-10T04:21:00Z]`: 1},
 		},
 		{
-			lo:   &storage.LookupOptions{FilterOptions: &filter.StorageOptions{Operation: filter.Latest, Field: filter.PredicateField}},
-			o:    triple.NewNodeObject(testutil.MustBuildNodeFromStrings(t, "/u", "bob")),
-			want: map[string]int{`"meet"@[2014-04-10T04:21:00Z]`: 1},
-		},
-		{
+			id:   "FILTER latest object",
 			lo:   &storage.LookupOptions{FilterOptions: &filter.StorageOptions{Operation: filter.Latest, Field: filter.ObjectField}},
 			o:    triple.NewPredicateObject(testutil.MustBuildPredicate(t, `"meet"@[2020-04-10T04:21:00Z]`)),
 			want: map[string]int{`"_predicate"@[]`: 1},
@@ -779,27 +793,29 @@ func TestPredicatesForObjectFilter(t *testing.T) {
 	}
 
 	for _, entry := range testTable {
-		// To avoid blocking on the test we use a buffered channel of size 100. On a real
-		// usage of the driver you would like to call the graph operation on a separated
-		// goroutine using a sync.WaitGroup to collect the error code eventually.
-		pp := make(chan *predicate.Predicate, 100)
-		o := entry.o
-		if err := g.PredicatesForObject(ctx, o, entry.lo, pp); err != nil {
-			t.Fatalf("g.PredicatesForObject(%s, %s) = %v; want nil", o, entry.lo, err)
-		}
-		for p := range pp {
-			pStr := p.String()
-			if _, ok := entry.want[pStr]; !ok {
-				t.Fatalf("g.PredicatesForObject(%s, %s) retrieved unexpected %s", o, entry.lo, pStr)
+		t.Run(entry.id, func(t *testing.T) {
+			// To avoid blocking on the test we use a buffered channel of size 100. On a real
+			// usage of the driver you would like to call the graph operation on a separated
+			// goroutine using a sync.WaitGroup to collect the error code eventually.
+			pp := make(chan *predicate.Predicate, 100)
+			o := entry.o
+			if err := g.PredicatesForObject(ctx, o, entry.lo, pp); err != nil {
+				t.Fatalf("g.PredicatesForObject(%s, %s) = %v; want nil", o, entry.lo, err)
 			}
-			entry.want[pStr] = entry.want[pStr] - 1
-			if entry.want[pStr] == 0 {
-				delete(entry.want, pStr)
+			for p := range pp {
+				pStr := p.String()
+				if _, ok := entry.want[pStr]; !ok {
+					t.Fatalf("g.PredicatesForObject(%s, %s) retrieved unexpected %s", o, entry.lo, pStr)
+				}
+				entry.want[pStr] = entry.want[pStr] - 1
+				if entry.want[pStr] == 0 {
+					delete(entry.want, pStr)
+				}
 			}
-		}
-		if len(entry.want) != 0 {
-			t.Errorf("g.PredicatesForObject(%s, %s) failed to retrieve some expected elements: %v", o, entry.lo, entry.want)
-		}
+			if len(entry.want) != 0 {
+				t.Errorf("g.PredicatesForObject(%s, %s) failed to retrieve some expected elements: %v", o, entry.lo, entry.want)
+			}
+		})
 	}
 }
 
@@ -859,16 +875,19 @@ func TestTriplesForSubjectFilter(t *testing.T) {
 	}
 
 	testTable := []struct {
+		id   string
 		lo   *storage.LookupOptions
 		s    *node.Node
 		want map[string]int
 	}{
 		{
+			id: "FILTER latest predicate",
 			lo: &storage.LookupOptions{FilterOptions: &filter.StorageOptions{Operation: filter.Latest, Field: filter.PredicateField}},
 			s:  testutil.MustBuildNodeFromStrings(t, "/u", "john"),
 			want: map[string]int{`/u<john>	"meet"@[2014-04-10T04:21:00Z]	/u<mary>`: 1, `/u<john>	"meet"@[2014-04-10T04:21:00Z]	/u<bob>`: 1},
 		},
 		{
+			id: "FILTER latest object",
 			lo: &storage.LookupOptions{FilterOptions: &filter.StorageOptions{Operation: filter.Latest, Field: filter.ObjectField}},
 			s:  testutil.MustBuildNodeFromStrings(t, "/_", "bn"),
 			want: map[string]int{`/_<bn>	"_predicate"@[]	"meet"@[2021-04-10T04:21:00Z]`: 1},
@@ -876,27 +895,29 @@ func TestTriplesForSubjectFilter(t *testing.T) {
 	}
 
 	for _, entry := range testTable {
-		// To avoid blocking on the test we use a buffered channel of size 100. On a real
-		// usage of the driver you would like to call the graph operation on a separated
-		// goroutine using a sync.WaitGroup to collect the error code eventually.
-		trpls := make(chan *triple.Triple, 100)
-		s := entry.s
-		if err := g.TriplesForSubject(ctx, s, entry.lo, trpls); err != nil {
-			t.Fatalf("g.TriplesForSubject(%s, %s) = %v; want nil", s, entry.lo, err)
-		}
-		for trpl := range trpls {
-			tStr := trpl.String()
-			if _, ok := entry.want[tStr]; !ok {
-				t.Fatalf("g.TriplesForSubject(%s, %s) retrieved unexpected %s", s, entry.lo, tStr)
+		t.Run(entry.id, func(t *testing.T) {
+			// To avoid blocking on the test we use a buffered channel of size 100. On a real
+			// usage of the driver you would like to call the graph operation on a separated
+			// goroutine using a sync.WaitGroup to collect the error code eventually.
+			trpls := make(chan *triple.Triple, 100)
+			s := entry.s
+			if err := g.TriplesForSubject(ctx, s, entry.lo, trpls); err != nil {
+				t.Fatalf("g.TriplesForSubject(%s, %s) = %v; want nil", s, entry.lo, err)
 			}
-			entry.want[tStr] = entry.want[tStr] - 1
-			if entry.want[tStr] == 0 {
-				delete(entry.want, tStr)
+			for trpl := range trpls {
+				tStr := trpl.String()
+				if _, ok := entry.want[tStr]; !ok {
+					t.Fatalf("g.TriplesForSubject(%s, %s) retrieved unexpected %s", s, entry.lo, tStr)
+				}
+				entry.want[tStr] = entry.want[tStr] - 1
+				if entry.want[tStr] == 0 {
+					delete(entry.want, tStr)
+				}
 			}
-		}
-		if len(entry.want) != 0 {
-			t.Errorf("g.TriplesForSubject(%s, %s) failed to retrieve some expected elements: %v", s, entry.lo, entry.want)
-		}
+			if len(entry.want) != 0 {
+				t.Errorf("g.TriplesForSubject(%s, %s) failed to retrieve some expected elements: %v", s, entry.lo, entry.want)
+			}
+		})
 	}
 }
 
@@ -956,21 +977,25 @@ func TestTriplesForPredicateFilter(t *testing.T) {
 	}
 
 	testTable := []struct {
+		id   string
 		lo   *storage.LookupOptions
 		p    *predicate.Predicate
 		want map[string]int
 	}{
 		{
+			id: "FILTER latest predicate",
 			lo: &storage.LookupOptions{FilterOptions: &filter.StorageOptions{Operation: filter.Latest, Field: filter.PredicateField}},
 			p:  testutil.MustBuildPredicate(t, `"meet"@[2012-04-10T04:21:00Z]`),
 			want: map[string]int{`/u<john>	"meet"@[2012-04-10T04:21:00Z]	/u<mary>`: 1},
 		},
 		{
+			id: "FILTER latest predicate duplicate timestamp",
 			lo: &storage.LookupOptions{FilterOptions: &filter.StorageOptions{Operation: filter.Latest, Field: filter.PredicateField}},
 			p:  testutil.MustBuildPredicate(t, `"meet"@[2014-04-10T04:21:00Z]`),
 			want: map[string]int{`/u<john>	"meet"@[2014-04-10T04:21:00Z]	/u<mary>`: 1, `/u<john>	"meet"@[2014-04-10T04:21:00Z]	/u<bob>`: 1},
 		},
 		{
+			id: "FILTER latest object",
 			lo: &storage.LookupOptions{FilterOptions: &filter.StorageOptions{Operation: filter.Latest, Field: filter.ObjectField}},
 			p:  testutil.MustBuildPredicate(t, `"_predicate"@[]`),
 			want: map[string]int{`/_<bn>	"_predicate"@[]	"meet"@[2021-04-10T04:21:00Z]`: 1},
@@ -978,27 +1003,29 @@ func TestTriplesForPredicateFilter(t *testing.T) {
 	}
 
 	for _, entry := range testTable {
-		// To avoid blocking on the test we use a buffered channel of size 100. On a real
-		// usage of the driver you would like to call the graph operation on a separated
-		// goroutine using a sync.WaitGroup to collect the error code eventually.
-		trpls := make(chan *triple.Triple, 100)
-		p := entry.p
-		if err := g.TriplesForPredicate(ctx, p, entry.lo, trpls); err != nil {
-			t.Fatalf("g.TriplesForPredicate(%s, %s) = %v; want nil", p, entry.lo, err)
-		}
-		for trpl := range trpls {
-			tStr := trpl.String()
-			if _, ok := entry.want[tStr]; !ok {
-				t.Fatalf("g.TriplesForPredicate(%s, %s) retrieved unexpected %s", p, entry.lo, tStr)
+		t.Run(entry.id, func(t *testing.T) {
+			// To avoid blocking on the test we use a buffered channel of size 100. On a real
+			// usage of the driver you would like to call the graph operation on a separated
+			// goroutine using a sync.WaitGroup to collect the error code eventually.
+			trpls := make(chan *triple.Triple, 100)
+			p := entry.p
+			if err := g.TriplesForPredicate(ctx, p, entry.lo, trpls); err != nil {
+				t.Fatalf("g.TriplesForPredicate(%s, %s) = %v; want nil", p, entry.lo, err)
 			}
-			entry.want[tStr] = entry.want[tStr] - 1
-			if entry.want[tStr] == 0 {
-				delete(entry.want, tStr)
+			for trpl := range trpls {
+				tStr := trpl.String()
+				if _, ok := entry.want[tStr]; !ok {
+					t.Fatalf("g.TriplesForPredicate(%s, %s) retrieved unexpected %s", p, entry.lo, tStr)
+				}
+				entry.want[tStr] = entry.want[tStr] - 1
+				if entry.want[tStr] == 0 {
+					delete(entry.want, tStr)
+				}
 			}
-		}
-		if len(entry.want) != 0 {
-			t.Errorf("g.TriplesForPredicate(%s, %s) failed to retrieve some expected elements: %v", p, entry.lo, entry.want)
-		}
+			if len(entry.want) != 0 {
+				t.Errorf("g.TriplesForPredicate(%s, %s) failed to retrieve some expected elements: %v", p, entry.lo, entry.want)
+			}
+		})
 	}
 }
 
@@ -1058,21 +1085,19 @@ func TestTriplesForObjectFilter(t *testing.T) {
 	}
 
 	testTable := []struct {
+		id   string
 		lo   *storage.LookupOptions
 		o    *triple.Object
 		want map[string]int
 	}{
 		{
+			id: "FILTER latest predicate",
 			lo: &storage.LookupOptions{FilterOptions: &filter.StorageOptions{Operation: filter.Latest, Field: filter.PredicateField}},
 			o:  triple.NewNodeObject(testutil.MustBuildNodeFromStrings(t, "/u", "mary")),
 			want: map[string]int{`/u<john>	"meet"@[2014-04-10T04:21:00Z]	/u<mary>`: 1},
 		},
 		{
-			lo: &storage.LookupOptions{FilterOptions: &filter.StorageOptions{Operation: filter.Latest, Field: filter.PredicateField}},
-			o:  triple.NewNodeObject(testutil.MustBuildNodeFromStrings(t, "/u", "bob")),
-			want: map[string]int{`/u<john>	"meet"@[2014-04-10T04:21:00Z]	/u<bob>`: 1},
-		},
-		{
+			id: "FILTER latest object",
 			lo: &storage.LookupOptions{FilterOptions: &filter.StorageOptions{Operation: filter.Latest, Field: filter.ObjectField}},
 			o:  triple.NewPredicateObject(testutil.MustBuildPredicate(t, `"meet"@[2020-04-10T04:21:00Z]`)),
 			want: map[string]int{`/_<bn>	"_predicate"@[]	"meet"@[2020-04-10T04:21:00Z]`: 1},
@@ -1080,27 +1105,29 @@ func TestTriplesForObjectFilter(t *testing.T) {
 	}
 
 	for _, entry := range testTable {
-		// To avoid blocking on the test we use a buffered channel of size 100. On a real
-		// usage of the driver you would like to call the graph operation on a separated
-		// goroutine using a sync.WaitGroup to collect the error code eventually.
-		trpls := make(chan *triple.Triple, 100)
-		o := entry.o
-		if err := g.TriplesForObject(ctx, o, entry.lo, trpls); err != nil {
-			t.Fatalf("g.TriplesForObject(%s, %s) = %v; want nil", o, entry.lo, err)
-		}
-		for trpl := range trpls {
-			tStr := trpl.String()
-			if _, ok := entry.want[tStr]; !ok {
-				t.Fatalf("g.TriplesForObject(%s, %s) retrieved unexpected %s", o, entry.lo, tStr)
+		t.Run(entry.id, func(t *testing.T) {
+			// To avoid blocking on the test we use a buffered channel of size 100. On a real
+			// usage of the driver you would like to call the graph operation on a separated
+			// goroutine using a sync.WaitGroup to collect the error code eventually.
+			trpls := make(chan *triple.Triple, 100)
+			o := entry.o
+			if err := g.TriplesForObject(ctx, o, entry.lo, trpls); err != nil {
+				t.Fatalf("g.TriplesForObject(%s, %s) = %v; want nil", o, entry.lo, err)
 			}
-			entry.want[tStr] = entry.want[tStr] - 1
-			if entry.want[tStr] == 0 {
-				delete(entry.want, tStr)
+			for trpl := range trpls {
+				tStr := trpl.String()
+				if _, ok := entry.want[tStr]; !ok {
+					t.Fatalf("g.TriplesForObject(%s, %s) retrieved unexpected %s", o, entry.lo, tStr)
+				}
+				entry.want[tStr] = entry.want[tStr] - 1
+				if entry.want[tStr] == 0 {
+					delete(entry.want, tStr)
+				}
 			}
-		}
-		if len(entry.want) != 0 {
-			t.Errorf("g.TriplesForObject(%s, %s) failed to retrieve some expected elements: %v", o, entry.lo, entry.want)
-		}
+			if len(entry.want) != 0 {
+				t.Errorf("g.TriplesForObject(%s, %s) failed to retrieve some expected elements: %v", o, entry.lo, entry.want)
+			}
+		})
 	}
 }
 
@@ -1203,24 +1230,28 @@ func TestTriplesForSubjectAndPredicateFilter(t *testing.T) {
 	}
 
 	testTable := []struct {
+		id   string
 		lo   *storage.LookupOptions
 		s    *node.Node
 		p    *predicate.Predicate
 		want map[string]int
 	}{
 		{
+			id: "FILTER latest predicate",
 			lo: &storage.LookupOptions{FilterOptions: &filter.StorageOptions{Operation: filter.Latest, Field: filter.PredicateField}},
 			s:  testutil.MustBuildNodeFromStrings(t, "/u", "john"),
 			p:  testutil.MustBuildPredicate(t, `"meet"@[2012-04-10T04:21:00Z]`),
 			want: map[string]int{`/u<john>	"meet"@[2012-04-10T04:21:00Z]	/u<mary>`: 1},
 		},
 		{
+			id: "FILTER latest predicate duplicate timestamp",
 			lo: &storage.LookupOptions{FilterOptions: &filter.StorageOptions{Operation: filter.Latest, Field: filter.PredicateField}},
 			s:  testutil.MustBuildNodeFromStrings(t, "/u", "john"),
 			p:  testutil.MustBuildPredicate(t, `"meet"@[2014-04-10T04:21:00Z]`),
 			want: map[string]int{`/u<john>	"meet"@[2014-04-10T04:21:00Z]	/u<mary>`: 1, `/u<john>	"meet"@[2014-04-10T04:21:00Z]	/u<bob>`: 1},
 		},
 		{
+			id: "FILTER latest object",
 			lo: &storage.LookupOptions{FilterOptions: &filter.StorageOptions{Operation: filter.Latest, Field: filter.ObjectField}},
 			s:  testutil.MustBuildNodeFromStrings(t, "/_", "bn"),
 			p:  testutil.MustBuildPredicate(t, `"_predicate"@[]`),
@@ -1229,28 +1260,30 @@ func TestTriplesForSubjectAndPredicateFilter(t *testing.T) {
 	}
 
 	for _, entry := range testTable {
-		// To avoid blocking on the test we use a buffered channel of size 100. On a real
-		// usage of the driver you would like to call the graph operation on a separated
-		// goroutine using a sync.WaitGroup to collect the error code eventually.
-		trpls := make(chan *triple.Triple, 100)
-		s := entry.s
-		p := entry.p
-		if err := g.TriplesForSubjectAndPredicate(ctx, s, p, entry.lo, trpls); err != nil {
-			t.Fatalf("g.TriplesForSubjectAndPredicate(%s, %s, %s) = %v; want nil", s, p, entry.lo, err)
-		}
-		for trpl := range trpls {
-			tStr := trpl.String()
-			if _, ok := entry.want[tStr]; !ok {
-				t.Fatalf("g.TriplesForSubjectAndPredicate(%s, %s, %s) retrieved unexpected %s", s, p, entry.lo, tStr)
+		t.Run(entry.id, func(t *testing.T) {
+			// To avoid blocking on the test we use a buffered channel of size 100. On a real
+			// usage of the driver you would like to call the graph operation on a separated
+			// goroutine using a sync.WaitGroup to collect the error code eventually.
+			trpls := make(chan *triple.Triple, 100)
+			s := entry.s
+			p := entry.p
+			if err := g.TriplesForSubjectAndPredicate(ctx, s, p, entry.lo, trpls); err != nil {
+				t.Fatalf("g.TriplesForSubjectAndPredicate(%s, %s, %s) = %v; want nil", s, p, entry.lo, err)
 			}
-			entry.want[tStr] = entry.want[tStr] - 1
-			if entry.want[tStr] == 0 {
-				delete(entry.want, tStr)
+			for trpl := range trpls {
+				tStr := trpl.String()
+				if _, ok := entry.want[tStr]; !ok {
+					t.Fatalf("g.TriplesForSubjectAndPredicate(%s, %s, %s) retrieved unexpected %s", s, p, entry.lo, tStr)
+				}
+				entry.want[tStr] = entry.want[tStr] - 1
+				if entry.want[tStr] == 0 {
+					delete(entry.want, tStr)
+				}
 			}
-		}
-		if len(entry.want) != 0 {
-			t.Errorf("g.TriplesForSubjectAndPredicate(%s, %s, %s) failed to retrieve some expected elements: %v", s, p, entry.lo, entry.want)
-		}
+			if len(entry.want) != 0 {
+				t.Errorf("g.TriplesForSubjectAndPredicate(%s, %s, %s) failed to retrieve some expected elements: %v", s, p, entry.lo, entry.want)
+			}
+		})
 	}
 }
 
@@ -1310,24 +1343,28 @@ func TestTriplesForPredicateAndObjectFilter(t *testing.T) {
 	}
 
 	testTable := []struct {
+		id   string
 		lo   *storage.LookupOptions
 		p    *predicate.Predicate
 		o    *triple.Object
 		want map[string]int
 	}{
 		{
+			id: "FILTER latest predicate",
 			lo: &storage.LookupOptions{FilterOptions: &filter.StorageOptions{Operation: filter.Latest, Field: filter.PredicateField}},
 			p:  testutil.MustBuildPredicate(t, `"meet"@[2012-04-10T04:21:00Z]`),
 			o:  triple.NewNodeObject(testutil.MustBuildNodeFromStrings(t, "/u", "mary")),
 			want: map[string]int{`/u<john>	"meet"@[2012-04-10T04:21:00Z]	/u<mary>`: 1},
 		},
 		{
+			id: "FILTER latest predicate duplicate timestamp",
 			lo: &storage.LookupOptions{FilterOptions: &filter.StorageOptions{Operation: filter.Latest, Field: filter.PredicateField}},
 			p:  testutil.MustBuildPredicate(t, `"meet"@[2014-04-10T04:21:00Z]`),
 			o:  triple.NewNodeObject(testutil.MustBuildNodeFromStrings(t, "/u", "mary")),
 			want: map[string]int{`/u<john>	"meet"@[2014-04-10T04:21:00Z]	/u<mary>`: 1},
 		},
 		{
+			id: "FILTER latest object",
 			lo: &storage.LookupOptions{FilterOptions: &filter.StorageOptions{Operation: filter.Latest, Field: filter.ObjectField}},
 			p:  testutil.MustBuildPredicate(t, `"_predicate"@[]`),
 			o:  triple.NewPredicateObject(testutil.MustBuildPredicate(t, `"meet"@[2020-04-10T04:21:00Z]`)),
@@ -1336,28 +1373,30 @@ func TestTriplesForPredicateAndObjectFilter(t *testing.T) {
 	}
 
 	for _, entry := range testTable {
-		// To avoid blocking on the test we use a buffered channel of size 100. On a real
-		// usage of the driver you would like to call the graph operation on a separated
-		// goroutine using a sync.WaitGroup to collect the error code eventually.
-		trpls := make(chan *triple.Triple, 100)
-		p := entry.p
-		o := entry.o
-		if err := g.TriplesForPredicateAndObject(ctx, p, o, entry.lo, trpls); err != nil {
-			t.Fatalf("g.TriplesForPredicateAndObject(%s, %s, %s) = %v; want nil", p, o, entry.lo, err)
-		}
-		for trpl := range trpls {
-			tStr := trpl.String()
-			if _, ok := entry.want[tStr]; !ok {
-				t.Fatalf("g.TriplesForPredicateAndObject(%s, %s, %s) retrieved unexpected %s", p, o, entry.lo, tStr)
+		t.Run(entry.id, func(t *testing.T) {
+			// To avoid blocking on the test we use a buffered channel of size 100. On a real
+			// usage of the driver you would like to call the graph operation on a separated
+			// goroutine using a sync.WaitGroup to collect the error code eventually.
+			trpls := make(chan *triple.Triple, 100)
+			p := entry.p
+			o := entry.o
+			if err := g.TriplesForPredicateAndObject(ctx, p, o, entry.lo, trpls); err != nil {
+				t.Fatalf("g.TriplesForPredicateAndObject(%s, %s, %s) = %v; want nil", p, o, entry.lo, err)
 			}
-			entry.want[tStr] = entry.want[tStr] - 1
-			if entry.want[tStr] == 0 {
-				delete(entry.want, tStr)
+			for trpl := range trpls {
+				tStr := trpl.String()
+				if _, ok := entry.want[tStr]; !ok {
+					t.Fatalf("g.TriplesForPredicateAndObject(%s, %s, %s) retrieved unexpected %s", p, o, entry.lo, tStr)
+				}
+				entry.want[tStr] = entry.want[tStr] - 1
+				if entry.want[tStr] == 0 {
+					delete(entry.want, tStr)
+				}
 			}
-		}
-		if len(entry.want) != 0 {
-			t.Errorf("g.TriplesForPredicateAndObject(%s, %s, %s) failed to retrieve some expected elements: %v", p, o, entry.lo, entry.want)
-		}
+			if len(entry.want) != 0 {
+				t.Errorf("g.TriplesForPredicateAndObject(%s, %s, %s) failed to retrieve some expected elements: %v", p, o, entry.lo, entry.want)
+			}
+		})
 	}
 }
 
@@ -1434,39 +1473,44 @@ func TestTriplesFilter(t *testing.T) {
 	}
 
 	testTable := []struct {
+		id   string
 		lo   *storage.LookupOptions
 		want map[string]int
 	}{
 		{
+			id: "FILTER latest predicate",
 			lo: &storage.LookupOptions{FilterOptions: &filter.StorageOptions{Operation: filter.Latest, Field: filter.PredicateField}},
 			want: map[string]int{`/u<john>	"meet"@[2014-04-10T04:21:00Z]	/u<mary>`: 1, `/u<john>	"meet"@[2014-04-10T04:21:00Z]	/u<bob>`: 1},
 		},
 		{
+			id: "FILTER latest object",
 			lo: &storage.LookupOptions{FilterOptions: &filter.StorageOptions{Operation: filter.Latest, Field: filter.ObjectField}},
 			want: map[string]int{`/_<bn>	"_predicate"@[]	"meet"@[2021-04-10T04:21:00Z]`: 1},
 		},
 	}
 
 	for _, entry := range testTable {
-		// To avoid blocking on the test we use a buffered channel of size 100. On a real
-		// usage of the driver you would like to call the graph operation on a separated
-		// goroutine using a sync.WaitGroup to collect the error code eventually.
-		trpls := make(chan *triple.Triple, 100)
-		if err := g.Triples(ctx, entry.lo, trpls); err != nil {
-			t.Fatalf("g.Triples(%s) = %v; want nil", entry.lo, err)
-		}
-		for trpl := range trpls {
-			tStr := trpl.String()
-			if _, ok := entry.want[tStr]; !ok {
-				t.Fatalf("g.Triples(%s) retrieved unexpected %s", entry.lo, tStr)
+		t.Run(entry.id, func(t *testing.T) {
+			// To avoid blocking on the test we use a buffered channel of size 100. On a real
+			// usage of the driver you would like to call the graph operation on a separated
+			// goroutine using a sync.WaitGroup to collect the error code eventually.
+			trpls := make(chan *triple.Triple, 100)
+			if err := g.Triples(ctx, entry.lo, trpls); err != nil {
+				t.Fatalf("g.Triples(%s) = %v; want nil", entry.lo, err)
 			}
-			entry.want[tStr] = entry.want[tStr] - 1
-			if entry.want[tStr] == 0 {
-				delete(entry.want, tStr)
+			for trpl := range trpls {
+				tStr := trpl.String()
+				if _, ok := entry.want[tStr]; !ok {
+					t.Fatalf("g.Triples(%s) retrieved unexpected %s", entry.lo, tStr)
+				}
+				entry.want[tStr] = entry.want[tStr] - 1
+				if entry.want[tStr] == 0 {
+					delete(entry.want, tStr)
+				}
 			}
-		}
-		if len(entry.want) != 0 {
-			t.Errorf("g.Triples(%s) failed to retrieve some expected elements: %v", entry.lo, entry.want)
-		}
+			if len(entry.want) != 0 {
+				t.Errorf("g.Triples(%s) failed to retrieve some expected elements: %v", entry.lo, entry.want)
+			}
+		})
 	}
 }

--- a/storage/memory/memory_test.go
+++ b/storage/memory/memory_test.go
@@ -331,19 +331,19 @@ func TestObjectsFilter(t *testing.T) {
 		want map[string]int
 	}{
 		{
-			lo:   &storage.LookupOptions{FilterOptions: &storage.FilteringOptions{Operation: filter.Latest, Field: "predicate"}},
+			lo:   &storage.LookupOptions{FilterOptions: &filter.StorageOptions{Operation: filter.Latest, Field: "predicate"}},
 			s:    testutil.MustBuildNodeFromStrings(t, "/u", "john"),
 			p:    testutil.MustBuildPredicate(t, `"meet"@[2012-04-10T04:21:00Z]`),
 			want: map[string]int{"/u<mary>": 1},
 		},
 		{
-			lo:   &storage.LookupOptions{FilterOptions: &storage.FilteringOptions{Operation: filter.Latest, Field: "predicate"}},
+			lo:   &storage.LookupOptions{FilterOptions: &filter.StorageOptions{Operation: filter.Latest, Field: "predicate"}},
 			s:    testutil.MustBuildNodeFromStrings(t, "/u", "john"),
 			p:    testutil.MustBuildPredicate(t, `"meet"@[2014-04-10T04:21:00Z]`),
 			want: map[string]int{"/u<mary>": 1, "/u<bob>": 1},
 		},
 		{
-			lo:   &storage.LookupOptions{FilterOptions: &storage.FilteringOptions{Operation: filter.Latest, Field: "object"}},
+			lo:   &storage.LookupOptions{FilterOptions: &filter.StorageOptions{Operation: filter.Latest, Field: "object"}},
 			s:    testutil.MustBuildNodeFromStrings(t, "/_", "bn"),
 			p:    testutil.MustBuildPredicate(t, `"_predicate"@[]`),
 			want: map[string]int{`"meet"@[2021-04-10T04:21:00Z]`: 1},
@@ -443,19 +443,19 @@ func TestSubjectsFilter(t *testing.T) {
 		want map[string]int
 	}{
 		{
-			lo:   &storage.LookupOptions{FilterOptions: &storage.FilteringOptions{Operation: filter.Latest, Field: "predicate"}},
+			lo:   &storage.LookupOptions{FilterOptions: &filter.StorageOptions{Operation: filter.Latest, Field: "predicate"}},
 			p:    testutil.MustBuildPredicate(t, `"meet"@[2012-04-10T04:21:00Z]`),
 			o:    triple.NewNodeObject(testutil.MustBuildNodeFromStrings(t, "/u", "mary")),
 			want: map[string]int{"/u<john>": 1},
 		},
 		{
-			lo:   &storage.LookupOptions{FilterOptions: &storage.FilteringOptions{Operation: filter.Latest, Field: "predicate"}},
+			lo:   &storage.LookupOptions{FilterOptions: &filter.StorageOptions{Operation: filter.Latest, Field: "predicate"}},
 			p:    testutil.MustBuildPredicate(t, `"meet"@[2014-04-10T04:21:00Z]`),
 			o:    triple.NewNodeObject(testutil.MustBuildNodeFromStrings(t, "/u", "mary")),
 			want: map[string]int{"/u<john>": 1},
 		},
 		{
-			lo:   &storage.LookupOptions{FilterOptions: &storage.FilteringOptions{Operation: filter.Latest, Field: "object"}},
+			lo:   &storage.LookupOptions{FilterOptions: &filter.StorageOptions{Operation: filter.Latest, Field: "object"}},
 			p:    testutil.MustBuildPredicate(t, `"_predicate"@[]`),
 			o:    triple.NewPredicateObject(testutil.MustBuildPredicate(t, `"meet"@[2020-04-10T04:21:00Z]`)),
 			want: map[string]int{"/_<bn>": 1},
@@ -553,19 +553,19 @@ func TestPredicatesForSubjectAndObjectFilter(t *testing.T) {
 		want map[string]int
 	}{
 		{
-			lo:   &storage.LookupOptions{FilterOptions: &storage.FilteringOptions{Operation: filter.Latest, Field: "predicate"}},
+			lo:   &storage.LookupOptions{FilterOptions: &filter.StorageOptions{Operation: filter.Latest, Field: "predicate"}},
 			s:    testutil.MustBuildNodeFromStrings(t, "/u", "john"),
 			o:    triple.NewNodeObject(testutil.MustBuildNodeFromStrings(t, "/u", "mary")),
 			want: map[string]int{`"meet"@[2014-04-10T04:21:00Z]`: 1},
 		},
 		{
-			lo:   &storage.LookupOptions{FilterOptions: &storage.FilteringOptions{Operation: filter.Latest, Field: "predicate"}},
+			lo:   &storage.LookupOptions{FilterOptions: &filter.StorageOptions{Operation: filter.Latest, Field: "predicate"}},
 			s:    testutil.MustBuildNodeFromStrings(t, "/u", "john"),
 			o:    triple.NewNodeObject(testutil.MustBuildNodeFromStrings(t, "/u", "bob")),
 			want: map[string]int{`"meet"@[2014-04-10T04:21:00Z]`: 1},
 		},
 		{
-			lo:   &storage.LookupOptions{FilterOptions: &storage.FilteringOptions{Operation: filter.Latest, Field: "object"}},
+			lo:   &storage.LookupOptions{FilterOptions: &filter.StorageOptions{Operation: filter.Latest, Field: "object"}},
 			s:    testutil.MustBuildNodeFromStrings(t, "/_", "bn"),
 			o:    triple.NewPredicateObject(testutil.MustBuildPredicate(t, `"meet"@[2020-04-10T04:21:00Z]`)),
 			want: map[string]int{`"_predicate"@[]`: 1},
@@ -662,12 +662,12 @@ func TestPredicatesForSubjectFilter(t *testing.T) {
 		want map[string]int
 	}{
 		{
-			lo:   &storage.LookupOptions{FilterOptions: &storage.FilteringOptions{Operation: filter.Latest, Field: "predicate"}},
+			lo:   &storage.LookupOptions{FilterOptions: &filter.StorageOptions{Operation: filter.Latest, Field: "predicate"}},
 			s:    testutil.MustBuildNodeFromStrings(t, "/u", "john"),
 			want: map[string]int{`"meet"@[2014-04-10T04:21:00Z]`: 2},
 		},
 		{
-			lo:   &storage.LookupOptions{FilterOptions: &storage.FilteringOptions{Operation: filter.Latest, Field: "object"}},
+			lo:   &storage.LookupOptions{FilterOptions: &filter.StorageOptions{Operation: filter.Latest, Field: "object"}},
 			s:    testutil.MustBuildNodeFromStrings(t, "/_", "bn"),
 			want: map[string]int{`"_predicate"@[]`: 1},
 		},
@@ -762,17 +762,17 @@ func TestPredicatesForObjectFilter(t *testing.T) {
 		want map[string]int
 	}{
 		{
-			lo:   &storage.LookupOptions{FilterOptions: &storage.FilteringOptions{Operation: filter.Latest, Field: "predicate"}},
+			lo:   &storage.LookupOptions{FilterOptions: &filter.StorageOptions{Operation: filter.Latest, Field: "predicate"}},
 			o:    triple.NewNodeObject(testutil.MustBuildNodeFromStrings(t, "/u", "mary")),
 			want: map[string]int{`"meet"@[2014-04-10T04:21:00Z]`: 1},
 		},
 		{
-			lo:   &storage.LookupOptions{FilterOptions: &storage.FilteringOptions{Operation: filter.Latest, Field: "predicate"}},
+			lo:   &storage.LookupOptions{FilterOptions: &filter.StorageOptions{Operation: filter.Latest, Field: "predicate"}},
 			o:    triple.NewNodeObject(testutil.MustBuildNodeFromStrings(t, "/u", "bob")),
 			want: map[string]int{`"meet"@[2014-04-10T04:21:00Z]`: 1},
 		},
 		{
-			lo:   &storage.LookupOptions{FilterOptions: &storage.FilteringOptions{Operation: filter.Latest, Field: "object"}},
+			lo:   &storage.LookupOptions{FilterOptions: &filter.StorageOptions{Operation: filter.Latest, Field: "object"}},
 			o:    triple.NewPredicateObject(testutil.MustBuildPredicate(t, `"meet"@[2020-04-10T04:21:00Z]`)),
 			want: map[string]int{`"_predicate"@[]`: 1},
 		},
@@ -864,12 +864,12 @@ func TestTriplesForSubjectFilter(t *testing.T) {
 		want map[string]int
 	}{
 		{
-			lo: &storage.LookupOptions{FilterOptions: &storage.FilteringOptions{Operation: filter.Latest, Field: "predicate"}},
+			lo: &storage.LookupOptions{FilterOptions: &filter.StorageOptions{Operation: filter.Latest, Field: "predicate"}},
 			s:  testutil.MustBuildNodeFromStrings(t, "/u", "john"),
 			want: map[string]int{`/u<john>	"meet"@[2014-04-10T04:21:00Z]	/u<mary>`: 1, `/u<john>	"meet"@[2014-04-10T04:21:00Z]	/u<bob>`: 1},
 		},
 		{
-			lo: &storage.LookupOptions{FilterOptions: &storage.FilteringOptions{Operation: filter.Latest, Field: "object"}},
+			lo: &storage.LookupOptions{FilterOptions: &filter.StorageOptions{Operation: filter.Latest, Field: "object"}},
 			s:  testutil.MustBuildNodeFromStrings(t, "/_", "bn"),
 			want: map[string]int{`/_<bn>	"_predicate"@[]	"meet"@[2021-04-10T04:21:00Z]`: 1},
 		},
@@ -961,17 +961,17 @@ func TestTriplesForPredicateFilter(t *testing.T) {
 		want map[string]int
 	}{
 		{
-			lo: &storage.LookupOptions{FilterOptions: &storage.FilteringOptions{Operation: filter.Latest, Field: "predicate"}},
+			lo: &storage.LookupOptions{FilterOptions: &filter.StorageOptions{Operation: filter.Latest, Field: "predicate"}},
 			p:  testutil.MustBuildPredicate(t, `"meet"@[2012-04-10T04:21:00Z]`),
 			want: map[string]int{`/u<john>	"meet"@[2012-04-10T04:21:00Z]	/u<mary>`: 1},
 		},
 		{
-			lo: &storage.LookupOptions{FilterOptions: &storage.FilteringOptions{Operation: filter.Latest, Field: "predicate"}},
+			lo: &storage.LookupOptions{FilterOptions: &filter.StorageOptions{Operation: filter.Latest, Field: "predicate"}},
 			p:  testutil.MustBuildPredicate(t, `"meet"@[2014-04-10T04:21:00Z]`),
 			want: map[string]int{`/u<john>	"meet"@[2014-04-10T04:21:00Z]	/u<mary>`: 1, `/u<john>	"meet"@[2014-04-10T04:21:00Z]	/u<bob>`: 1},
 		},
 		{
-			lo: &storage.LookupOptions{FilterOptions: &storage.FilteringOptions{Operation: filter.Latest, Field: "object"}},
+			lo: &storage.LookupOptions{FilterOptions: &filter.StorageOptions{Operation: filter.Latest, Field: "object"}},
 			p:  testutil.MustBuildPredicate(t, `"_predicate"@[]`),
 			want: map[string]int{`/_<bn>	"_predicate"@[]	"meet"@[2021-04-10T04:21:00Z]`: 1},
 		},
@@ -1063,17 +1063,17 @@ func TestTriplesForObjectFilter(t *testing.T) {
 		want map[string]int
 	}{
 		{
-			lo: &storage.LookupOptions{FilterOptions: &storage.FilteringOptions{Operation: filter.Latest, Field: "predicate"}},
+			lo: &storage.LookupOptions{FilterOptions: &filter.StorageOptions{Operation: filter.Latest, Field: "predicate"}},
 			o:  triple.NewNodeObject(testutil.MustBuildNodeFromStrings(t, "/u", "mary")),
 			want: map[string]int{`/u<john>	"meet"@[2014-04-10T04:21:00Z]	/u<mary>`: 1},
 		},
 		{
-			lo: &storage.LookupOptions{FilterOptions: &storage.FilteringOptions{Operation: filter.Latest, Field: "predicate"}},
+			lo: &storage.LookupOptions{FilterOptions: &filter.StorageOptions{Operation: filter.Latest, Field: "predicate"}},
 			o:  triple.NewNodeObject(testutil.MustBuildNodeFromStrings(t, "/u", "bob")),
 			want: map[string]int{`/u<john>	"meet"@[2014-04-10T04:21:00Z]	/u<bob>`: 1},
 		},
 		{
-			lo: &storage.LookupOptions{FilterOptions: &storage.FilteringOptions{Operation: filter.Latest, Field: "object"}},
+			lo: &storage.LookupOptions{FilterOptions: &filter.StorageOptions{Operation: filter.Latest, Field: "object"}},
 			o:  triple.NewPredicateObject(testutil.MustBuildPredicate(t, `"meet"@[2020-04-10T04:21:00Z]`)),
 			want: map[string]int{`/_<bn>	"_predicate"@[]	"meet"@[2020-04-10T04:21:00Z]`: 1},
 		},
@@ -1209,19 +1209,19 @@ func TestTriplesForSubjectAndPredicateFilter(t *testing.T) {
 		want map[string]int
 	}{
 		{
-			lo: &storage.LookupOptions{FilterOptions: &storage.FilteringOptions{Operation: filter.Latest, Field: "predicate"}},
+			lo: &storage.LookupOptions{FilterOptions: &filter.StorageOptions{Operation: filter.Latest, Field: "predicate"}},
 			s:  testutil.MustBuildNodeFromStrings(t, "/u", "john"),
 			p:  testutil.MustBuildPredicate(t, `"meet"@[2012-04-10T04:21:00Z]`),
 			want: map[string]int{`/u<john>	"meet"@[2012-04-10T04:21:00Z]	/u<mary>`: 1},
 		},
 		{
-			lo: &storage.LookupOptions{FilterOptions: &storage.FilteringOptions{Operation: filter.Latest, Field: "predicate"}},
+			lo: &storage.LookupOptions{FilterOptions: &filter.StorageOptions{Operation: filter.Latest, Field: "predicate"}},
 			s:  testutil.MustBuildNodeFromStrings(t, "/u", "john"),
 			p:  testutil.MustBuildPredicate(t, `"meet"@[2014-04-10T04:21:00Z]`),
 			want: map[string]int{`/u<john>	"meet"@[2014-04-10T04:21:00Z]	/u<mary>`: 1, `/u<john>	"meet"@[2014-04-10T04:21:00Z]	/u<bob>`: 1},
 		},
 		{
-			lo: &storage.LookupOptions{FilterOptions: &storage.FilteringOptions{Operation: filter.Latest, Field: "object"}},
+			lo: &storage.LookupOptions{FilterOptions: &filter.StorageOptions{Operation: filter.Latest, Field: "object"}},
 			s:  testutil.MustBuildNodeFromStrings(t, "/_", "bn"),
 			p:  testutil.MustBuildPredicate(t, `"_predicate"@[]`),
 			want: map[string]int{`/_<bn>	"_predicate"@[]	"meet"@[2021-04-10T04:21:00Z]`: 1},
@@ -1316,19 +1316,19 @@ func TestTriplesForPredicateAndObjectFilter(t *testing.T) {
 		want map[string]int
 	}{
 		{
-			lo: &storage.LookupOptions{FilterOptions: &storage.FilteringOptions{Operation: filter.Latest, Field: "predicate"}},
+			lo: &storage.LookupOptions{FilterOptions: &filter.StorageOptions{Operation: filter.Latest, Field: "predicate"}},
 			p:  testutil.MustBuildPredicate(t, `"meet"@[2012-04-10T04:21:00Z]`),
 			o:  triple.NewNodeObject(testutil.MustBuildNodeFromStrings(t, "/u", "mary")),
 			want: map[string]int{`/u<john>	"meet"@[2012-04-10T04:21:00Z]	/u<mary>`: 1},
 		},
 		{
-			lo: &storage.LookupOptions{FilterOptions: &storage.FilteringOptions{Operation: filter.Latest, Field: "predicate"}},
+			lo: &storage.LookupOptions{FilterOptions: &filter.StorageOptions{Operation: filter.Latest, Field: "predicate"}},
 			p:  testutil.MustBuildPredicate(t, `"meet"@[2014-04-10T04:21:00Z]`),
 			o:  triple.NewNodeObject(testutil.MustBuildNodeFromStrings(t, "/u", "mary")),
 			want: map[string]int{`/u<john>	"meet"@[2014-04-10T04:21:00Z]	/u<mary>`: 1},
 		},
 		{
-			lo: &storage.LookupOptions{FilterOptions: &storage.FilteringOptions{Operation: filter.Latest, Field: "object"}},
+			lo: &storage.LookupOptions{FilterOptions: &filter.StorageOptions{Operation: filter.Latest, Field: "object"}},
 			p:  testutil.MustBuildPredicate(t, `"_predicate"@[]`),
 			o:  triple.NewPredicateObject(testutil.MustBuildPredicate(t, `"meet"@[2020-04-10T04:21:00Z]`)),
 			want: map[string]int{`/_<bn>	"_predicate"@[]	"meet"@[2020-04-10T04:21:00Z]`: 1},
@@ -1438,11 +1438,11 @@ func TestTriplesFilter(t *testing.T) {
 		want map[string]int
 	}{
 		{
-			lo: &storage.LookupOptions{FilterOptions: &storage.FilteringOptions{Operation: filter.Latest, Field: "predicate"}},
+			lo: &storage.LookupOptions{FilterOptions: &filter.StorageOptions{Operation: filter.Latest, Field: "predicate"}},
 			want: map[string]int{`/u<john>	"meet"@[2014-04-10T04:21:00Z]	/u<mary>`: 1, `/u<john>	"meet"@[2014-04-10T04:21:00Z]	/u<bob>`: 1},
 		},
 		{
-			lo: &storage.LookupOptions{FilterOptions: &storage.FilteringOptions{Operation: filter.Latest, Field: "object"}},
+			lo: &storage.LookupOptions{FilterOptions: &filter.StorageOptions{Operation: filter.Latest, Field: "object"}},
 			want: map[string]int{`/_<bn>	"_predicate"@[]	"meet"@[2021-04-10T04:21:00Z]`: 1},
 		},
 	}

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -22,6 +22,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/google/badwolf/bql/planner/filter"
 	"github.com/google/badwolf/triple"
 	"github.com/google/badwolf/triple/node"
 	"github.com/google/badwolf/triple/predicate"
@@ -52,7 +53,11 @@ type LookupOptions struct {
 // Operation below refers to the filter function being applied (eg: "latest"), Field refers to the position of the graph clause it
 // will be applied to ("subject", "predicate" or "object") and Value, when specified, contains the second argument of the filter
 // function (not applicable for all Operations - some like "latest" do not use it while others like "greaterThan" do, see Issue 129).
-type FilteringOptions struct{ Operation, Field, Value string }
+type FilteringOptions struct {
+	Operation filter.Operation
+	Field     string
+	Value     string
+}
 
 // String returns a readable version of the LookupOptions instance.
 func (l *LookupOptions) String() string {

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -66,9 +66,7 @@ func (l *LookupOptions) String() string {
 		b.WriteString("nil")
 	}
 	b.WriteString(fmt.Sprintf(", LatestAnchor=%v", l.LatestAnchor))
-	b.WriteString(", FilterOptions=")
-	b.WriteString(fmt.Sprintf("%+v", l.FilterOptions))
-	b.WriteString(">")
+	b.WriteString(fmt.Sprintf(", FilterOptions=%s>", l.FilterOptions))
 	return b.String()
 }
 

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -46,17 +46,7 @@ type LookupOptions struct {
 	LatestAnchor bool
 
 	// FilterOptions, if provided, represent the specifications for the filtering to be executed.
-	FilterOptions *FilteringOptions
-}
-
-// FilteringOptions represent the storage level specifications for the filtering to be executed.
-// Operation below refers to the filter function being applied (eg: "latest"), Field refers to the position of the graph clause it
-// will be applied to ("subject", "predicate" or "object") and Value, when specified, contains the second argument of the filter
-// function (not applicable for all Operations - some like "latest" do not use it while others like "greaterThan" do, see Issue 129).
-type FilteringOptions struct {
-	Operation filter.Operation
-	Field     string
-	Value     string
+	FilterOptions *filter.StorageOptions
 }
 
 // String returns a readable version of the LookupOptions instance.

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -71,6 +71,8 @@ func (l *LookupOptions) String() string {
 		b.WriteString("nil")
 	}
 	b.WriteString(fmt.Sprintf(", LatestAnchor=%v", l.LatestAnchor))
+	b.WriteString(", FilterOptions=")
+	b.WriteString(fmt.Sprintf("%+v", l.FilterOptions))
 	b.WriteString(">")
 	return b.String()
 }

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -43,7 +43,16 @@ type LookupOptions struct {
 	// LatestAnchor only. If set, it will ignore the time boundaries provided and
 	// just use the last available anchor.
 	LatestAnchor bool
+
+	// FilterOptions, if provided, represent the specifications for the filtering to be executed.
+	FilterOptions *FilteringOptions
 }
+
+// FilteringOptions represent the storage level specifications for the filtering to be executed.
+// Operation below refers to the filter function being applied (eg: "latest"), Field refers to the position of the graph clause it
+// will be applied to ("subject", "predicate" or "object") and Value, when specified, contains the second argument of the filter
+// function (not applicable for all Operations - some like "latest" do not use it while others like "greaterThan" do, see Issue 129).
+type FilteringOptions struct{ Operation, Field, Value string }
 
 // String returns a readable version of the LookupOptions instance.
 func (l *LookupOptions) String() string {


### PR DESCRIPTION
This PR comes as a part of #129, finishing to set up a `FILTER` keyword in BadWolf at the planner and memory levels. The first `FILTER` function chosen to be implemented is the `latest` one, solving what was requested by #86.

It would be very useful to have in BQL a `FILTER` keyword that could allow us to filter out part of the results of a query in a level closer to the storage (closer to the driver), improving performance. This is exactly what this PR finishes introducing, completing what started with the PR #149. This PR also showcases the full implementation of how this keyword could work on the driver/storage side as well (exemplified with the changes added to the volatile open-source driver in `memory.go` below).

Then, now the user can specify, inside of `WHERE`, which bindings they want to apply a `FILTER` to, proceeding with a more fine-grained lookup on storage, avoiding unnecessary retrieval of data and optimizing query performance.

To illustrate, queries such as the one below are now possible:

```
SELECT ?s, ?p, ?o
FROM ?test
WHERE {
    ?s ?p ?o .
    FILTER latest(?p)
};
```

That would return all the temporal triples of the `?test` graph that have the latest timestamp of the time series they are part of (a recorrent use case in BadWolf), skipping immutable triples found along the way. This FILTER function also works for objects `?o` in the case of reification/blank nodes: in this case the returned triples would be the ones on which the object is necessarily a temporal predicate with latest timestamp among the predicates with that same predicate ID (in the "object" position of the clause), analogously to what happened with `?p`.

This `FILTER` for `latest` anchor above also works for alias bindings obtained with the `AS` keyword for predicates and objects too.

At the moment only one `FILTER` is supported for each graph clause inside of `WHERE`, and only one `FILTER` is supported for each given binding as well.

In the future, to add a new `FILTER` function, the steps to follow are:

1. Add a new enum item in the list of supported filter Operations in `filter.go`;
2. Add a new entry in the `SupportedOperations` map in `filter.go` to map the **lowercase** string of the `FILTER` function being added to its correspondent `filter.Operation` element;
3. Update the `String` method of `Operation` in `filter.go`;
4. Add a new switch case inside `compatibleBindingsInClauseForFilterOperation` in `planner.go` to specify for which fields and bindings of a clause the newly added `filter.Operation` can be applied to;
5. Implement the appropriate behavior on the driver side.