### PR TITLE
FILTER isImmutable

### DIFF
--- a/bql/planner/filter/filter.go
+++ b/bql/planner/filter/filter.go
@@ -25,6 +25,7 @@ type Operation int
 // List of supported filter operations.
 const (
 	Latest Operation = iota + 1
+	IsImmutable
 )
 
 // Field represents the position of the semantic.GraphClause that will be operated by the filter at storage level.
@@ -40,7 +41,8 @@ const (
 // SupportedOperations maps suported filter operation strings to their correspondant Operation.
 // Note that the string keys here must be in lowercase letters only (for compatibility with the WhereFilterClauseHook).
 var SupportedOperations = map[string]Operation{
-	"latest": Latest,
+	"latest":      Latest,
+	"isimmutable": IsImmutable,
 }
 
 // StorageOptions represent the storage level specifications for the filtering to be executed.
@@ -58,6 +60,8 @@ func (op Operation) String() string {
 	switch op {
 	case Latest:
 		return "latest"
+	case IsImmutable:
+		return "isImmutable"
 	default:
 		return fmt.Sprintf(`not defined filter operation "%d"`, op)
 	}

--- a/bql/planner/planner.go
+++ b/bql/planner/planner.go
@@ -668,6 +668,15 @@ func compatibleBindingsInClauseForFilterOperation(operation filter.Operation) (c
 			return bindingsByField
 		}
 		return compatibleBindingsInClause, nil
+	case filter.IsImmutable:
+		compatibleBindingsInClause = func(cls *semantic.GraphClause) (bindingsByField map[filter.Field]map[string]bool) {
+			bindingsByField = map[filter.Field]map[string]bool{
+				filter.PredicateField: {cls.PBinding: true, cls.PAlias: true},
+				filter.ObjectField:    {cls.OBinding: true, cls.OAlias: true},
+			}
+			return bindingsByField
+		}
+		return compatibleBindingsInClause, nil
 	default:
 		return nil, fmt.Errorf("filter function %q has no bindings in clause specified for it (planner level)", operation)
 	}

--- a/bql/planner/planner_test.go
+++ b/bql/planner/planner_test.go
@@ -1107,6 +1107,46 @@ func TestPlannerQuery(t *testing.T) {
 			nBindings: 2,
 			nRows:     1,
 		},
+		{
+			q: `SELECT ?p, ?o
+				FROM ?test
+				WHERE {
+					/u<peter> ?p ?o .
+					FILTER isImmutable(?p)
+				};`,
+			nBindings: 2,
+			nRows:     2,
+		},
+		{
+			q: `SELECT ?s, ?p, ?o
+				FROM ?test
+				WHERE {
+					?s ?p ?o .
+					FILTER isImmutable(?o)
+				};`,
+			nBindings: 3,
+			nRows:     1,
+		},
+		{
+			q: `SELECT ?p_alias, ?o
+				FROM ?test
+				WHERE {
+					/u<peter> ?p AS ?p_alias ?o .
+					FILTER isImmutable(?p_alias)
+				};`,
+			nBindings: 2,
+			nRows:     2,
+		},
+		{
+			q: `SELECT ?s, ?p, ?o_alias
+				FROM ?test
+				WHERE {
+					?s ?p ?o AS ?o_alias .
+					FILTER isImmutable(?o_alias)
+				};`,
+			nBindings: 3,
+			nRows:     1,
+		},
 	}
 
 	s, ctx := memory.NewStore(), context.Background()

--- a/storage/memory/memory_test.go
+++ b/storage/memory/memory_test.go
@@ -352,6 +352,20 @@ func TestObjectsFilter(t *testing.T) {
 			p:    testutil.MustBuildPredicate(t, `"_predicate"@[]`),
 			want: map[string]int{`"meet"@[2021-04-10T04:21:00Z]`: 1},
 		},
