### PR TITLE
Support verbosity levels configuration for tracing

### DIFF
--- a/bql/planner/data_access.go
+++ b/bql/planner/data_access.go
@@ -99,7 +99,7 @@ func simpleExist(ctx context.Context, gs []storage.Graph, cls *semantic.GraphCla
 	}
 	for _, g := range gs {
 		gID := g.ID(ctx)
-		tracer.Trace(w, func() *tracer.Arguments {
+		tracer.V(2).Trace(w, func() *tracer.Arguments {
 			return &tracer.Arguments{
 				Msgs: []string{fmt.Sprintf("g.Exist(%v), graph: %s", t, gID)},
 			}
@@ -139,7 +139,7 @@ func simpleFetch(ctx context.Context, gs []storage.Graph, cls *semantic.GraphCla
 		}
 		for _, g := range gs {
 			gID := g.ID(ctx)
-			tracer.Trace(w, func() *tracer.Arguments {
+			tracer.V(2).Trace(w, func() *tracer.Arguments {
 				return &tracer.Arguments{
 					Msgs: []string{fmt.Sprintf("g.Exist(%v), graph: %s", t, gID)},
 				}
@@ -169,7 +169,7 @@ func simpleFetch(ctx context.Context, gs []storage.Graph, cls *semantic.GraphCla
 				lErr error
 				wg   sync.WaitGroup
 			)
-			tracer.Trace(w, func() *tracer.Arguments {
+			tracer.V(2).Trace(w, func() *tracer.Arguments {
 				return &tracer.Arguments{
 					Msgs: []string{fmt.Sprintf("g.Objects(%v, %v, %v), graph: %s", s, p, lo, gID)},
 				}
@@ -221,7 +221,7 @@ func simpleFetch(ctx context.Context, gs []storage.Graph, cls *semantic.GraphCla
 				lErr error
 				wg   sync.WaitGroup
 			)
-			tracer.Trace(w, func() *tracer.Arguments {
+			tracer.V(2).Trace(w, func() *tracer.Arguments {
 				return &tracer.Arguments{
 					Msgs: []string{fmt.Sprintf("g.PredicatesForSubjectAndObject(%v, %v, %v), graph: %s", s, o, lo, gID)},
 				}
@@ -273,7 +273,7 @@ func simpleFetch(ctx context.Context, gs []storage.Graph, cls *semantic.GraphCla
 				lErr error
 				wg   sync.WaitGroup
 			)
-			tracer.Trace(w, func() *tracer.Arguments {
+			tracer.V(2).Trace(w, func() *tracer.Arguments {
 				return &tracer.Arguments{
 					Msgs: []string{fmt.Sprintf("g.Subjects(%v, %v, %v), graph: %s", p, o, lo, gID)},
 				}
@@ -324,7 +324,7 @@ func simpleFetch(ctx context.Context, gs []storage.Graph, cls *semantic.GraphCla
 				aErr error
 				wg   sync.WaitGroup
 			)
-			tracer.Trace(w, func() *tracer.Arguments {
+			tracer.V(2).Trace(w, func() *tracer.Arguments {
 				return &tracer.Arguments{
 					Msgs: []string{fmt.Sprintf("g.TriplesForSubject(%v, %v), graph: %s", s, lo, gID)},
 				}
@@ -355,7 +355,7 @@ func simpleFetch(ctx context.Context, gs []storage.Graph, cls *semantic.GraphCla
 				aErr error
 				wg   sync.WaitGroup
 			)
-			tracer.Trace(w, func() *tracer.Arguments {
+			tracer.V(2).Trace(w, func() *tracer.Arguments {
 				return &tracer.Arguments{
 					Msgs: []string{fmt.Sprintf("g.TriplesForPredicate(%v, %v), graph: %s", p, lo, gID)},
 				}
@@ -385,7 +385,7 @@ func simpleFetch(ctx context.Context, gs []storage.Graph, cls *semantic.GraphCla
 				tErr error
 				wg   sync.WaitGroup
 			)
-			tracer.Trace(w, func() *tracer.Arguments {
+			tracer.V(2).Trace(w, func() *tracer.Arguments {
 				return &tracer.Arguments{
 					Msgs: []string{fmt.Sprintf("g.TriplesForObject(%v, %v), graph: %s", o, lo, gID)},
 				}
@@ -416,7 +416,7 @@ func simpleFetch(ctx context.Context, gs []storage.Graph, cls *semantic.GraphCla
 				aErr error
 				wg   sync.WaitGroup
 			)
-			tracer.Trace(w, func() *tracer.Arguments {
+			tracer.V(2).Trace(w, func() *tracer.Arguments {
 				return &tracer.Arguments{
 					Msgs: []string{fmt.Sprintf("g.Triples(%v), graph: %s", lo, gID)},
 				}
@@ -538,12 +538,12 @@ func addTriples(ts <-chan *triple.Triple, cls *semantic.GraphClause, tbl *table.
 		tbl.AddRow(r)
 		nRowsAdded++
 	}
-	tracer.Trace(w, func() *tracer.Arguments {
+	tracer.V(2).Trace(w, func() *tracer.Arguments {
 		return &tracer.Arguments{
 			Msgs: []string{fmt.Sprintf("Received %d triples from driver, in planner.addTriples", nTrpls)},
 		}
 	})
-	tracer.Trace(w, func() *tracer.Arguments {
+	tracer.V(2).Trace(w, func() *tracer.Arguments {
 		return &tracer.Arguments{
 			Msgs: []string{fmt.Sprintf("Added %d rows to table, in planner.addTriples", nRowsAdded)},
 		}

--- a/bql/planner/planner.go
+++ b/bql/planner/planner.go
@@ -73,7 +73,7 @@ func (p *createPlan) Execute(ctx context.Context) (*table.Table, error) {
 	}
 	errs := []string{}
 	for _, g := range p.stm.GraphNames() {
-		tracer.Trace(p.tracer, func() *tracer.Arguments {
+		tracer.V(2).Trace(p.tracer, func() *tracer.Arguments {
 			return &tracer.Arguments{
 				Msgs: []string{"Creating new graph \"" + g + "\""},
 			}
@@ -114,7 +114,7 @@ func (p *dropPlan) Execute(ctx context.Context) (*table.Table, error) {
 	}
 	errs := []string{}
 	for _, g := range p.stm.GraphNames() {
-		tracer.Trace(p.tracer, func() *tracer.Arguments {
+		tracer.V(2).Trace(p.tracer, func() *tracer.Arguments {
 			return &tracer.Arguments{
 				Msgs: []string{"Deleting graph \"" + g + "\""},
 			}
@@ -190,7 +190,7 @@ func (p *insertPlan) Execute(ctx context.Context) (*table.Table, error) {
 		return nil, err
 	}
 	return t, update(ctx, p.stm.Data(), p.stm.OutputGraphNames(), p.store, func(g storage.Graph, d []*triple.Triple) error {
-		tracer.Trace(p.tracer, func() *tracer.Arguments {
+		tracer.V(2).Trace(p.tracer, func() *tracer.Arguments {
 			return &tracer.Arguments{
 				Msgs: []string{"Inserting triples to graph \"" + g.ID(ctx) + "\""},
 			}
@@ -234,7 +234,7 @@ func (p *deletePlan) Execute(ctx context.Context) (*table.Table, error) {
 		return nil, err
 	}
 	return t, update(ctx, p.stm.Data(), p.stm.InputGraphNames(), p.store, func(g storage.Graph, d []*triple.Triple) error {
-		tracer.Trace(p.tracer, func() *tracer.Arguments {
+		tracer.V(2).Trace(p.tracer, func() *tracer.Arguments {
 			return &tracer.Arguments{
 				Msgs: []string{"Removing triples from graph \"" + g.ID(ctx) + "\""},
 			}
@@ -309,13 +309,13 @@ func (p *queryPlan) processClause(ctx context.Context, cls *semantic.GraphClause
 	// This method decides how to process the clause based on the current
 	// list of bindings solved and data available.
 	if cls.Specificity() == 3 {
-		tracer.Trace(p.tracer, func() *tracer.Arguments {
+		tracer.V(3).Trace(p.tracer, func() *tracer.Arguments {
 			return &tracer.Arguments{
 				Msgs: []string{"Clause is fully specified"},
 			}
 		})
 		if cls.Optional && !cls.HasAlias() {
-			tracer.Trace(p.tracer, func() *tracer.Arguments {
+			tracer.V(3).Trace(p.tracer, func() *tracer.Arguments {
 				return &tracer.Arguments{
 					Msgs: []string{fmt.Sprintf("Processing optional clause of specificity 3 %v", cls)},
 				}
@@ -347,7 +347,7 @@ func (p *queryPlan) processClause(ctx context.Context, cls *semantic.GraphClause
 	}
 
 	if exist == 0 {
-		tracer.Trace(p.tracer, func() *tracer.Arguments {
+		tracer.V(3).Trace(p.tracer, func() *tracer.Arguments {
 			return &tracer.Arguments{
 				Msgs: []string{fmt.Sprintf("None of the clause binding exist %v/%v", cls.Bindings(), existing)},
 			}
@@ -364,7 +364,7 @@ func (p *queryPlan) processClause(ctx context.Context, cls *semantic.GraphClause
 
 		if len(p.tbl.Bindings()) > 0 {
 			if cls.Optional {
-				tracer.Trace(p.tracer, func() *tracer.Arguments {
+				tracer.V(3).Trace(p.tracer, func() *tracer.Arguments {
 					return &tracer.Arguments{
 						Msgs: []string{fmt.Sprintf("Processing optional clause of disjoint bindings %v", cls)},
 					}
@@ -376,7 +376,7 @@ func (p *queryPlan) processClause(ctx context.Context, cls *semantic.GraphClause
 		return false, p.tbl.AppendTable(tbl)
 	}
 
-	tracer.Trace(p.tracer, func() *tracer.Arguments {
+	tracer.V(3).Trace(p.tracer, func() *tracer.Arguments {
 		return &tracer.Arguments{
 			Msgs: []string{fmt.Sprintf("Some clause binding exist %v/%v", cls.Bindings(), existing)},
 		}
@@ -458,7 +458,7 @@ func (p *queryPlan) addSpecifiedData(ctx context.Context, r table.Row, cls *sema
 		lo = nlo
 	}
 
-	tracer.Trace(p.tracer, func() *tracer.Arguments {
+	tracer.V(3).Trace(p.tracer, func() *tracer.Arguments {
 		return &tracer.Arguments{
 			Msgs: []string{fmt.Sprintf("Corrected clause: %v", cls)},
 		}
@@ -626,7 +626,7 @@ func (p *queryPlan) filterOnExistence(ctx context.Context, cls *semantic.GraphCl
 				if err != nil {
 					return err
 				}
-				tracer.Trace(p.tracer, func() *tracer.Arguments {
+				tracer.V(2).Trace(p.tracer, func() *tracer.Arguments {
 					return &tracer.Arguments{
 						Msgs: []string{fmt.Sprintf("g.Exist(%v), graph: %s", t, gID)},
 					}
@@ -756,7 +756,7 @@ func resetFilterOptions(lo *storage.LookupOptions) {
 // processGraphPattern process the query graph pattern to retrieve the
 // data from the specified graphs.
 func (p *queryPlan) processGraphPattern(ctx context.Context, lo *storage.LookupOptions) error {
-	tracer.Trace(p.tracer, func() *tracer.Arguments {
+	tracer.V(3).Trace(p.tracer, func() *tracer.Arguments {
 		var res []string
 		for i, cls := range p.clauses {
 			res = append(res, fmt.Sprintf("Clause %d to process: %v", i, cls))
@@ -770,7 +770,7 @@ func (p *queryPlan) processGraphPattern(ctx context.Context, lo *storage.LookupO
 	if err != nil {
 		return err
 	}
-	tracer.Trace(p.tracer, func() *tracer.Arguments {
+	tracer.V(2).Trace(p.tracer, func() *tracer.Arguments {
 		return &tracer.Arguments{
 			Msgs: []string{fmt.Sprintf("Starting to process clauses")},
 		}
@@ -778,7 +778,7 @@ func (p *queryPlan) processGraphPattern(ctx context.Context, lo *storage.LookupO
 	tStartClauses := time.Now()
 	for i, cls := range p.clauses {
 		iCopy, clsCopy := i, cls // creating local copies of the loop variables to not pass them by reference to the closure of the lazy tracer.
-		tracer.Trace(p.tracer, func() *tracer.Arguments {
+		tracer.V(2).Trace(p.tracer, func() *tracer.Arguments {
 			return &tracer.Arguments{
 				Msgs: []string{fmt.Sprintf("Starting to process clause %d: %v", iCopy, clsCopy)},
 			}
@@ -790,7 +790,7 @@ func (p *queryPlan) processGraphPattern(ctx context.Context, lo *storage.LookupO
 		resetFilterOptions(lo)
 		tElapsedCurrClause := time.Now().Sub(tStartCurrClause)
 
-		tracer.Trace(p.tracer, func() *tracer.Arguments {
+		tracer.V(2).Trace(p.tracer, func() *tracer.Arguments {
 			return &tracer.Arguments{
 				Msgs: []string{fmt.Sprintf("Finished processing clause %d: %v, latency: %v", iCopy, clsCopy, tElapsedCurrClause)},
 			}
@@ -804,7 +804,7 @@ func (p *queryPlan) processGraphPattern(ctx context.Context, lo *storage.LookupO
 		}
 	}
 	tElapsedClauses := time.Now().Sub(tStartClauses)
-	tracer.Trace(p.tracer, func() *tracer.Arguments {
+	tracer.V(2).Trace(p.tracer, func() *tracer.Arguments {
 		return &tracer.Arguments{
 			Msgs: []string{fmt.Sprintf("Finished processing all clauses, total latency: %v", tElapsedClauses)},
 		}
@@ -818,7 +818,7 @@ func (p *queryPlan) processGraphPattern(ctx context.Context, lo *storage.LookupO
 func (p *queryPlan) projectAndGroupBy() error {
 	grp := p.stm.GroupByBindings()
 	if len(grp) == 0 { // The table only needs to be projected.
-		tracer.Trace(p.tracer, func() *tracer.Arguments {
+		tracer.V(3).Trace(p.tracer, func() *tracer.Arguments {
 			return &tracer.Arguments{
 				Msgs: []string{fmt.Sprintf("Running projection for %v", grp)},
 			}
@@ -830,14 +830,14 @@ func (p *queryPlan) projectAndGroupBy() error {
 				row[prj.Alias] = row[prj.Binding]
 			}
 		}
-		tracer.Trace(p.tracer, func() *tracer.Arguments {
+		tracer.V(3).Trace(p.tracer, func() *tracer.Arguments {
 			return &tracer.Arguments{
 				Msgs: []string{fmt.Sprintf("Output bindings projected %v", p.stm.OutputBindings())},
 			}
 		})
 		return p.tbl.ProjectBindings(p.stm.OutputBindings())
 	}
-	tracer.Trace(p.tracer, func() *tracer.Arguments {
+	tracer.V(3).Trace(p.tracer, func() *tracer.Arguments {
 		return &tracer.Arguments{
 			Msgs: []string{"Starting group reduce and projection"},
 		}
@@ -850,7 +850,7 @@ func (p *queryPlan) projectAndGroupBy() error {
 	cfg := table.SortConfig{}
 	aaps := []table.AliasAccPair{}
 	for _, prj := range p.stm.Projections() {
-		tracer.Trace(p.tracer, func() *tracer.Arguments {
+		tracer.V(3).Trace(p.tracer, func() *tracer.Arguments {
 			return &tracer.Arguments{
 				Msgs: []string{"Analysing projection " + prj.String()},
 			}
@@ -900,7 +900,7 @@ func (p *queryPlan) projectAndGroupBy() error {
 		}
 		aaps = append(aaps, aap)
 	}
-	tracer.Trace(p.tracer, func() *tracer.Arguments {
+	tracer.V(3).Trace(p.tracer, func() *tracer.Arguments {
 		return &tracer.Arguments{
 			Msgs: []string{fmt.Sprintf("Projecting %v", tmpBindings)},
 		}
@@ -908,7 +908,7 @@ func (p *queryPlan) projectAndGroupBy() error {
 	if err := p.tbl.ProjectBindings(tmpBindings); err != nil {
 		return err
 	}
-	tracer.Trace(p.tracer, func() *tracer.Arguments {
+	tracer.V(3).Trace(p.tracer, func() *tracer.Arguments {
 		return &tracer.Arguments{
 			Msgs: []string{"Reducing the table using configuration " + cfg.String()},
 		}
@@ -924,7 +924,7 @@ func (p *queryPlan) orderBy() {
 	if len(order) <= 0 {
 		return
 	}
-	tracer.Trace(p.tracer, func() *tracer.Arguments {
+	tracer.V(2).Trace(p.tracer, func() *tracer.Arguments {
 		return &tracer.Arguments{
 			Msgs: []string{"Ordering by " + order.String()},
 		}
@@ -935,7 +935,7 @@ func (p *queryPlan) orderBy() {
 // having runs the filtering based on the having clause if needed.
 func (p *queryPlan) having() error {
 	if p.stm.HasHavingClause() {
-		tracer.Trace(p.tracer, func() *tracer.Arguments {
+		tracer.V(2).Trace(p.tracer, func() *tracer.Arguments {
 			return &tracer.Arguments{
 				Msgs: []string{"Starting to process HAVING clause"},
 			}
@@ -951,14 +951,14 @@ func (p *queryPlan) having() error {
 			return !b
 		})
 		if !ok {
-			tracer.Trace(p.tracer, func() *tracer.Arguments {
+			tracer.V(2).Trace(p.tracer, func() *tracer.Arguments {
 				return &tracer.Arguments{
 					Msgs: []string{eErr.Error()},
 				}
 			})
 			return eErr
 		}
-		tracer.Trace(p.tracer, func() *tracer.Arguments {
+		tracer.V(2).Trace(p.tracer, func() *tracer.Arguments {
 			return &tracer.Arguments{
 				Msgs: []string{fmt.Sprintf("Finished processing HAVING clause, %d rows were removed from table", nRowsRemoved)},
 			}
@@ -970,7 +970,7 @@ func (p *queryPlan) having() error {
 // limit truncates the table if the limit clause if available.
 func (p *queryPlan) limit() {
 	if p.stm.IsLimitSet() {
-		tracer.Trace(p.tracer, func() *tracer.Arguments {
+		tracer.V(2).Trace(p.tracer, func() *tracer.Arguments {
 			return &tracer.Arguments{
 				Msgs: []string{"Limit results to " + strconv.Itoa(int(p.stm.Limit()))},
 			}
@@ -982,7 +982,7 @@ func (p *queryPlan) limit() {
 // Execute queries the indicated graphs.
 func (p *queryPlan) Execute(ctx context.Context) (*table.Table, error) {
 	// Fetch and cache graph instances.
-	tracer.Trace(p.tracer, func() *tracer.Arguments {
+	tracer.V(3).Trace(p.tracer, func() *tracer.Arguments {
 		return &tracer.Arguments{
 			Msgs: []string{fmt.Sprintf("Caching graph instances for graphs %v", p.stm.InputGraphNames())},
 		}
@@ -993,7 +993,7 @@ func (p *queryPlan) Execute(ctx context.Context) (*table.Table, error) {
 	p.grfs = p.stm.InputGraphs()
 	// Retrieve the data.
 	lo := p.stm.GlobalLookupOptions()
-	tracer.Trace(p.tracer, func() *tracer.Arguments {
+	tracer.V(2).Trace(p.tracer, func() *tracer.Arguments {
 		return &tracer.Arguments{
 			Msgs: []string{"Setting global lookup options to " + lo.String()},
 		}
@@ -1186,7 +1186,7 @@ func (p *constructPlan) Execute(ctx context.Context) (*table.Table, error) {
 	go func() {
 		var ts []*triple.Triple
 		updateFunc := func(g storage.Graph, d []*triple.Triple) error {
-			tracer.Trace(p.tracer, func() *tracer.Arguments {
+			tracer.V(2).Trace(p.tracer, func() *tracer.Arguments {
 				return &tracer.Arguments{
 					Msgs: []string{"Removing triples from graph \"" + g.ID(ctx) + "\""},
 				}
@@ -1195,7 +1195,7 @@ func (p *constructPlan) Execute(ctx context.Context) (*table.Table, error) {
 		}
 		if p.construct {
 			updateFunc = func(g storage.Graph, d []*triple.Triple) error {
-				tracer.Trace(p.tracer, func() *tracer.Arguments {
+				tracer.V(2).Trace(p.tracer, func() *tracer.Arguments {
 					return &tracer.Arguments{
 						Msgs: []string{"Inserting triples to graph \"" + g.ID(ctx) + "\""},
 					}

--- a/bql/planner/tracer/trace.go
+++ b/bql/planner/tracer/trace.go
@@ -31,9 +31,19 @@ type event struct {
 	tracerArgs func() *Arguments
 }
 
+// MessageTracer encapsulates the intrinsic verbosity of a given tracing message.
+type MessageTracer struct {
+	verbosity int
+}
+
+// tracerVerbosity represents the global verbosity level of the current tracer. Level 1 means minimum verbosity (printing
+// only what is crucial) while level 3 means maximum verbosity (printing all available tracing messages).
+var tracerVerbosity int
+
 var c chan *event
 
 func init() {
+	tracerVerbosity = 1          // The default tracer has minimum verbosity.
 	c = make(chan *event, 10000) // Large enought to avoid blocking as much as possible.
 
 	go func() {
@@ -49,11 +59,47 @@ func init() {
 	}()
 }
 
-// Trace attempts to write a trace if a valid writer is provided. The
-// tracer is lazy on the arguments generation to avoid adding too much
-// overhead when tracing is not on.
-func Trace(w io.Writer, tracerArgs func() *Arguments) {
-	if w == nil {
+// SetVerbosity sets the global verbosity of the current tracer to the value received as
+// input, 1 meaning minimum and 3 meaning maximum verbosity. If the received value is not
+// in the interval [1, 3], then it is truncated. The function returns the actual verbosity set.
+func SetVerbosity(verbosity int) int {
+	// Truncate verbosity if out of the range supported.
+	if verbosity < 1 {
+		verbosity = 1
+	} else if verbosity > 3 {
+		verbosity = 3
+	}
+
+	tracerVerbosity = verbosity
+	return tracerVerbosity
+}
+
+// V returns a MessageTracer with the specified verbosity level. Level 1 here means that the correspondent
+// message has the highest priority and will always be printed to the tracing output, while 3 means that this message
+// has the lowest priority and will be printed to the output only if the current tracer has maximum tracerVerbosity.
+// If the received verbosity level is out of the range [1, 3] supported, then it is truncated.
+func V(verbosity int) MessageTracer {
+	// Truncate verbosity if out of the range supported.
+	if verbosity < 1 {
+		verbosity = 1
+	} else if verbosity > 3 {
+		verbosity = 3
+	}
+
+	return MessageTracer{verbosity}
+}
+
+// isTraceable returns true if the current tracer is verbose enough to let the given MessageTracer
+// indeed trace its correspondent message.
+func (t MessageTracer) isTraceable() bool {
+	return t.verbosity <= tracerVerbosity
+}
+
+// Trace attempts to write a trace if a valid writer is provided and the verbosity level
+// of the MessageTracer is coherent with the global tracer verbosity. The tracer is lazy
+// on the arguments generation to avoid adding too much overhead when tracing is not on.
+func (t MessageTracer) Trace(w io.Writer, tracerArgs func() *Arguments) {
+	if w == nil || !t.isTraceable() {
 		return
 	}
 	c <- &event{w, time.Now(), tracerArgs}

--- a/bql/planner/tracer/trace.go
+++ b/bql/planner/tracer/trace.go
@@ -44,7 +44,7 @@ var c chan *event
 
 func init() {
 	tracerVerbosity = 1          // The default tracer has minimum verbosity.
-	c = make(chan *event, 10000) // Large enought to avoid blocking as much as possible.
+	c = make(chan *event, 10000) // Large enough to avoid blocking as much as possible.
 
 	go func() {
 		for e := range c {

--- a/tools/vcli/bw/repl/repl.go
+++ b/tools/vcli/bw/repl/repl.go
@@ -369,7 +369,7 @@ func runBQLFromFile(ctx context.Context, driver storage.Store, chanSize, bulkSiz
 		return "", 0, fmt.Errorf("wrong syntax: run <file_with_bql_statements>")
 	}
 	path := ss[1]
-	tracer.Trace(w, func() *tracer.Arguments {
+	tracer.V(1).Trace(w, func() *tracer.Arguments {
 		return &tracer.Arguments{
 			Msgs: []string{fmt.Sprintf("Attempting to read file %q", path)},
 		}
@@ -377,7 +377,7 @@ func runBQLFromFile(ctx context.Context, driver storage.Store, chanSize, bulkSiz
 	lines, err := bio.GetStatementsFromFile(path)
 	if err != nil {
 		msg := fmt.Errorf("failed to read file %q; error %v", path, err)
-		tracer.Trace(w, func() *tracer.Arguments {
+		tracer.V(1).Trace(w, func() *tracer.Arguments {
 			return &tracer.Arguments{
 				Msgs: []string{msg.Error()},
 			}
@@ -389,7 +389,7 @@ func runBQLFromFile(ctx context.Context, driver storage.Store, chanSize, bulkSiz
 		_, err := runBQL(ctx, stm, driver, chanSize, bulkSize, w)
 		if err != nil {
 			msg := fmt.Errorf("%q; %v", stm, err)
-			tracer.Trace(w, func() *tracer.Arguments {
+			tracer.V(1).Trace(w, func() *tracer.Arguments {
 				return &tracer.Arguments{
 					Msgs: []string{msg.Error()},
 				}
@@ -403,7 +403,7 @@ func runBQLFromFile(ctx context.Context, driver storage.Store, chanSize, bulkSiz
 
 // runBQL attempts to execute the provided query against the given store.
 func runBQL(ctx context.Context, bql string, s storage.Store, chanSize, bulkSize int, w io.Writer) (*table.Table, error) {
-	tracer.Trace(w, func() *tracer.Arguments {
+	tracer.V(1).Trace(w, func() *tracer.Arguments {
 		return &tracer.Arguments{
 			Msgs: []string{fmt.Sprintf("Executing query: %s", bql)},
 		}
@@ -418,14 +418,14 @@ func runBQL(ctx context.Context, bql string, s storage.Store, chanSize, bulkSize
 	res, err := pln.Execute(ctx)
 	if err != nil {
 		msg := fmt.Errorf("planner.Execute: failed to execute; %v", err)
-		tracer.Trace(w, func() *tracer.Arguments {
+		tracer.V(1).Trace(w, func() *tracer.Arguments {
 			return &tracer.Arguments{
 				Msgs: []string{msg.Error()},
 			}
 		})
 		return nil, msg
 	}
-	tracer.Trace(w, func() *tracer.Arguments {
+	tracer.V(1).Trace(w, func() *tracer.Arguments {
 		return &tracer.Arguments{
 			Msgs: []string{fmt.Sprintf("Executed plan returned %d rows", res.NumRows())},
 		}
@@ -437,7 +437,7 @@ func runBQL(ctx context.Context, bql string, s storage.Store, chanSize, bulkSize
 func planBQL(ctx context.Context, bql string, s storage.Store, chanSize, bulkSize int, w io.Writer) (planner.Executor, error) {
 	bql = strings.TrimSpace(bql)
 	if bql == ";" {
-		tracer.Trace(w, func() *tracer.Arguments {
+		tracer.V(1).Trace(w, func() *tracer.Arguments {
 			return &tracer.Arguments{
 				Msgs: []string{"Empty statement found"},
 			}
@@ -447,7 +447,7 @@ func planBQL(ctx context.Context, bql string, s storage.Store, chanSize, bulkSiz
 	p, err := grammar.NewParser(grammar.SemanticBQL())
 	if err != nil {
 		msg := fmt.Errorf("NewParser failed; %v", err)
-		tracer.Trace(w, func() *tracer.Arguments {
+		tracer.V(1).Trace(w, func() *tracer.Arguments {
 			return &tracer.Arguments{
 				Msgs: []string{msg.Error()},
 			}
@@ -457,7 +457,7 @@ func planBQL(ctx context.Context, bql string, s storage.Store, chanSize, bulkSiz
 	stm := &semantic.Statement{}
 	if err := p.Parse(grammar.NewLLk(bql, 1), stm); err != nil {
 		msg := fmt.Errorf("NewLLk parser failed; %v", err)
-		tracer.Trace(w, func() *tracer.Arguments {
+		tracer.V(1).Trace(w, func() *tracer.Arguments {
 			return &tracer.Arguments{
 				Msgs: []string{msg.Error()},
 			}
@@ -467,14 +467,14 @@ func planBQL(ctx context.Context, bql string, s storage.Store, chanSize, bulkSiz
 	pln, err := planner.New(ctx, s, stm, chanSize, bulkSize, w)
 	if err != nil {
 		msg := fmt.Errorf("planer.New failed failed; %v", err)
-		tracer.Trace(w, func() *tracer.Arguments {
+		tracer.V(1).Trace(w, func() *tracer.Arguments {
 			return &tracer.Arguments{
 				Msgs: []string{msg.Error()},
 			}
 		})
 		return nil, msg
 	}
-	tracer.Trace(w, func() *tracer.Arguments {
+	tracer.V(1).Trace(w, func() *tracer.Arguments {
 		return &tracer.Arguments{
 			Msgs: []string{"Plan successfully created"},
 		}

--- a/tools/vcli/bw/repl/repl.go
+++ b/tools/vcli/bw/repl/repl.go
@@ -281,7 +281,7 @@ func REPL(od storage.Store, input *os.File, rl ReadLiner, chanSize, bulkSize, bu
 				fmt.Println("Profiling with pprof is on.")
 			case 4:
 				if args[2] != "-cpurate" {
-					fmt.Printf("Invalid syntax with %q.\n\tstart profiling -cpurate <samples_per_second>\n", args[2])
+					fmt.Printf("Invalid syntax with %q.\n\tstart profiling [-cpurate samples_per_second]\n", args[2])
 					break
 				}
 				cpuProfRate, err := strconv.ParseInt(args[3], 10, 32)
@@ -300,7 +300,7 @@ func REPL(od storage.Store, input *os.File, rl ReadLiner, chanSize, bulkSize, bu
 				isProfiling = true
 				fmt.Printf("Profiling with pprof is on (CPU profiling rate: %d samples per second).\n", cpuProfRate)
 			default:
-				fmt.Println("Invalid syntax.\n\tstart profiling -cpurate <samples_per_second>")
+				fmt.Println("Invalid syntax.\n\tstart profiling [-cpurate samples_per_second]")
 			}
 			done <- false
 			continue
@@ -396,8 +396,7 @@ func printHelp() {
 	fmt.Println("run <file_with_bql_statements>                        - runs all the BQL statements in the file.")
 	fmt.Println("start tracing [-v verbosity_level] [trace_file]       - starts tracing queries, verbosity levels supported are 1, 2 and 3 (with 3 meaning maximum verbosity).")
 	fmt.Println("stop tracing                                          - stops tracing queries.")
-	fmt.Println("start profiling                                       - starts pprof profiling for queries.")
-	fmt.Println("start profiling -cpurate <samples_per_second>         - starts pprof profiling with customized CPU sampling rate.")
+	fmt.Println("start profiling [-cpurate samples_per_second]         - starts pprof profiling for queries (customizable CPU sampling rate).")
 	fmt.Println("stop profiling                                        - stops pprof profiling for queries.")
 	fmt.Println("quit                                                  - quits the console.")
 	fmt.Println()

--- a/tools/vcli/bw/repl/repl.go
+++ b/tools/vcli/bw/repl/repl.go
@@ -506,7 +506,7 @@ func planBQL(ctx context.Context, bql string, s storage.Store, chanSize, bulkSiz
 	}
 	pln, err := planner.New(ctx, s, stm, chanSize, bulkSize, w)
 	if err != nil {
-		msg := fmt.Errorf("planer.New failed failed; %v", err)
+		msg := fmt.Errorf("planner.New failed with error: %v", err)
 		tracer.V(1).Trace(w, func() *tracer.Arguments {
 			return &tracer.Arguments{
 				Msgs: []string{msg.Error()},

--- a/tools/vcli/bw/repl/repl.go
+++ b/tools/vcli/bw/repl/repl.go
@@ -210,7 +210,7 @@ func REPL(od storage.Store, input *os.File, rl ReadLiner, chanSize, bulkSize, bu
 				}
 				traceWriter, isTracingToFile = f, true
 				tracer.SetVerbosity(1)
-				fmt.Println("[WARNING] Tracing is on. This may slow your BQL queries.\nDefault verbosity level set to 1 (minimum).")
+				fmt.Printf("[WARNING] Tracing to %q is on. This may slow your BQL queries.\nDefault verbosity level set to 1 (minimum).\n", f.Name())
 			case 4:
 				// Start tracing to the console with specified verbosity level.
 				stopTracing()
@@ -248,7 +248,7 @@ func REPL(od storage.Store, input *os.File, rl ReadLiner, chanSize, bulkSize, bu
 				}
 				traceWriter, isTracingToFile = f, true
 				verbositySet := tracer.SetVerbosity(int(verbosity))
-				fmt.Printf("[WARNING] Tracing is on. This may slow your BQL queries.\nVerbosity level set to %d.\n", verbositySet)
+				fmt.Printf("[WARNING] Tracing to %q is on. This may slow your BQL queries.\nVerbosity level set to %d.\n", f.Name(), verbositySet)
 			default:
 				fmt.Println("Invalid syntax.\n\tstart tracing [-v verbosity_level] [trace_file]")
 			}


### PR DESCRIPTION
This PR comes to support **different verbosity levels for tracing** in BadWolf, and also to allow the user to customize the current tracing verbosity through the BadWolf's CLI.

This way, it is now possible for the user to control the amount of information they want in the tracing output, accordingly to the use case, and also to control how much of computing power they want to dedicate for tracing.

In the CLI, the syntax for tracing now is:

```
start tracing [-v verbosity_level] [trace_file];
```

With the `-v` flag indicating the global verbosity level to be set for the current tracer.

At the moment, each tracing message in code can be allocated to one of the three following verbosity levels:

- **Level 1:** This level contains the **most crucial** and basic tracing messages to understand the flow of the program. Examples of messages that come here:
  - The one specifying **which query is being executed** at the moment; 
  - The one with the **final number of rows returned** after each created Plan was executed.

- **Level 2:** Tracing messages with **intermediate importance**. Examples of messages that come here:
  - The one specifying **which clause is being processed** (planner level);
  - The one specifying the **latency** of this clause processing (planner level); 
  - The one detailing the **number of triples received from the driver** after each driver call and the **number of rows** actually added to the result table after that.

- **Level 3:** The **less crucial** tracing messages, whose purpose is, mainly, to add additional details to the tracing log. Examples of messages that could come here (both examples extracted from planner):
  - “Processing **optional** clause”;
  - “Some clause bindings exist”.

If the current tracer has its global verbosity level set to `L` (after a command in the CLI), then all tracing messages with intrinsic verbosity `<= L` will be printed to the tracing output. 

Then, a global verbosity level of `1` means a very light tracer, printing to the output only what is essential, while a verbosity level of `3` means a very verbose tracer printing to the output all available tracing messages.