### PR TITLE
FILTER isTemporal

### DIFF
--- a/bql/planner/filter/filter.go
+++ b/bql/planner/filter/filter.go
@@ -26,6 +26,7 @@ type Operation int
 const (
 	Latest Operation = iota + 1
 	IsImmutable
+	IsTemporal
 )
 
 // Field represents the position of the semantic.GraphClause that will be operated by the filter at storage level.
@@ -43,6 +44,7 @@ const (
 var SupportedOperations = map[string]Operation{
 	"latest":      Latest,
 	"isimmutable": IsImmutable,
+	"istemporal":  IsTemporal,
 }
 
 // StorageOptions represent the storage level specifications for the filtering to be executed.
@@ -62,6 +64,8 @@ func (op Operation) String() string {
 		return "latest"
 	case IsImmutable:
 		return "isImmutable"
+	case IsTemporal:
+		return "isTemporal"
 	default:
 		return fmt.Sprintf(`not defined filter operation "%d"`, op)
 	}

--- a/bql/planner/planner.go
+++ b/bql/planner/planner.go
@@ -677,6 +677,15 @@ func compatibleBindingsInClauseForFilterOperation(operation filter.Operation) (c
 			return bindingsByField
 		}
 		return compatibleBindingsInClause, nil
+	case filter.IsTemporal:
+		compatibleBindingsInClause = func(cls *semantic.GraphClause) (bindingsByField map[filter.Field]map[string]bool) {
+			bindingsByField = map[filter.Field]map[string]bool{
+				filter.PredicateField: {cls.PBinding: true, cls.PAlias: true},
+				filter.ObjectField:    {cls.OBinding: true, cls.OAlias: true},
+			}
+			return bindingsByField
+		}
+		return compatibleBindingsInClause, nil
 	default:
 		return nil, fmt.Errorf("filter function %q has no bindings in clause specified for it (planner level)", operation)
 	}

--- a/bql/planner/planner_test.go
+++ b/bql/planner/planner_test.go
@@ -1147,6 +1147,46 @@ func TestPlannerQuery(t *testing.T) {
 			nBindings: 3,
 			nRows:     1,
 		},
+		{
+			q: `SELECT ?p, ?o
+				FROM ?test
+				WHERE {
+					/u<peter> ?p ?o .
+					FILTER isTemporal(?p)
+				};`,
+			nBindings: 2,
+			nRows:     4,
+		},
+		{
+			q: `SELECT ?s, ?p, ?o
+				FROM ?test
+				WHERE {
+					?s ?p ?o .
+					FILTER isTemporal(?o)
+				};`,
+			nBindings: 3,
+			nRows:     5,
+		},
+		{
+			q: `SELECT ?p_alias, ?o
+				FROM ?test
+				WHERE {
+					/u<peter> ?p AS ?p_alias ?o .
+					FILTER isTemporal(?p_alias)
+				};`,
+			nBindings: 2,
+			nRows:     4,
+		},
+		{
+			q: `SELECT ?s, ?p, ?o_alias
+				FROM ?test
+				WHERE {
+					?s ?p ?o AS ?o_alias .
+					FILTER isTemporal(?o_alias)
+				};`,
+			nBindings: 3,
+			nRows:     5,
+		},
 	}
 
 	s, ctx := memory.NewStore(), context.Background()

--- a/storage/memory/memory_test.go
+++ b/storage/memory/memory_test.go
@@ -366,6 +366,20 @@ func TestObjectsFilter(t *testing.T) {
 			p:    testutil.MustBuildPredicate(t, `"_predicate"@[]`),
 			want: map[string]int{`"height_cm"@[]`: 1},
 		},
