### PR TITLE
Fix issues with tracer and improve tracing messages

### DIFF
--- a/bql/planner/data_access.go
+++ b/bql/planner/data_access.go
@@ -127,6 +127,7 @@ func simpleExist(ctx context.Context, gs []storage.Graph, cls *semantic.GraphCla
 func simpleFetch(ctx context.Context, gs []storage.Graph, cls *semantic.GraphClause, lo *storage.LookupOptions, stmLimit int64, chanSize int, w io.Writer) (*table.Table, error) {
 	s, p, o := cls.S, cls.P, cls.O
 	lo = updateTimeBounds(lo, cls)
+	loStr := lo.String()
 	tbl, err := table.New(cls.Bindings())
 	if err != nil {
 		return nil, err
@@ -171,7 +172,7 @@ func simpleFetch(ctx context.Context, gs []storage.Graph, cls *semantic.GraphCla
 			)
 			tracer.V(2).Trace(w, func() *tracer.Arguments {
 				return &tracer.Arguments{
-					Msgs: []string{fmt.Sprintf("g.Objects(%v, %v, %v), graph: %s", s, p, lo, gID)},
+					Msgs: []string{fmt.Sprintf("g.Objects(%v, %v, %s), graph: %s", s, p, loStr, gID)},
 				}
 			})
 			wg.Add(2)
@@ -223,7 +224,7 @@ func simpleFetch(ctx context.Context, gs []storage.Graph, cls *semantic.GraphCla
 			)
 			tracer.V(2).Trace(w, func() *tracer.Arguments {
 				return &tracer.Arguments{
-					Msgs: []string{fmt.Sprintf("g.PredicatesForSubjectAndObject(%v, %v, %v), graph: %s", s, o, lo, gID)},
+					Msgs: []string{fmt.Sprintf("g.PredicatesForSubjectAndObject(%v, %v, %s), graph: %s", s, o, loStr, gID)},
 				}
 			})
 			wg.Add(2)
@@ -275,7 +276,7 @@ func simpleFetch(ctx context.Context, gs []storage.Graph, cls *semantic.GraphCla
 			)
 			tracer.V(2).Trace(w, func() *tracer.Arguments {
 				return &tracer.Arguments{
-					Msgs: []string{fmt.Sprintf("g.Subjects(%v, %v, %v), graph: %s", p, o, lo, gID)},
+					Msgs: []string{fmt.Sprintf("g.Subjects(%v, %v, %s), graph: %s", p, o, loStr, gID)},
 				}
 			})
 			wg.Add(2)
@@ -326,7 +327,7 @@ func simpleFetch(ctx context.Context, gs []storage.Graph, cls *semantic.GraphCla
 			)
 			tracer.V(2).Trace(w, func() *tracer.Arguments {
 				return &tracer.Arguments{
-					Msgs: []string{fmt.Sprintf("g.TriplesForSubject(%v, %v), graph: %s", s, lo, gID)},
+					Msgs: []string{fmt.Sprintf("g.TriplesForSubject(%v, %s), graph: %s", s, loStr, gID)},
 				}
 			})
 			ts := make(chan *triple.Triple, chanSize)
@@ -357,7 +358,7 @@ func simpleFetch(ctx context.Context, gs []storage.Graph, cls *semantic.GraphCla
 			)
 			tracer.V(2).Trace(w, func() *tracer.Arguments {
 				return &tracer.Arguments{
-					Msgs: []string{fmt.Sprintf("g.TriplesForPredicate(%v, %v), graph: %s", p, lo, gID)},
+					Msgs: []string{fmt.Sprintf("g.TriplesForPredicate(%v, %s), graph: %s", p, loStr, gID)},
 				}
 			})
 			ts := make(chan *triple.Triple, chanSize)
@@ -387,7 +388,7 @@ func simpleFetch(ctx context.Context, gs []storage.Graph, cls *semantic.GraphCla
 			)
 			tracer.V(2).Trace(w, func() *tracer.Arguments {
 				return &tracer.Arguments{
-					Msgs: []string{fmt.Sprintf("g.TriplesForObject(%v, %v), graph: %s", o, lo, gID)},
+					Msgs: []string{fmt.Sprintf("g.TriplesForObject(%v, %s), graph: %s", o, loStr, gID)},
 				}
 			})
 			ts := make(chan *triple.Triple, chanSize)
@@ -418,7 +419,7 @@ func simpleFetch(ctx context.Context, gs []storage.Graph, cls *semantic.GraphCla
 			)
 			tracer.V(2).Trace(w, func() *tracer.Arguments {
 				return &tracer.Arguments{
-					Msgs: []string{fmt.Sprintf("g.Triples(%v), graph: %s", lo, gID)},
+					Msgs: []string{fmt.Sprintf("g.Triples(%s), graph: %s", loStr, gID)},
 				}
 			})
 			ts := make(chan *triple.Triple, chanSize)

--- a/bql/planner/planner.go
+++ b/bql/planner/planner.go
@@ -323,7 +323,7 @@ func (p *queryPlan) processClause(ctx context.Context, cls *semantic.GraphClause
 		if cls.Optional && !cls.HasAlias() {
 			tracer.V(3).Trace(p.tracer, func() *tracer.Arguments {
 				return &tracer.Arguments{
-					Msgs: []string{fmt.Sprintf("Processing optional clause of specificity 3 %v", cls)},
+					Msgs: []string{fmt.Sprintf("Processing optional clause of specificity 3: %v", cls)},
 				}
 			})
 			return false, nil
@@ -372,7 +372,7 @@ func (p *queryPlan) processClause(ctx context.Context, cls *semantic.GraphClause
 			if cls.Optional {
 				tracer.V(3).Trace(p.tracer, func() *tracer.Arguments {
 					return &tracer.Arguments{
-						Msgs: []string{fmt.Sprintf("Processing optional clause of disjoint bindings %v", cls)},
+						Msgs: []string{fmt.Sprintf("Processing optional clause of disjoint bindings: %v", cls)},
 					}
 				})
 				return false, p.tbl.LeftOptionalJoin(tbl)

--- a/bql/planner/planner.go
+++ b/bql/planner/planner.go
@@ -72,13 +72,14 @@ func (p *createPlan) Execute(ctx context.Context) (*table.Table, error) {
 		return nil, err
 	}
 	errs := []string{}
-	for _, g := range p.stm.GraphNames() {
+	for _, gName := range p.stm.GraphNames() {
+		gNameCopy := gName // creating a local copy of the loop variable to not pass it by reference to the closure of the lazy tracer.
 		tracer.V(2).Trace(p.tracer, func() *tracer.Arguments {
 			return &tracer.Arguments{
-				Msgs: []string{"Creating new graph \"" + g + "\""},
+				Msgs: []string{fmt.Sprintf("Creating new graph %q", gNameCopy)},
 			}
 		})
-		if _, err := p.store.NewGraph(ctx, g); err != nil {
+		if _, err := p.store.NewGraph(ctx, gName); err != nil {
 			errs = append(errs, err.Error())
 		}
 	}

--- a/bql/planner/planner.go
+++ b/bql/planner/planner.go
@@ -113,13 +113,14 @@ func (p *dropPlan) Execute(ctx context.Context) (*table.Table, error) {
 		return nil, err
 	}
 	errs := []string{}
-	for _, g := range p.stm.GraphNames() {
+	for _, gName := range p.stm.GraphNames() {
+		gNameCopy := gName // creating a local copy of the loop variable to not pass it by reference to the closure of the lazy tracer.
 		tracer.V(2).Trace(p.tracer, func() *tracer.Arguments {
 			return &tracer.Arguments{
-				Msgs: []string{"Deleting graph \"" + g + "\""},
+				Msgs: []string{fmt.Sprintf("Deleting graph %q", gNameCopy)},
 			}
 		})
-		if err := p.store.DeleteGraph(ctx, g); err != nil {
+		if err := p.store.DeleteGraph(ctx, gName); err != nil {
 			errs = append(errs, err.Error())
 		}
 	}

--- a/bql/planner/planner.go
+++ b/bql/planner/planner.go
@@ -193,9 +193,10 @@ func (p *insertPlan) Execute(ctx context.Context) (*table.Table, error) {
 	}
 	return t, update(ctx, p.stm.Data(), p.stm.OutputGraphNames(), p.store, func(g storage.Graph, d []*triple.Triple) error {
 		gID := g.ID(ctx)
+		nTrpls := len(d)
 		tracer.V(2).Trace(p.tracer, func() *tracer.Arguments {
 			return &tracer.Arguments{
-				Msgs: []string{fmt.Sprintf("Inserting triples to graph %q", gID)},
+				Msgs: []string{fmt.Sprintf("Inserting %d triples to graph %q", nTrpls, gID)},
 			}
 		})
 		return g.AddTriples(ctx, d)
@@ -238,9 +239,10 @@ func (p *deletePlan) Execute(ctx context.Context) (*table.Table, error) {
 	}
 	return t, update(ctx, p.stm.Data(), p.stm.InputGraphNames(), p.store, func(g storage.Graph, d []*triple.Triple) error {
 		gID := g.ID(ctx)
+		nTrpls := len(d)
 		tracer.V(2).Trace(p.tracer, func() *tracer.Arguments {
 			return &tracer.Arguments{
-				Msgs: []string{fmt.Sprintf("Removing triples from graph %q", gID)},
+				Msgs: []string{fmt.Sprintf("Removing %d triples from graph %q", nTrpls, gID)},
 			}
 		})
 		return g.RemoveTriples(ctx, d)
@@ -1196,9 +1198,10 @@ func (p *constructPlan) Execute(ctx context.Context) (*table.Table, error) {
 		var ts []*triple.Triple
 		updateFunc := func(g storage.Graph, d []*triple.Triple) error {
 			gID := g.ID(ctx)
+			nTrpls := len(d)
 			tracer.V(2).Trace(p.tracer, func() *tracer.Arguments {
 				return &tracer.Arguments{
-					Msgs: []string{fmt.Sprintf("Removing triples from graph %q", gID)},
+					Msgs: []string{fmt.Sprintf("Removing %d triples from graph %q", nTrpls, gID)},
 				}
 			})
 			return g.RemoveTriples(ctx, d)
@@ -1206,9 +1209,10 @@ func (p *constructPlan) Execute(ctx context.Context) (*table.Table, error) {
 		if p.construct {
 			updateFunc = func(g storage.Graph, d []*triple.Triple) error {
 				gID := g.ID(ctx)
+				nTrpls := len(d)
 				tracer.V(2).Trace(p.tracer, func() *tracer.Arguments {
 					return &tracer.Arguments{
-						Msgs: []string{fmt.Sprintf("Inserting triples to graph %q", gID)},
+						Msgs: []string{fmt.Sprintf("Inserting %d triples to graph %q", nTrpls, gID)},
 					}
 				})
 				return g.AddTriples(ctx, d)

--- a/bql/planner/planner.go
+++ b/bql/planner/planner.go
@@ -858,9 +858,10 @@ func (p *queryPlan) projectAndGroupBy() error {
 	cfg := table.SortConfig{}
 	aaps := []table.AliasAccPair{}
 	for _, prj := range p.stm.Projections() {
+		prjCopy := prj // creating a local copy of the loop variable to not pass it by reference to the closure of the lazy tracer.
 		tracer.V(3).Trace(p.tracer, func() *tracer.Arguments {
 			return &tracer.Arguments{
-				Msgs: []string{"Analysing projection " + prj.String()},
+				Msgs: []string{fmt.Sprintf("Analysing projection %q", prjCopy)},
 			}
 		})
 		// Only include used incoming bindings.

--- a/bql/planner/planner.go
+++ b/bql/planner/planner.go
@@ -994,9 +994,10 @@ func (p *queryPlan) Execute(ctx context.Context) (*table.Table, error) {
 	p.grfs = p.stm.InputGraphs()
 	// Retrieve the data.
 	lo := p.stm.GlobalLookupOptions()
+	loStr := lo.String()
 	tracer.V(2).Trace(p.tracer, func() *tracer.Arguments {
 		return &tracer.Arguments{
-			Msgs: []string{"Setting global lookup options to " + lo.String()},
+			Msgs: []string{fmt.Sprintf("Setting global lookup options to %s", loStr)},
 		}
 	})
 	if err := p.processGraphPattern(ctx, lo); err != nil {

--- a/tools/vcli/bw/repl/repl.go
+++ b/tools/vcli/bw/repl/repl.go
@@ -465,9 +465,10 @@ func runBQL(ctx context.Context, bql string, s storage.Store, chanSize, bulkSize
 		})
 		return nil, msg
 	}
+	nRows := res.NumRows()
 	tracer.V(1).Trace(w, func() *tracer.Arguments {
 		return &tracer.Arguments{
-			Msgs: []string{fmt.Sprintf("Executed plan returned %d rows", res.NumRows())},
+			Msgs: []string{fmt.Sprintf("Executed plan returned %d rows", nRows)},
 		}
 	})
 	return res, nil


### PR DESCRIPTION
This PR comes mainly to:

- Fix problem of **loop variables being passed by reference to the tracing closure** and then having only its last value being shown in the tracing output;

- Fix problem of `lookupOptions` being **passed as a pointer to the tracing closure** (in the "global lookup options" tracing message, for example, another value was being written to the output since the referenced content was changed in the meantime between the call to `.Trace` and the generation of the string message when calling the closure);

- Avoid **unnecessary and more expensive captures** inside the tracing closures (such as capturing an entire `graph` in the closure just to get its `ID` later).