### PR TITLE
Support pprof profiling in BadWolf

### DIFF
--- a/tools/vcli/bw/repl/repl.go
+++ b/tools/vcli/bw/repl/repl.go
@@ -353,6 +353,9 @@ func printHelp() {
 	fmt.Println("run <file_with_bql_statements>                        - runs all the BQL statements in the file.")
 	fmt.Println("start tracing [trace_file]                            - starts tracing queries.")
 	fmt.Println("stop tracing                                          - stops tracing queries.")
+	fmt.Println("start profiling                                       - starts pprof profiling for queries.")
+	fmt.Println("start profiling -cpurate <samples_per_second>         - starts pprof profiling with customized CPU sampling rate.")
+	fmt.Println("stop profiling                                        - stops pprof profiling for queries.")
 	fmt.Println("quit                                                  - quits the console.")
 	fmt.Println()
 }

--- a/tools/vcli/bw/repl/repl.go
+++ b/tools/vcli/bw/repl/repl.go
@@ -230,13 +230,14 @@ func REPL(od storage.Store, input *os.File, rl ReadLiner, chanSize, bulkSize, bu
 			var err error
 			switch len(args) {
 			case 2:
-				if cpuProfile, memProfile, err = startProfiling(); err == nil {
-					isProfiling = true
-					fmt.Println("Profiling with pprof is on.")
-				} else {
+				cpuProfile, memProfile, err = startProfiling()
+				if err != nil {
 					fmt.Println(err)
 					fmt.Println("Profiling failed to start.")
+					break
 				}
+				isProfiling = true
+				fmt.Println("Profiling with pprof is on.")
 			case 4:
 				if args[2] != "-cpurate" {
 					fmt.Printf("Invalid syntax with %q.\n\tstart profiling -cpurate <samples_per_second>\n", args[2])
@@ -249,13 +250,14 @@ func REPL(od storage.Store, input *os.File, rl ReadLiner, chanSize, bulkSize, bu
 					break
 				}
 				runtime.SetCPUProfileRate(int(cpuProfRate))
-				if cpuProfile, memProfile, err = startProfiling(); err == nil {
-					isProfiling = true
-					fmt.Printf("Profiling with pprof is on (CPU profiling rate: %d samples per second).\n", cpuProfRate)
-				} else {
+				cpuProfile, memProfile, err = startProfiling()
+				if err != nil {
 					fmt.Println(err)
 					fmt.Println("Profiling failed to start.")
+					break
 				}
+				isProfiling = true
+				fmt.Printf("Profiling with pprof is on (CPU profiling rate: %d samples per second).\n", cpuProfRate)
 			default:
 				fmt.Println("Invalid syntax.\n\tstart profiling -cpurate <samples_per_second>")
 			}


### PR DESCRIPTION
This PR comes to allow the user to have more visibility on latency and memory metrics when using BadWolf, adding support for [pprof](https://github.com/google/pprof) profiling through BadWolf's CLI.

When in the terminal, after already entering the BadWolf's CLI with the command `bw bql`, the user can now write:

```
start profiling;
```

To start `pprof` profiling. The user can also specify the CPU profiling rate with the `-cpurate` flag below:

```
start profiling -cpurate <samples_per_second>
```

Similarly, to stop it they can just write:

```
stop profiling;
```

With profiling enabled, the metrics for latency and memory consumption for the BQLs executed will be printed into two files, `cpuprofile` and `memprofile`, that can then be consumed and visualized through the `go pprof` CLI tool. 

Commands such as `go tool pprof -http=":8081" bw cpuprofile` open in the browser an interface to visualize the CPU metrics: the user can see the graph of function calls made and the latencies involved, useful to identify bottlenecks; they can visualize the correspondent Flame Graph as well, and also an ordered list of the heaviest function calls made. Another useful command is `go tool pprof -pdf bw cpuprofile > cpuprofile.pdf` to generate pdfs from the profiling files. With `memprofile` the previous `pprof` commands work similarly.