+		{
+			id:   "FILTER isTemporal predicate",
+			lo:   &storage.LookupOptions{FilterOptions: &filter.StorageOptions{Operation: filter.IsTemporal, Field: filter.PredicateField}},
+			s:    testutil.MustBuildNodeFromStrings(t, "/u", "john"),
+			p:    testutil.MustBuildPredicate(t, `"parent_of"@[]`),
+			want: map[string]int{},
+		},
+		{
+			id:   "FILTER isTemporal object",
+			lo:   &storage.LookupOptions{FilterOptions: &filter.StorageOptions{Operation: filter.IsTemporal, Field: filter.ObjectField}},
+			s:    testutil.MustBuildNodeFromStrings(t, "/_", "bn"),
+			p:    testutil.MustBuildPredicate(t, `"_predicate"@[]`),
+			want: map[string]int{`"meet"@[2020-04-10T04:21:00Z]`: 1, `"meet"@[2021-04-10T04:21:00Z]`: 1},
+		},
 	}
 
 	for _, entry := range testTable {
@@ -498,6 +512,20 @@ func TestSubjectsFilter(t *testing.T) {
 			o:    triple.NewPredicateObject(testutil.MustBuildPredicate(t, `"height_cm"@[]`)),
 			want: map[string]int{"/_<bn>": 1},
 		},
+		{
+			id:   "FILTER isTemporal predicate",
+			lo:   &storage.LookupOptions{FilterOptions: &filter.StorageOptions{Operation: filter.IsTemporal, Field: filter.PredicateField}},
+			p:    testutil.MustBuildPredicate(t, `"parent_of"@[]`),
+			o:    triple.NewNodeObject(testutil.MustBuildNodeFromStrings(t, "/u", "paul")),
+			want: map[string]int{},
+		},
+		{
+			id:   "FILTER isTemporal object",
+			lo:   &storage.LookupOptions{FilterOptions: &filter.StorageOptions{Operation: filter.IsTemporal, Field: filter.ObjectField}},
+			p:    testutil.MustBuildPredicate(t, `"_predicate"@[]`),
+			o:    triple.NewPredicateObject(testutil.MustBuildPredicate(t, `"height_cm"@[]`)),
+			want: map[string]int{},
+		},
 	}
 
 	for _, entry := range testTable {
@@ -621,6 +649,20 @@ func TestPredicatesForSubjectAndObjectFilter(t *testing.T) {
 			o:    triple.NewPredicateObject(testutil.MustBuildPredicate(t, `"meet"@[2020-04-10T04:21:00Z]`)),
 			want: map[string]int{},
 		},
+		{
+			id:   "FILTER isTemporal predicate",
+			lo:   &storage.LookupOptions{FilterOptions: &filter.StorageOptions{Operation: filter.IsTemporal, Field: filter.PredicateField}},
+			s:    testutil.MustBuildNodeFromStrings(t, "/u", "john"),
+			o:    triple.NewNodeObject(testutil.MustBuildNodeFromStrings(t, "/u", "bob")),
+			want: map[string]int{`"meet"@[2014-04-10T04:21:00Z]`: 1},
+		},
+		{
+			id:   "FILTER isTemporal object",
+			lo:   &storage.LookupOptions{FilterOptions: &filter.StorageOptions{Operation: filter.IsTemporal, Field: filter.ObjectField}},
+			s:    testutil.MustBuildNodeFromStrings(t, "/_", "bn"),
+			o:    triple.NewPredicateObject(testutil.MustBuildPredicate(t, `"meet"@[2020-04-10T04:21:00Z]`)),
+			want: map[string]int{`"_predicate"@[]`: 1},
+		},
 	}
 
 	for _, entry := range testTable {
@@ -739,6 +781,18 @@ func TestPredicatesForSubjectFilter(t *testing.T) {
 			s:    testutil.MustBuildNodeFromStrings(t, "/_", "bn"),
 			want: map[string]int{`"_predicate"@[]`: 1},
 		},
+		{
+			id:   "FILTER isTemporal predicate",
+			lo:   &storage.LookupOptions{FilterOptions: &filter.StorageOptions{Operation: filter.IsTemporal, Field: filter.PredicateField}},
+			s:    testutil.MustBuildNodeFromStrings(t, "/u", "john"),
+			want: map[string]int{`"meet"@[2012-04-10T04:21:00Z]`: 1, `"meet"@[2013-04-10T04:21:00Z]`: 1, `"meet"@[2014-04-10T04:21:00Z]`: 2},
+		},
+		{
+			id:   "FILTER isTemporal object",
+			lo:   &storage.LookupOptions{FilterOptions: &filter.StorageOptions{Operation: filter.IsTemporal, Field: filter.ObjectField}},
+			s:    testutil.MustBuildNodeFromStrings(t, "/_", "bn"),
+			want: map[string]int{`"_predicate"@[]`: 2},
+		},
 	}
 
 	for _, entry := range testTable {
@@ -856,6 +910,18 @@ func TestPredicatesForObjectFilter(t *testing.T) {
 			o:    triple.NewPredicateObject(testutil.MustBuildPredicate(t, `"height_cm"@[]`)),
 			want: map[string]int{`"_predicate"@[]`: 1},
 		},
+		{
+			id:   "FILTER isTemporal predicate",
+			lo:   &storage.LookupOptions{FilterOptions: &filter.StorageOptions{Operation: filter.IsTemporal, Field: filter.PredicateField}},
+			o:    triple.NewNodeObject(testutil.MustBuildNodeFromStrings(t, "/u", "bob")),
+			want: map[string]int{`"meet"@[2014-04-10T04:21:00Z]`: 1},
+		},
+		{
+			id:   "FILTER isTemporal object",
+			lo:   &storage.LookupOptions{FilterOptions: &filter.StorageOptions{Operation: filter.IsTemporal, Field: filter.ObjectField}},
+			o:    triple.NewPredicateObject(testutil.MustBuildPredicate(t, `"meet"@[2020-04-10T04:21:00Z]`)),
+			want: map[string]int{`"_predicate"@[]`: 1},
+		},
 	}
 
 	for _, entry := range testTable {
@@ -969,6 +1035,18 @@ func TestTriplesForSubjectFilter(t *testing.T) {
 			lo: &storage.LookupOptions{FilterOptions: &filter.StorageOptions{Operation: filter.IsImmutable, Field: filter.ObjectField}},
 			s:  testutil.MustBuildNodeFromStrings(t, "/_", "bn"),
 			want: map[string]int{`/_<bn>	"_predicate"@[]	"height_cm"@[]`: 1},
+		},
+		{
+			id: "FILTER isTemporal predicate",
+			lo: &storage.LookupOptions{FilterOptions: &filter.StorageOptions{Operation: filter.IsTemporal, Field: filter.PredicateField}},
+			s:  testutil.MustBuildNodeFromStrings(t, "/u", "john"),
+			want: map[string]int{`/u<john>	"meet"@[2012-04-10T04:21:00Z]	/u<mary>`: 1, `/u<john>	"meet"@[2013-04-10T04:21:00Z]	/u<mary>`: 1, `/u<john>	"meet"@[2014-04-10T04:21:00Z]	/u<mary>`: 1, `/u<john>	"meet"@[2014-04-10T04:21:00Z]	/u<bob>`: 1},
+		},
+		{
+			id: "FILTER isTemporal object",
+			lo: &storage.LookupOptions{FilterOptions: &filter.StorageOptions{Operation: filter.IsTemporal, Field: filter.ObjectField}},
+			s:  testutil.MustBuildNodeFromStrings(t, "/_", "bn"),
+			want: map[string]int{`/_<bn>	"_predicate"@[]	"meet"@[2020-04-10T04:21:00Z]`: 1, `/_<bn>	"_predicate"@[]	"meet"@[2021-04-10T04:21:00Z]`: 1},
 		},
 	}
 
