### PR TITLE
Structure tracer and make it more easily extendible

### DIFF
--- a/bql/planner/data_access.go
+++ b/bql/planner/data_access.go
@@ -130,8 +130,10 @@ func simpleFetch(ctx context.Context, gs []storage.Graph, cls *semantic.GraphCla
 		if err != nil {
 			return nil, err
 		}
-		tracer.Trace(w, func() []string {
-			return []string{fmt.Sprintf("g.Exist(%v, %v)", t, lo)}
+		tracer.Trace(w, func() *tracer.Arguments {
+			return &tracer.Arguments{
+				Msgs: []string{fmt.Sprintf("g.Exist(%v, %v)", t, lo)},
+			}
 		})
 		for _, g := range gs {
 			b, err := g.Exist(ctx, t)
@@ -158,8 +160,10 @@ func simpleFetch(ctx context.Context, gs []storage.Graph, cls *semantic.GraphCla
 				lErr error
 				wg   sync.WaitGroup
 			)
-			tracer.Trace(w, func() []string {
-				return []string{fmt.Sprintf("g.Objects(%v, %v, %v)", s, p, lo)}
+			tracer.Trace(w, func() *tracer.Arguments {
+				return &tracer.Arguments{
+					Msgs: []string{fmt.Sprintf("g.Objects(%v, %v, %v)", s, p, lo)},
+				}
 			})
 			wg.Add(2)
 			os := make(chan *triple.Object, chanSize)
@@ -207,8 +211,10 @@ func simpleFetch(ctx context.Context, gs []storage.Graph, cls *semantic.GraphCla
 				lErr error
 				wg   sync.WaitGroup
 			)
-			tracer.Trace(w, func() []string {
-				return []string{fmt.Sprintf("g.PredicatesForSubjectAndObject(%v, %v, %v)", s, o, lo)}
+			tracer.Trace(w, func() *tracer.Arguments {
+				return &tracer.Arguments{
+					Msgs: []string{fmt.Sprintf("g.PredicatesForSubjectAndObject(%v, %v, %v)", s, o, lo)},
+				}
 			})
 			wg.Add(2)
 			ps := make(chan *predicate.Predicate, chanSize)
@@ -256,8 +262,10 @@ func simpleFetch(ctx context.Context, gs []storage.Graph, cls *semantic.GraphCla
 				lErr error
 				wg   sync.WaitGroup
 			)
-			tracer.Trace(w, func() []string {
-				return []string{fmt.Sprintf("g.Subjects(%v, %v, %v)", p, o, lo)}
+			tracer.Trace(w, func() *tracer.Arguments {
+				return &tracer.Arguments{
+					Msgs: []string{fmt.Sprintf("g.Subjects(%v, %v, %v)", p, o, lo)},
+				}
 			})
 			wg.Add(2)
 			ss := make(chan *node.Node, chanSize)
@@ -304,8 +312,10 @@ func simpleFetch(ctx context.Context, gs []storage.Graph, cls *semantic.GraphCla
 				aErr error
 				wg   sync.WaitGroup
 			)
-			tracer.Trace(w, func() []string {
-				return []string{fmt.Sprintf("g.TriplesForSubject(%v, %v)", s, lo)}
+			tracer.Trace(w, func() *tracer.Arguments {
+				return &tracer.Arguments{
+					Msgs: []string{fmt.Sprintf("g.TriplesForSubject(%v, %v)", s, lo)},
+				}
 			})
 			ts := make(chan *triple.Triple, chanSize)
 			wg.Add(1)
@@ -332,8 +342,10 @@ func simpleFetch(ctx context.Context, gs []storage.Graph, cls *semantic.GraphCla
 				aErr error
 				wg   sync.WaitGroup
 			)
-			tracer.Trace(w, func() []string {
-				return []string{fmt.Sprintf("g.TriplesForPredicate(%v, %v)", p, lo)}
+			tracer.Trace(w, func() *tracer.Arguments {
+				return &tracer.Arguments{
+					Msgs: []string{fmt.Sprintf("g.TriplesForPredicate(%v, %v)", p, lo)},
+				}
 			})
 			ts := make(chan *triple.Triple, chanSize)
 			wg.Add(1)
@@ -359,8 +371,10 @@ func simpleFetch(ctx context.Context, gs []storage.Graph, cls *semantic.GraphCla
 				tErr error
 				wg   sync.WaitGroup
 			)
-			tracer.Trace(w, func() []string {
-				return []string{fmt.Sprintf("g.TriplesForObject(%v, %v)", o, lo)}
+			tracer.Trace(w, func() *tracer.Arguments {
+				return &tracer.Arguments{
+					Msgs: []string{fmt.Sprintf("g.TriplesForObject(%v, %v)", o, lo)},
+				}
 			})
 			ts := make(chan *triple.Triple, chanSize)
 			wg.Add(1)
@@ -387,8 +401,10 @@ func simpleFetch(ctx context.Context, gs []storage.Graph, cls *semantic.GraphCla
 				aErr error
 				wg   sync.WaitGroup
 			)
-			tracer.Trace(w, func() []string {
-				return []string{fmt.Sprintf("g.Triples(%v)", lo)}
+			tracer.Trace(w, func() *tracer.Arguments {
+				return &tracer.Arguments{
+					Msgs: []string{fmt.Sprintf("g.Triples(%v)", lo)},
+				}
 			})
 			ts := make(chan *triple.Triple, chanSize)
 			wg.Add(1)

--- a/bql/planner/tracer/trace.go
+++ b/bql/planner/tracer/trace.go
@@ -40,7 +40,7 @@ func init() {
 		for e := range c {
 			for _, msg := range e.tracerArgs().Msgs {
 				e.w.Write([]byte("["))
-				e.w.Write([]byte(e.t.Format("2006-01-02T15:04:05.999999-07:00")))
+				e.w.Write([]byte(e.t.Format(time.RFC3339Nano)))
 				e.w.Write([]byte("] "))
 				e.w.Write([]byte(msg))
 				e.w.Write([]byte("\n"))

--- a/bql/planner/tracer/trace.go
+++ b/bql/planner/tracer/trace.go
@@ -20,10 +20,15 @@ import (
 	"time"
 )
 
+// Arguments encapsulates the elements passed to the tracer.
+type Arguments struct {
+	Msgs []string
+}
+
 type event struct {
-	w    io.Writer
-	t    time.Time
-	msgs func() []string
+	w          io.Writer
+	t          time.Time
+	tracerArgs func() *Arguments
 }
 
 var c chan *event
@@ -33,7 +38,7 @@ func init() {
 
 	go func() {
 		for e := range c {
-			for _, msg := range e.msgs() {
+			for _, msg := range e.tracerArgs().Msgs {
 				e.w.Write([]byte("["))
 				e.w.Write([]byte(e.t.Format("2006-01-02T15:04:05.999999-07:00")))
 				e.w.Write([]byte("] "))
@@ -45,11 +50,11 @@ func init() {
 }
 
 // Trace attempts to write a trace if a valid writer is provided. The
-// tracer is lazy on the string generation to avoid adding too much
-// overhead when tracing ins not on.
-func Trace(w io.Writer, msgs func() []string) {
+// tracer is lazy on the arguments generation to avoid adding too much
+// overhead when tracing is not on.
+func Trace(w io.Writer, tracerArgs func() *Arguments) {
 	if w == nil {
 		return
 	}
-	c <- &event{w, time.Now(), msgs}
+	c <- &event{w, time.Now(), tracerArgs}
 }


### PR DESCRIPTION
This PR comes mainly to structure the current tracer to make it lazily receive, instead of a limited slice of strings, a more flexible struct `tracer.Arguments`. This way it will be much easier in the future to extend it, adding more fields to be passed to the tracer inside the struct, without the need of changing all the other calls for `tracer.Trace` in code.

To illustrate:

```
// Old:
tracer.Trace(p.tracer, func() []string {
	return []string{fmt.Sprintf("Processing clause %d: %v", i, &cls)}
})

// Now:
tracer.Trace(p.tracer, func() *tracer.Arguments {
	return &tracer.Arguments {
		msgs: []string{fmt.Sprintf("Processing clause %d: %v", i, &cls)}
	}
})
```

It was deliberately decided to keep the lazy aspect of tracing here, keeping a lambda function as the second parameter for `tracer.Trace` above, as a way of avoiding the addition of too much overhead when tracing is not on.