+		{
+			id:   "FILTER isImmutable predicate",
+			lo:   &storage.LookupOptions{FilterOptions: &filter.StorageOptions{Operation: filter.IsImmutable, Field: filter.PredicateField}},
+			s:    testutil.MustBuildNodeFromStrings(t, "/u", "john"),
+			p:    testutil.MustBuildPredicate(t, `"parent_of"@[]`),
+			want: map[string]int{"/u<paul>": 1},
+		},
+		{
+			id:   "FILTER isImmutable object",
+			lo:   &storage.LookupOptions{FilterOptions: &filter.StorageOptions{Operation: filter.IsImmutable, Field: filter.ObjectField}},
+			s:    testutil.MustBuildNodeFromStrings(t, "/_", "bn"),
+			p:    testutil.MustBuildPredicate(t, `"_predicate"@[]`),
+			want: map[string]int{`"height_cm"@[]`: 1},
+		},
 	}
 
 	for _, entry := range testTable {
@@ -470,6 +484,20 @@ func TestSubjectsFilter(t *testing.T) {
 			o:    triple.NewPredicateObject(testutil.MustBuildPredicate(t, `"meet"@[2020-04-10T04:21:00Z]`)),
 			want: map[string]int{"/_<bn>": 1},
 		},
+		{
+			id:   "FILTER isImmutable predicate",
+			lo:   &storage.LookupOptions{FilterOptions: &filter.StorageOptions{Operation: filter.IsImmutable, Field: filter.PredicateField}},
+			p:    testutil.MustBuildPredicate(t, `"parent_of"@[]`),
+			o:    triple.NewNodeObject(testutil.MustBuildNodeFromStrings(t, "/u", "paul")),
+			want: map[string]int{"/u<john>": 1},
+		},
+		{
+			id:   "FILTER isImmutable object",
+			lo:   &storage.LookupOptions{FilterOptions: &filter.StorageOptions{Operation: filter.IsImmutable, Field: filter.ObjectField}},
+			p:    testutil.MustBuildPredicate(t, `"_predicate"@[]`),
+			o:    triple.NewPredicateObject(testutil.MustBuildPredicate(t, `"height_cm"@[]`)),
+			want: map[string]int{"/_<bn>": 1},
+		},
 	}
 
 	for _, entry := range testTable {
@@ -579,6 +607,20 @@ func TestPredicatesForSubjectAndObjectFilter(t *testing.T) {
 			o:    triple.NewPredicateObject(testutil.MustBuildPredicate(t, `"meet"@[2020-04-10T04:21:00Z]`)),
 			want: map[string]int{`"_predicate"@[]`: 1},
 		},
+		{
+			id:   "FILTER isImmutable predicate",
+			lo:   &storage.LookupOptions{FilterOptions: &filter.StorageOptions{Operation: filter.IsImmutable, Field: filter.PredicateField}},
+			s:    testutil.MustBuildNodeFromStrings(t, "/u", "john"),
+			o:    triple.NewNodeObject(testutil.MustBuildNodeFromStrings(t, "/u", "bob")),
+			want: map[string]int{},
+		},
+		{
+			id:   "FILTER isImmutable object",
+			lo:   &storage.LookupOptions{FilterOptions: &filter.StorageOptions{Operation: filter.IsImmutable, Field: filter.ObjectField}},
+			s:    testutil.MustBuildNodeFromStrings(t, "/_", "bn"),
+			o:    triple.NewPredicateObject(testutil.MustBuildPredicate(t, `"meet"@[2020-04-10T04:21:00Z]`)),
+			want: map[string]int{},
+		},
 	}
 
 	for _, entry := range testTable {
@@ -682,6 +724,18 @@ func TestPredicatesForSubjectFilter(t *testing.T) {
 		{
 			id:   "FILTER latest object",
 			lo:   &storage.LookupOptions{FilterOptions: &filter.StorageOptions{Operation: filter.Latest, Field: filter.ObjectField}},
+			s:    testutil.MustBuildNodeFromStrings(t, "/_", "bn"),
+			want: map[string]int{`"_predicate"@[]`: 1},
+		},
+		{
+			id:   "FILTER isImmutable predicate",
+			lo:   &storage.LookupOptions{FilterOptions: &filter.StorageOptions{Operation: filter.IsImmutable, Field: filter.PredicateField}},
+			s:    testutil.MustBuildNodeFromStrings(t, "/u", "john"),
+			want: map[string]int{`"parent_of"@[]`: 1},
+		},
+		{
+			id:   "FILTER isImmutable object",
+			lo:   &storage.LookupOptions{FilterOptions: &filter.StorageOptions{Operation: filter.IsImmutable, Field: filter.ObjectField}},
 			s:    testutil.MustBuildNodeFromStrings(t, "/_", "bn"),
 			want: map[string]int{`"_predicate"@[]`: 1},
 		},
@@ -790,6 +844,18 @@ func TestPredicatesForObjectFilter(t *testing.T) {
 			o:    triple.NewPredicateObject(testutil.MustBuildPredicate(t, `"meet"@[2020-04-10T04:21:00Z]`)),
 			want: map[string]int{`"_predicate"@[]`: 1},
 		},
+		{
+			id:   "FILTER isImmutable predicate",
+			lo:   &storage.LookupOptions{FilterOptions: &filter.StorageOptions{Operation: filter.IsImmutable, Field: filter.PredicateField}},
+			o:    triple.NewNodeObject(testutil.MustBuildNodeFromStrings(t, "/u", "paul")),
+			want: map[string]int{`"parent_of"@[]`: 1},
+		},
+		{
+			id:   "FILTER isImmutable object",
+			lo:   &storage.LookupOptions{FilterOptions: &filter.StorageOptions{Operation: filter.IsImmutable, Field: filter.ObjectField}},
+			o:    triple.NewPredicateObject(testutil.MustBuildPredicate(t, `"height_cm"@[]`)),
+			want: map[string]int{`"_predicate"@[]`: 1},
+		},
 	}
 
 	for _, entry := range testTable {
@@ -891,6 +957,18 @@ func TestTriplesForSubjectFilter(t *testing.T) {
 			lo: &storage.LookupOptions{FilterOptions: &filter.StorageOptions{Operation: filter.Latest, Field: filter.ObjectField}},
 			s:  testutil.MustBuildNodeFromStrings(t, "/_", "bn"),
 			want: map[string]int{`/_<bn>	"_predicate"@[]	"meet"@[2021-04-10T04:21:00Z]`: 1},
+		},
+		{
+			id: "FILTER isImmutable predicate",
+			lo: &storage.LookupOptions{FilterOptions: &filter.StorageOptions{Operation: filter.IsImmutable, Field: filter.PredicateField}},
+			s:  testutil.MustBuildNodeFromStrings(t, "/u", "john"),
+			want: map[string]int{`/u<john>	"parent_of"@[]	/u<paul>`: 1},
+		},
+		{
+			id: "FILTER isImmutable object",
+			lo: &storage.LookupOptions{FilterOptions: &filter.StorageOptions{Operation: filter.IsImmutable, Field: filter.ObjectField}},
+			s:  testutil.MustBuildNodeFromStrings(t, "/_", "bn"),
+			want: map[string]int{`/_<bn>	"_predicate"@[]	"height_cm"@[]`: 1},
 		},
 	}
 
@@ -1000,6 +1078,18 @@ func TestTriplesForPredicateFilter(t *testing.T) {
 			p:  testutil.MustBuildPredicate(t, `"_predicate"@[]`),
 			want: map[string]int{`/_<bn>	"_predicate"@[]	"meet"@[2021-04-10T04:21:00Z]`: 1},
 		},
+		{
+			id:   "FILTER isImmutable predicate",
+			lo:   &storage.LookupOptions{FilterOptions: &filter.StorageOptions{Operation: filter.IsImmutable, Field: filter.PredicateField}},
+			p:    testutil.MustBuildPredicate(t, `"meet"@[2014-04-10T04:21:00Z]`),
+			want: map[string]int{},
+		},
+		{
+			id: "FILTER isImmutable object",
+			lo: &storage.LookupOptions{FilterOptions: &filter.StorageOptions{Operation: filter.IsImmutable, Field: filter.ObjectField}},
+			p:  testutil.MustBuildPredicate(t, `"_predicate"@[]`),
+			want: map[string]int{`/_<bn>	"_predicate"@[]	"height_cm"@[]`: 1},
+		},
 	}
 
 	for _, entry := range testTable {
@@ -1101,6 +1191,18 @@ func TestTriplesForObjectFilter(t *testing.T) {
 			lo: &storage.LookupOptions{FilterOptions: &filter.StorageOptions{Operation: filter.Latest, Field: filter.ObjectField}},
 			o:  triple.NewPredicateObject(testutil.MustBuildPredicate(t, `"meet"@[2020-04-10T04:21:00Z]`)),
 			want: map[string]int{`/_<bn>	"_predicate"@[]	"meet"@[2020-04-10T04:21:00Z]`: 1},
+		},
+		{
+			id:   "FILTER isImmutable predicate",
+			lo:   &storage.LookupOptions{FilterOptions: &filter.StorageOptions{Operation: filter.IsImmutable, Field: filter.PredicateField}},
+			o:    triple.NewNodeObject(testutil.MustBuildNodeFromStrings(t, "/u", "bob")),
+			want: map[string]int{},
+		},
+		{
+			id: "FILTER isImmutable object",
+			lo: &storage.LookupOptions{FilterOptions: &filter.StorageOptions{Operation: filter.IsImmutable, Field: filter.ObjectField}},
+			o:  triple.NewPredicateObject(testutil.MustBuildPredicate(t, `"height_cm"@[]`)),
+			want: map[string]int{`/_<bn>	"_predicate"@[]	"height_cm"@[]`: 1},
 		},
 	}
 