@@ -1090,6 +1168,18 @@ func TestTriplesForPredicateFilter(t *testing.T) {
 			p:  testutil.MustBuildPredicate(t, `"_predicate"@[]`),
 			want: map[string]int{`/_<bn>	"_predicate"@[]	"height_cm"@[]`: 1},
 		},
+		{
+			id: "FILTER isTemporal predicate",
+			lo: &storage.LookupOptions{FilterOptions: &filter.StorageOptions{Operation: filter.IsTemporal, Field: filter.PredicateField}},
+			p:  testutil.MustBuildPredicate(t, `"meet"@[2014-04-10T04:21:00Z]`),
+			want: map[string]int{`/u<john>	"meet"@[2014-04-10T04:21:00Z]	/u<mary>`: 1, `/u<john>	"meet"@[2014-04-10T04:21:00Z]	/u<bob>`: 1},
+		},
+		{
+			id: "FILTER isTemporal object",
+			lo: &storage.LookupOptions{FilterOptions: &filter.StorageOptions{Operation: filter.IsTemporal, Field: filter.ObjectField}},
+			p:  testutil.MustBuildPredicate(t, `"_predicate"@[]`),
+			want: map[string]int{`/_<bn>	"_predicate"@[]	"meet"@[2020-04-10T04:21:00Z]`: 1, `/_<bn>	"_predicate"@[]	"meet"@[2021-04-10T04:21:00Z]`: 1},
+		},
 	}
 
 	for _, entry := range testTable {
@@ -1203,6 +1293,18 @@ func TestTriplesForObjectFilter(t *testing.T) {
 			lo: &storage.LookupOptions{FilterOptions: &filter.StorageOptions{Operation: filter.IsImmutable, Field: filter.ObjectField}},
 			o:  triple.NewPredicateObject(testutil.MustBuildPredicate(t, `"height_cm"@[]`)),
 			want: map[string]int{`/_<bn>	"_predicate"@[]	"height_cm"@[]`: 1},
+		},
+		{
+			id: "FILTER isTemporal predicate",
+			lo: &storage.LookupOptions{FilterOptions: &filter.StorageOptions{Operation: filter.IsTemporal, Field: filter.PredicateField}},
+			o:  triple.NewNodeObject(testutil.MustBuildNodeFromStrings(t, "/u", "bob")),
+			want: map[string]int{`/u<john>	"meet"@[2014-04-10T04:21:00Z]	/u<bob>`: 1},
+		},
+		{
+			id:   "FILTER isTemporal object",
+			lo:   &storage.LookupOptions{FilterOptions: &filter.StorageOptions{Operation: filter.IsTemporal, Field: filter.ObjectField}},
+			o:    triple.NewPredicateObject(testutil.MustBuildPredicate(t, `"height_cm"@[]`)),
+			want: map[string]int{},
 		},
 	}
 
