### PR TITLE
Add support for FILTER Value at the grammar and hooks levels

### DIFF
--- a/bql/grammar/grammar.go
+++ b/bql/grammar/grammar.go
@@ -385,8 +385,20 @@ func filterClauses() []*Clause {
 				NewTokenType(lexer.ItemFilterFunction),
 				NewTokenType(lexer.ItemLPar),
 				NewTokenType(lexer.ItemBinding),
+				NewSymbol("MORE_FILTER_ARGUMENTS"),
 				NewTokenType(lexer.ItemRPar),
 				NewSymbol("MORE_FILTER_CLAUSES"),
+			},
+		},
+		{},
+	}
+}
+func moreFilterArguments() []*Clause {
+	return []*Clause{
+		{
+			Elements: []Element{
+				NewTokenType(lexer.ItemComma),
+				NewTokenType(lexer.ItemLiteral),
 			},
 		},
 		{},
@@ -1296,6 +1308,7 @@ func BQL() *Grammar {
 		"OPTIONAL_CLAUSE":                        optionalClauses(),
 		"FILTER_CLAUSES":                         filterClauses(),
 		"MORE_FILTER_CLAUSES":                    moreFilterClauses(),
+		"MORE_FILTER_ARGUMENTS":                  moreFilterArguments(),
 		"SUBJECT_EXTRACT":                        subjectExtractClauses(),
 		"SUBJECT_TYPE":                           subjectTypeClauses(),
 		"SUBJECT_ID":                             subjectIDClauses(),
@@ -1432,7 +1445,7 @@ func SemanticBQL() *Grammar {
 
 	// Filter clause hook.
 	filterSymbols := []semantic.Symbol{
-		"FILTER_CLAUSES",
+		"FILTER_CLAUSES", "MORE_FILTER_ARGUMENTS",
 	}
 	setElementHook(semanticBQL, filterSymbols, semantic.WhereFilterClauseHook(), nil)
 

--- a/bql/grammar/grammar_test.go
+++ b/bql/grammar/grammar_test.go
@@ -208,6 +208,12 @@ func TestAcceptByParse(t *testing.T) {
 			FILTER latest(?p) .
 			FILTER latest(?o)
 		 };`,
+		`select ?a
+		 from ?b
+		 where {
+			?s ?p ?o .
+			FILTER greaterThan(?o, "37"^^type:int64)
+		 };`,
 		// Test optional trailing dot after the last clause inside WHERE.
 		`select ?a
 		 from ?b
@@ -453,6 +459,18 @@ func TestRejectByParse(t *testing.T) {
 			?s ?p ?o .
 			FILTER late^st(?p)
 		 };`,
+		`select ?a
+		 from ?b
+		 where {
+			?s ?p ?o .
+			FILTER greaterThan(?o "37"^^type:int64)
+		 };`,
+		`select ?a
+		 from ?b
+		 where {
+			?s ?p ?o .
+			FILTER greaterThan(?o, /u<paul>)
+		 };`,
 		// Test invalid trailing dot use inside WHERE.
 		`select ?a
 		 from ?b
@@ -689,6 +707,13 @@ func TestRejectByParseAndSemantic(t *testing.T) {
 		 where {
 			/u<peter> ?p ?o .
 			FILTER notSupportedFilterFunction(?p)
+		 };`,
+		// Reject FILTER Value inconsistent with FILTER Operation.
+		`select ?p, ?o
+		 from ?test
+		 where {
+			/u<peter> ?p ?o .
+			FILTER latest(?p, "37"^^type:int64)
 		 };`,
 	}
 	p, err := NewParser(SemanticBQL())

--- a/bql/planner/filter/filter.go
+++ b/bql/planner/filter/filter.go
@@ -47,6 +47,9 @@ var SupportedOperations = map[string]Operation{
 	"istemporal":  IsTemporal,
 }
 
+// OperationRequiresValue keeps track of the filter Operations that require Value in the filter clause.
+var OperationRequiresValue = map[Operation]bool{}
+
 // StorageOptions represent the storage level specifications for the filtering to be executed.
 // Operation below refers to the filter function being applied (eg: Latest), Field refers to the position of the graph clause it
 // will be applied to (subject, predicate, or object) and Value, when specified, contains the second argument of the filter

--- a/bql/semantic/hooks.go
+++ b/bql/semantic/hooks.go
@@ -703,6 +703,19 @@ func addBindingToWorkingFilter(bndg string, workingFilter *FilterClause) error {
 	return nil
 }
 
+// addValueToWorkingFilter takes the given value and tries to add it to workingFilter.
+func addValueToWorkingFilter(value string, workingFilter *FilterClause) error {
+	if workingFilter == nil {
+		return fmt.Errorf("could not add value %q to nil filter clause (which is still nil probably because a call to st.ResetWorkingFilterClause was not made before start processing the first filter clause)", value)
+	}
+	if workingFilter.Value != "" {
+		return fmt.Errorf("invalid value %q on filter clause since already set to %q", value, workingFilter.Value)
+	}
+
+	workingFilter.Value = value
+	return nil
+}
+
 // validateFilterClause returns an error if the given filter clause is either invalid or incomplete.
 func validateFilterClause(f *FilterClause) error {
 	if f == nil {
@@ -738,6 +751,12 @@ func whereFilterClause() ElementHook {
 			return hook, nil
 		case lexer.ItemBinding:
 			err := addBindingToWorkingFilter(tkn.Text, st.WorkingFilter())
+			if err != nil {
+				return nil, err
+			}
+			return hook, nil
+		case lexer.ItemLiteral:
+			err := addValueToWorkingFilter(tkn.Text, st.WorkingFilter())
 			if err != nil {
 				return nil, err
 			}

--- a/bql/semantic/hooks.go
+++ b/bql/semantic/hooks.go
@@ -727,6 +727,12 @@ func validateFilterClause(f *FilterClause) error {
 	if f.Binding == "" {
 		return fmt.Errorf("filter clause Binding is missing")
 	}
+	if f.Value == "" && filter.OperationRequiresValue[f.Operation] {
+		return fmt.Errorf("filter clause Value is required for filter Operation %q", f.Operation)
+	}
+	if f.Value != "" && !filter.OperationRequiresValue[f.Operation] {
+		return fmt.Errorf("filter clause Value is inconsistent with filter Operation %q", f.Operation)
+	}
 
 	return nil
 }

--- a/bql/semantic/hooks.go
+++ b/bql/semantic/hooks.go
@@ -731,7 +731,7 @@ func validateFilterClause(f *FilterClause) error {
 		return fmt.Errorf("filter clause Value is required for filter Operation %q", f.Operation)
 	}
 	if f.Value != "" && !filter.OperationRequiresValue[f.Operation] {
-		return fmt.Errorf("filter clause Value is inconsistent with filter Operation %q", f.Operation)
+		return fmt.Errorf("filter clause Value is not required for filter Operation %q", f.Operation)
 	}
 
 	return nil

--- a/bql/semantic/hooks_test.go
+++ b/bql/semantic/hooks_test.go
@@ -379,6 +379,40 @@ func TestWhereFilterClauseHookError(t *testing.T) {
 			},
 			ceIndexError: 5,
 		},
+		{
+			id: `FILTER latest(?p, "37"^^type:int64)`,
+			ces: []ConsumedElement{
+				NewConsumedToken(&lexer.Token{
+					Type: lexer.ItemFilter,
+					Text: "FILTER",
+				}),
+				NewConsumedToken(&lexer.Token{
+					Type: lexer.ItemFilterFunction,
+					Text: "latest",
+				}),
+				NewConsumedToken(&lexer.Token{
+					Type: lexer.ItemLPar,
+					Text: "(",
+				}),
+				NewConsumedToken(&lexer.Token{
+					Type: lexer.ItemBinding,
+					Text: "?p",
+				}),
+				NewConsumedToken(&lexer.Token{
+					Type: lexer.ItemComma,
+					Text: ",",
+				}),
+				NewConsumedToken(&lexer.Token{
+					Type: lexer.ItemLiteral,
+					Text: `"37"^^type:int64)`,
+				}),
+				NewConsumedToken(&lexer.Token{
+					Type: lexer.ItemRPar,
+					Text: ")",
+				}),
+			},
+			ceIndexError: 6,
+		},
 	}
 	for _, entry := range testTable {
 		t.Run(entry.id, func(t *testing.T) {


### PR DESCRIPTION
Since there will be `FILTER` functions that require a `Value` parameter (such as `greaterThan` in the future), we must have support for a `Value` argument in the BadWolf's grammar for `FILTER` as well. But, at the same time, we must be able to differentiate these `FILTER` functions from others that do not require `Value` (such as `latest`), for a fine-grained error checking.

This PR, then, comes to implement this above, adding support for `Value` in the BadWolf's `FILTER` grammar while also checking its validity at the hooks level.

After this PR, the steps to add support for a new FILTER function become:

1. Add a new enum item in the list of supported filter Operations in `filter.go`;
2. Add a new entry in the `SupportedOperations` map in `filter.go` to map the **lowercase** string of the filter function being added to its correspondent `filter.Operation` element;
3. If this new filter function requires a `Value` parameter, add the correspondent `filter.Operation` to the `OperationRequiresValue` hash set in `filter.go`;
4. Update the `String` method of `Operation` in `filter.go`;
5. Add a new switch case inside `compatibleBindingsInClauseForFilterOperation` in `planner.go` to specify for which fields and bindings of a clause the newly added `filter.Operation` can be applied to;
6. Implement the appropriate behavior on the driver side.