### PR TITLE
Add more metadata to tracer to improve debugability

### DIFF
--- a/bql/planner/data_access.go
+++ b/bql/planner/data_access.go
@@ -91,13 +91,18 @@ func updateTimeBoundsForRow(lo *storage.LookupOptions, cls *semantic.GraphClause
 
 // simpleExist returns true if the triple exist. Return the unfeasible state,
 // the table and the error if present.
-func simpleExist(ctx context.Context, gs []storage.Graph, cls *semantic.GraphClause, t *triple.Triple) (bool, *table.Table, error) {
+func simpleExist(ctx context.Context, gs []storage.Graph, cls *semantic.GraphClause, t *triple.Triple, w io.Writer) (bool, *table.Table, error) {
 	unfeasible := true
 	tbl, err := table.New(cls.Bindings())
 	if err != nil {
 		return true, nil, err
 	}
 	for _, g := range gs {
+		tracer.Trace(w, func() *tracer.Arguments {
+			return &tracer.Arguments{
+				Msgs: []string{fmt.Sprintf("g.Exist(%v)", t)},
+			}
+		})
 		b, err := g.Exist(ctx, t)
 		if err != nil {
 			return true, nil, err
@@ -131,12 +136,12 @@ func simpleFetch(ctx context.Context, gs []storage.Graph, cls *semantic.GraphCla
 		if err != nil {
 			return nil, err
 		}
-		tracer.Trace(w, func() *tracer.Arguments {
-			return &tracer.Arguments{
-				Msgs: []string{fmt.Sprintf("g.Exist(%v, %v)", t, lo)},
-			}
-		})
 		for _, g := range gs {
+			tracer.Trace(w, func() *tracer.Arguments {
+				return &tracer.Arguments{
+					Msgs: []string{fmt.Sprintf("g.Exist(%v)", t)},
+				}
+			})
 			b, err := g.Exist(ctx, t)
 			if err != nil {
 				return nil, err

--- a/bql/planner/data_access.go
+++ b/bql/planner/data_access.go
@@ -98,9 +98,10 @@ func simpleExist(ctx context.Context, gs []storage.Graph, cls *semantic.GraphCla
 		return true, nil, err
 	}
 	for _, g := range gs {
+		gID := g.ID(ctx)
 		tracer.Trace(w, func() *tracer.Arguments {
 			return &tracer.Arguments{
-				Msgs: []string{fmt.Sprintf("g.Exist(%v)", t)},
+				Msgs: []string{fmt.Sprintf("g.Exist(%v), graph: %s", t, gID)},
 			}
 		})
 		b, err := g.Exist(ctx, t)
@@ -137,9 +138,10 @@ func simpleFetch(ctx context.Context, gs []storage.Graph, cls *semantic.GraphCla
 			return nil, err
 		}
 		for _, g := range gs {
+			gID := g.ID(ctx)
 			tracer.Trace(w, func() *tracer.Arguments {
 				return &tracer.Arguments{
-					Msgs: []string{fmt.Sprintf("g.Exist(%v)", t)},
+					Msgs: []string{fmt.Sprintf("g.Exist(%v), graph: %s", t, gID)},
 				}
 			})
 			b, err := g.Exist(ctx, t)
@@ -160,6 +162,7 @@ func simpleFetch(ctx context.Context, gs []storage.Graph, cls *semantic.GraphCla
 	if s != nil && p != nil && o == nil {
 		// SP request.
 		for _, g := range gs {
+			gID := g.ID(ctx)
 			var (
 				oErr error
 				aErr error
@@ -168,7 +171,7 @@ func simpleFetch(ctx context.Context, gs []storage.Graph, cls *semantic.GraphCla
 			)
 			tracer.Trace(w, func() *tracer.Arguments {
 				return &tracer.Arguments{
-					Msgs: []string{fmt.Sprintf("g.Objects(%v, %v, %v)", s, p, lo)},
+					Msgs: []string{fmt.Sprintf("g.Objects(%v, %v, %v), graph: %s", s, p, lo, gID)},
 				}
 			})
 			wg.Add(2)
@@ -211,6 +214,7 @@ func simpleFetch(ctx context.Context, gs []storage.Graph, cls *semantic.GraphCla
 	if s != nil && p == nil && o != nil {
 		// SO request.
 		for _, g := range gs {
+			gID := g.ID(ctx)
 			var (
 				pErr error
 				aErr error
@@ -219,7 +223,7 @@ func simpleFetch(ctx context.Context, gs []storage.Graph, cls *semantic.GraphCla
 			)
 			tracer.Trace(w, func() *tracer.Arguments {
 				return &tracer.Arguments{
-					Msgs: []string{fmt.Sprintf("g.PredicatesForSubjectAndObject(%v, %v, %v)", s, o, lo)},
+					Msgs: []string{fmt.Sprintf("g.PredicatesForSubjectAndObject(%v, %v, %v), graph: %s", s, o, lo, gID)},
 				}
 			})
 			wg.Add(2)
@@ -262,6 +266,7 @@ func simpleFetch(ctx context.Context, gs []storage.Graph, cls *semantic.GraphCla
 	if s == nil && p != nil && o != nil {
 		// PO request.
 		for _, g := range gs {
+			gID := g.ID(ctx)
 			var (
 				pErr error
 				aErr error
@@ -270,7 +275,7 @@ func simpleFetch(ctx context.Context, gs []storage.Graph, cls *semantic.GraphCla
 			)
 			tracer.Trace(w, func() *tracer.Arguments {
 				return &tracer.Arguments{
-					Msgs: []string{fmt.Sprintf("g.Subjects(%v, %v, %v)", p, o, lo)},
+					Msgs: []string{fmt.Sprintf("g.Subjects(%v, %v, %v), graph: %s", p, o, lo, gID)},
 				}
 			})
 			wg.Add(2)
@@ -313,6 +318,7 @@ func simpleFetch(ctx context.Context, gs []storage.Graph, cls *semantic.GraphCla
 	if s != nil && p == nil && o == nil {
 		// S request.
 		for _, g := range gs {
+			gID := g.ID(ctx)
 			var (
 				tErr error
 				aErr error
@@ -320,7 +326,7 @@ func simpleFetch(ctx context.Context, gs []storage.Graph, cls *semantic.GraphCla
 			)
 			tracer.Trace(w, func() *tracer.Arguments {
 				return &tracer.Arguments{
-					Msgs: []string{fmt.Sprintf("g.TriplesForSubject(%v, %v)", s, lo)},
+					Msgs: []string{fmt.Sprintf("g.TriplesForSubject(%v, %v), graph: %s", s, lo, gID)},
 				}
 			})
 			ts := make(chan *triple.Triple, chanSize)
@@ -343,6 +349,7 @@ func simpleFetch(ctx context.Context, gs []storage.Graph, cls *semantic.GraphCla
 	if s == nil && p != nil && o == nil {
 		// P request.
 		for _, g := range gs {
+			gID := g.ID(ctx)
 			var (
 				tErr error
 				aErr error
@@ -350,7 +357,7 @@ func simpleFetch(ctx context.Context, gs []storage.Graph, cls *semantic.GraphCla
 			)
 			tracer.Trace(w, func() *tracer.Arguments {
 				return &tracer.Arguments{
-					Msgs: []string{fmt.Sprintf("g.TriplesForPredicate(%v, %v)", p, lo)},
+					Msgs: []string{fmt.Sprintf("g.TriplesForPredicate(%v, %v), graph: %s", p, lo, gID)},
 				}
 			})
 			ts := make(chan *triple.Triple, chanSize)
@@ -373,13 +380,14 @@ func simpleFetch(ctx context.Context, gs []storage.Graph, cls *semantic.GraphCla
 	if s == nil && p == nil && o != nil {
 		// O request.
 		for _, g := range gs {
+			gID := g.ID(ctx)
 			var (
 				tErr error
 				wg   sync.WaitGroup
 			)
 			tracer.Trace(w, func() *tracer.Arguments {
 				return &tracer.Arguments{
-					Msgs: []string{fmt.Sprintf("g.TriplesForObject(%v, %v)", o, lo)},
+					Msgs: []string{fmt.Sprintf("g.TriplesForObject(%v, %v), graph: %s", o, lo, gID)},
 				}
 			})
 			ts := make(chan *triple.Triple, chanSize)
@@ -402,6 +410,7 @@ func simpleFetch(ctx context.Context, gs []storage.Graph, cls *semantic.GraphCla
 	if s == nil && p == nil && o == nil {
 		// Full data request.
 		for _, g := range gs {
+			gID := g.ID(ctx)
 			var (
 				tErr error
 				aErr error
@@ -409,7 +418,7 @@ func simpleFetch(ctx context.Context, gs []storage.Graph, cls *semantic.GraphCla
 			)
 			tracer.Trace(w, func() *tracer.Arguments {
 				return &tracer.Arguments{
-					Msgs: []string{fmt.Sprintf("g.Triples(%v)", lo)},
+					Msgs: []string{fmt.Sprintf("g.Triples(%v), graph: %s", lo, gID)},
 				}
 			})
 			ts := make(chan *triple.Triple, chanSize)

--- a/bql/planner/data_access_test.go
+++ b/bql/planner/data_access_test.go
@@ -228,7 +228,7 @@ func TestDataAccessAddTriples(t *testing.T) {
 	}()
 	go func() {
 		defer wg.Done()
-		if err := addTriples(ts, cls, tbl); err != nil {
+		if err := addTriples(ts, cls, tbl, nil); err != nil {
 			t.Errorf("addTriple failed with errorf %v", err)
 		}
 	}()

--- a/bql/planner/data_access_test.go
+++ b/bql/planner/data_access_test.go
@@ -156,7 +156,7 @@ func TestDataAccessFeasibleSimpleExist(t *testing.T) {
 		P: p,
 		O: o,
 	}
-	unfeasible, tbl, err := simpleExist(ctx, []storage.Graph{g}, clsOK, tt[0])
+	unfeasible, tbl, err := simpleExist(ctx, []storage.Graph{g}, clsOK, tt[0], nil)
 	if err != nil {
 		t.Errorf("simpleExist should have not failed with error %v", err)
 	}
@@ -189,7 +189,7 @@ func TestDataAccessUnfeasibleSimpleExist(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	unfeasible, tbl, err := simpleExist(ctx, []storage.Graph{g}, clsNotOK, tplNotOK)
+	unfeasible, tbl, err := simpleExist(ctx, []storage.Graph{g}, clsNotOK, tplNotOK, nil)
 	if err != nil {
 		t.Errorf("simpleExist should have not failed with error %v", err)
 	}

--- a/bql/planner/planner.go
+++ b/bql/planner/planner.go
@@ -621,13 +621,14 @@ func (p *queryPlan) filterOnExistence(ctx context.Context, cls *semantic.GraphCl
 			}
 			exist := false
 			for _, g := range p.stm.InputGraphs() {
+				gID := g.ID(gCtx)
 				t, err := triple.New(sbj, prd, obj)
 				if err != nil {
 					return err
 				}
 				tracer.Trace(p.tracer, func() *tracer.Arguments {
 					return &tracer.Arguments{
-						Msgs: []string{fmt.Sprintf("g.Exist(%v)", t)},
+						Msgs: []string{fmt.Sprintf("g.Exist(%v), graph: %s", t, gID)},
 					}
 				})
 				b, err := g.Exist(gCtx, t)

--- a/bql/planner/planner.go
+++ b/bql/planner/planner.go
@@ -325,7 +325,7 @@ func (p *queryPlan) processClause(ctx context.Context, cls *semantic.GraphClause
 		if err != nil {
 			return false, err
 		}
-		b, tbl, err := simpleExist(ctx, p.grfs, cls, t)
+		b, tbl, err := simpleExist(ctx, p.grfs, cls, t, p.tracer)
 		if err != nil {
 			return false, err
 		}
@@ -624,6 +624,11 @@ func (p *queryPlan) filterOnExistence(ctx context.Context, cls *semantic.GraphCl
 				if err != nil {
 					return err
 				}
+				tracer.Trace(p.tracer, func() *tracer.Arguments {
+					return &tracer.Arguments{
+						Msgs: []string{fmt.Sprintf("g.Exist(%v)", t)},
+					}
+				})
 				b, err := g.Exist(gCtx, t)
 				if err != nil {
 					return err

--- a/bql/table/table.go
+++ b/bql/table/table.go
@@ -964,8 +964,9 @@ func (t *Table) Reduce(cfg SortConfig, aaps []AliasAccPair) error {
 	return nil
 }
 
-// Filter removes all the rows where the provided function returns true.
-func (t *Table) Filter(f func(Row) bool) {
+// Filter removes all the rows where the provided function returns true, returning
+// by the end the final number of rows removed.
+func (t *Table) Filter(f func(Row) bool) int {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 	var newData []Row
@@ -974,7 +975,9 @@ func (t *Table) Filter(f func(Row) bool) {
 			newData = append(newData, r)
 		}
 	}
+	nRowsRemoved := len(t.Data) - len(newData)
 	t.Data = newData
+	return nRowsRemoved
 }
 
 // ToText convert the table into a readable text versions. It requires the

--- a/tools/vcli/bw/repl/repl.go
+++ b/tools/vcli/bw/repl/repl.go
@@ -427,7 +427,7 @@ func runBQL(ctx context.Context, bql string, s storage.Store, chanSize, bulkSize
 	}
 	tracer.Trace(w, func() *tracer.Arguments {
 		return &tracer.Arguments{
-			Msgs: []string{fmt.Sprintf("planner execute returned %d rows", res.NumRows())},
+			Msgs: []string{fmt.Sprintf("Executed plan returned %d rows", res.NumRows())},
 		}
 	})
 	return res, nil


### PR DESCRIPTION
This PR comes to enhance **debugability** in BadWolf, adding more useful metadata to be traced to help in the occasion of investigating production issues.

To be more precise, this PR comes mainly to add for tracing:

- More **metadata on clause processing** in the planner level (especially the **latency for processing each clause** on the graph pattern and the **overall latency for the entire pattern** as well); 

- The **number of triples returned from driver** for each driver call, along with the **specific name of the graph** being queried during this call and also the **number of rows actually being added to the result table** after that;

- The **number of rows removed from the result table** after processing the **HAVING clause**.