@@ -1373,6 +1475,20 @@ func TestTriplesForSubjectAndPredicateFilter(t *testing.T) {
 			p:  testutil.MustBuildPredicate(t, `"_predicate"@[]`),
 			want: map[string]int{`/_<bn>	"_predicate"@[]	"height_cm"@[]`: 1},
 		},
+		{
+			id: "FILTER isTemporal predicate",
+			lo: &storage.LookupOptions{FilterOptions: &filter.StorageOptions{Operation: filter.IsTemporal, Field: filter.PredicateField}},
+			s:  testutil.MustBuildNodeFromStrings(t, "/u", "john"),
+			p:  testutil.MustBuildPredicate(t, `"meet"@[2014-04-10T04:21:00Z]`),
+			want: map[string]int{`/u<john>	"meet"@[2014-04-10T04:21:00Z]	/u<mary>`: 1, `/u<john>	"meet"@[2014-04-10T04:21:00Z]	/u<bob>`: 1},
+		},
+		{
+			id: "FILTER isTemporal object",
+			lo: &storage.LookupOptions{FilterOptions: &filter.StorageOptions{Operation: filter.IsTemporal, Field: filter.ObjectField}},
+			s:  testutil.MustBuildNodeFromStrings(t, "/_", "bn"),
+			p:  testutil.MustBuildPredicate(t, `"_predicate"@[]`),
+			want: map[string]int{`/_<bn>	"_predicate"@[]	"meet"@[2020-04-10T04:21:00Z]`: 1, `/_<bn>	"_predicate"@[]	"meet"@[2021-04-10T04:21:00Z]`: 1},
+		},
 	}
 
 	for _, entry := range testTable {
@@ -1498,6 +1614,20 @@ func TestTriplesForPredicateAndObjectFilter(t *testing.T) {
 			lo:   &storage.LookupOptions{FilterOptions: &filter.StorageOptions{Operation: filter.IsImmutable, Field: filter.ObjectField}},
 			p:    testutil.MustBuildPredicate(t, `"_predicate"@[]`),
 			o:    triple.NewPredicateObject(testutil.MustBuildPredicate(t, `"meet"@[2020-04-10T04:21:00Z]`)),
+			want: map[string]int{},
+		},
+		{
+			id: "FILTER isTemporal predicate",
+			lo: &storage.LookupOptions{FilterOptions: &filter.StorageOptions{Operation: filter.IsTemporal, Field: filter.PredicateField}},
+			p:  testutil.MustBuildPredicate(t, `"meet"@[2014-04-10T04:21:00Z]`),
+			o:  triple.NewNodeObject(testutil.MustBuildNodeFromStrings(t, "/u", "mary")),
+			want: map[string]int{`/u<john>	"meet"@[2014-04-10T04:21:00Z]	/u<mary>`: 1},
+		},
+		{
+			id:   "FILTER isTemporal object",
+			lo:   &storage.LookupOptions{FilterOptions: &filter.StorageOptions{Operation: filter.IsTemporal, Field: filter.ObjectField}},
+			p:    testutil.MustBuildPredicate(t, `"_predicate"@[]`),
+			o:    triple.NewPredicateObject(testutil.MustBuildPredicate(t, `"height_cm"@[]`)),
 			want: map[string]int{},
 		},
 	}