@@ -1257,6 +1359,20 @@ func TestTriplesForSubjectAndPredicateFilter(t *testing.T) {
 			p:  testutil.MustBuildPredicate(t, `"_predicate"@[]`),
 			want: map[string]int{`/_<bn>	"_predicate"@[]	"meet"@[2021-04-10T04:21:00Z]`: 1},
 		},
+		{
+			id:   "FILTER isImmutable predicate",
+			lo:   &storage.LookupOptions{FilterOptions: &filter.StorageOptions{Operation: filter.IsImmutable, Field: filter.PredicateField}},
+			s:    testutil.MustBuildNodeFromStrings(t, "/u", "john"),
+			p:    testutil.MustBuildPredicate(t, `"meet"@[2014-04-10T04:21:00Z]`),
+			want: map[string]int{},
+		},
+		{
+			id: "FILTER isImmutable object",
+			lo: &storage.LookupOptions{FilterOptions: &filter.StorageOptions{Operation: filter.IsImmutable, Field: filter.ObjectField}},
+			s:  testutil.MustBuildNodeFromStrings(t, "/_", "bn"),
+			p:  testutil.MustBuildPredicate(t, `"_predicate"@[]`),
+			want: map[string]int{`/_<bn>	"_predicate"@[]	"height_cm"@[]`: 1},
+		},
 	}
 
 	for _, entry := range testTable {
@@ -1369,6 +1485,20 @@ func TestTriplesForPredicateAndObjectFilter(t *testing.T) {
 			p:  testutil.MustBuildPredicate(t, `"_predicate"@[]`),
 			o:  triple.NewPredicateObject(testutil.MustBuildPredicate(t, `"meet"@[2020-04-10T04:21:00Z]`)),
 			want: map[string]int{`/_<bn>	"_predicate"@[]	"meet"@[2020-04-10T04:21:00Z]`: 1},
+		},
+		{
+			id: "FILTER isImmutable predicate",
+			lo: &storage.LookupOptions{FilterOptions: &filter.StorageOptions{Operation: filter.IsImmutable, Field: filter.PredicateField}},
+			p:  testutil.MustBuildPredicate(t, `"parent_of"@[]`),
+			o:  triple.NewNodeObject(testutil.MustBuildNodeFromStrings(t, "/u", "paul")),
+			want: map[string]int{`/u<john>	"parent_of"@[]	/u<paul>`: 1},
+		},
+		{
+			id:   "FILTER isImmutable object",
+			lo:   &storage.LookupOptions{FilterOptions: &filter.StorageOptions{Operation: filter.IsImmutable, Field: filter.ObjectField}},
+			p:    testutil.MustBuildPredicate(t, `"_predicate"@[]`),
+			o:    triple.NewPredicateObject(testutil.MustBuildPredicate(t, `"meet"@[2020-04-10T04:21:00Z]`)),
+			want: map[string]int{},
 		},
 	}
 