@@ -1626,6 +1756,16 @@ func TestTriplesFilter(t *testing.T) {
 			id: "FILTER isImmutable object",
 			lo: &storage.LookupOptions{FilterOptions: &filter.StorageOptions{Operation: filter.IsImmutable, Field: filter.ObjectField}},
 			want: map[string]int{`/_<bn>	"_predicate"@[]	"height_cm"@[]`: 1},
+		},
+		{
+			id: "FILTER isTemporal predicate",
+			lo: &storage.LookupOptions{FilterOptions: &filter.StorageOptions{Operation: filter.IsTemporal, Field: filter.PredicateField}},
+			want: map[string]int{`/u<john>	"meet"@[2012-04-10T04:21:00Z]	/u<mary>`: 1, `/u<john>	"meet"@[2013-04-10T04:21:00Z]	/u<mary>`: 1, `/u<john>	"meet"@[2014-04-10T04:21:00Z]	/u<mary>`: 1, `/u<john>	"meet"@[2014-04-10T04:21:00Z]	/u<bob>`: 1},
+		},
+		{
+			id: "FILTER isTemporal object",
+			lo: &storage.LookupOptions{FilterOptions: &filter.StorageOptions{Operation: filter.IsTemporal, Field: filter.ObjectField}},
+			want: map[string]int{`/_<bn>	"_predicate"@[]	"meet"@[2020-04-10T04:21:00Z]`: 1, `/_<bn>	"_predicate"@[]	"meet"@[2021-04-10T04:21:00Z]`: 1},
 		},
 	}
 


### PR DESCRIPTION
This PR comes to add support for the `isTemporal` FILTER function in BadWolf, as detailed in #129. It also comes to help resolving what was requested by #115.

To illustrate its implementation on the driver side, this PR also adds support for this FILTER in the volatile OSS driver (in `memory.go`).

Now, the user can write queries like: 

```
SELECT ?p, ?o
FROM ?test
WHERE {
    /u<peter> ?p ?o .
    FILTER isTemporal(?p)
};
```

That would return only rows for which the predicate `?p` is temporal. For other examples of queries have a look at the newly added tests in `planner_test.go`.

This FILTER function also works for object bindings in the clause, along with predicate aliases and object aliases too.