@@ -1486,6 +1616,16 @@ func TestTriplesFilter(t *testing.T) {
 			id: "FILTER latest object",
 			lo: &storage.LookupOptions{FilterOptions: &filter.StorageOptions{Operation: filter.Latest, Field: filter.ObjectField}},
 			want: map[string]int{`/_<bn>	"_predicate"@[]	"meet"@[2021-04-10T04:21:00Z]`: 1},
+		},
+		{
+			id: "FILTER isImmutable predicate",
+			lo: &storage.LookupOptions{FilterOptions: &filter.StorageOptions{Operation: filter.IsImmutable, Field: filter.PredicateField}},
+			want: map[string]int{`/u<john>	"parent_of"@[]	/u<paul>`: 1, `/_<bn>	"_predicate"@[]	"meet"@[2020-04-10T04:21:00Z]`: 1, `/_<bn>	"_predicate"@[]	"meet"@[2021-04-10T04:21:00Z]`: 1, `/_<bn>	"_predicate"@[]	"height_cm"@[]`: 1},
+		},
+		{
+			id: "FILTER isImmutable object",
+			lo: &storage.LookupOptions{FilterOptions: &filter.StorageOptions{Operation: filter.IsImmutable, Field: filter.ObjectField}},
+			want: map[string]int{`/_<bn>	"_predicate"@[]	"height_cm"@[]`: 1},
 		},
 	}
 


### PR DESCRIPTION
This PR comes to add support for the `isImmutable` FILTER function in BadWolf, as detailed in #129. It also comes to help resolving what was requested by #115.

To illustrate its implementation on the driver side, this PR also adds support for this FILTER in the volatile OSS driver (in `memory.go`).

Now, the user can write queries like: 

```
SELECT ?p, ?o
FROM ?test
WHERE {
    /u<peter> ?p ?o .
    FILTER isImmutable(?p)
};
```

That would return only rows for which the predicate `?p` is not temporal. For other examples of queries have a look at the newly added tests in `planner_test.go`.

This FILTER function also works for object bindings in the clause, along with predicate aliases and object aliases too.