### PR TITLE
Fix behavior when having FILTER options and global lookup options simultaneously

### DIFF
--- a/bql/planner/planner_test.go
+++ b/bql/planner/planner_test.go
@@ -1187,6 +1187,39 @@ func TestPlannerQuery(t *testing.T) {
 			nBindings: 3,
 			nRows:     5,
 		},
+		{
+			q: `SELECT ?p, ?o
+				FROM ?test
+				WHERE {
+					/u<peter> ?p ?o .
+					FILTER isTemporal(?p)
+				}
+				BETWEEN 2016-02-01T00:00:00-08:00, 2016-03-01T00:00:00-08:00;`,
+			nBindings: 2,
+			nRows:     2,
+		},
+		{
+			q: `SELECT ?p, ?o
+				FROM ?test
+				WHERE {
+					/u<peter> ?p ?o .
+					FILTER latest(?p)
+				}
+				BETWEEN 2016-02-01T00:00:00-08:00, 2016-03-01T00:00:00-08:00;`,
+			nBindings: 2,
+			nRows:     1,
+		},
+		{
+			q: `SELECT ?s, ?p, ?o
+				FROM ?test
+				WHERE {
+					?s ?p ?o .
+					FILTER isTemporal(?p)
+				}
+				LIMIT "3"^^type:int64;`,
+			nBindings: 3,
+			nRows:     3,
+		},
 	}
 
 	s, ctx := memory.NewStore(), context.Background()

--- a/storage/memory/memory.go
+++ b/storage/memory/memory.go
@@ -433,7 +433,7 @@ func (m *memory) Objects(ctx context.Context, s *node.Node, p *predicate.Predica
 	defer close(objs)
 
 	ckr := newChecker(lo, p)
-	trps := applyGlobalTimeBounds(m.idxSP[spIdx], ckr)
+	selectedTrpls := applyGlobalTimeBounds(m.idxSP[spIdx], ckr)
 
 	var err error
 	if lo.LatestAnchor {
@@ -450,13 +450,13 @@ func (m *memory) Objects(ctx context.Context, s *node.Node, p *predicate.Predica
 		}()
 	}
 	if lo.FilterOptions != nil {
-		trps, err = executeFilter(trps, p, lo.FilterOptions)
+		selectedTrpls, err = executeFilter(selectedTrpls, p, lo.FilterOptions)
 		if err != nil {
 			return err
 		}
 	}
 
-	for _, t := range trps {
+	for _, t := range selectedTrpls {
 		if t != nil && ckr.CheckLimitAndUpdate() {
 			objs <- t.Object()
 		}
@@ -480,7 +480,7 @@ func (m *memory) Subjects(ctx context.Context, p *predicate.Predicate, o *triple
 	defer close(subjs)
 
 	ckr := newChecker(lo, p)
-	trps := applyGlobalTimeBounds(m.idxPO[poIdx], ckr)
+	selectedTrpls := applyGlobalTimeBounds(m.idxPO[poIdx], ckr)
 
 	var err error
 	if lo.LatestAnchor {
@@ -497,13 +497,13 @@ func (m *memory) Subjects(ctx context.Context, p *predicate.Predicate, o *triple
 		}()
 	}
 	if lo.FilterOptions != nil {
-		trps, err = executeFilter(trps, p, lo.FilterOptions)
+		selectedTrpls, err = executeFilter(selectedTrpls, p, lo.FilterOptions)
 		if err != nil {
 			return err
 		}
 	}
 
-	for _, t := range trps {
+	for _, t := range selectedTrpls {
 		if t != nil && ckr.CheckLimitAndUpdate() {
 			subjs <- t.Subject()
 		}
@@ -527,7 +527,7 @@ func (m *memory) PredicatesForSubjectAndObject(ctx context.Context, s *node.Node
 	defer close(prds)
 
 	ckr := newChecker(lo, nil)
-	trps := applyGlobalTimeBounds(m.idxSO[soIdx], ckr)
+	selectedTrpls := applyGlobalTimeBounds(m.idxSO[soIdx], ckr)
 
 	var err error
 	if lo.LatestAnchor {
@@ -544,13 +544,13 @@ func (m *memory) PredicatesForSubjectAndObject(ctx context.Context, s *node.Node
 		}()
 	}
 	if lo.FilterOptions != nil {
-		trps, err = executeFilter(trps, nil, lo.FilterOptions)
+		selectedTrpls, err = executeFilter(selectedTrpls, nil, lo.FilterOptions)
 		if err != nil {
 			return err
 		}
 	}
 
-	for _, t := range trps {
+	for _, t := range selectedTrpls {
 		if t != nil && ckr.CheckLimitAndUpdate() {
 			prds <- t.Predicate()
 		}
@@ -572,7 +572,7 @@ func (m *memory) PredicatesForSubject(ctx context.Context, s *node.Node, lo *sto
 	defer close(prds)
 
 	ckr := newChecker(lo, nil)
-	trps := applyGlobalTimeBounds(m.idxS[sUUID], ckr)
+	selectedTrpls := applyGlobalTimeBounds(m.idxS[sUUID], ckr)
 
 	var err error
 	if lo.LatestAnchor {
@@ -589,13 +589,13 @@ func (m *memory) PredicatesForSubject(ctx context.Context, s *node.Node, lo *sto
 		}()
 	}
 	if lo.FilterOptions != nil {
-		trps, err = executeFilter(trps, nil, lo.FilterOptions)
+		selectedTrpls, err = executeFilter(selectedTrpls, nil, lo.FilterOptions)
 		if err != nil {
 			return err
 		}
 	}
 
-	for _, t := range trps {
+	for _, t := range selectedTrpls {
 		if t != nil && ckr.CheckLimitAndUpdate() {
 			prds <- t.Predicate()
 		}
@@ -617,7 +617,7 @@ func (m *memory) PredicatesForObject(ctx context.Context, o *triple.Object, lo *
 	defer close(prds)
 
 	ckr := newChecker(lo, nil)
-	trps := applyGlobalTimeBounds(m.idxO[oUUID], ckr)
+	selectedTrpls := applyGlobalTimeBounds(m.idxO[oUUID], ckr)
 
 	var err error
 	if lo.LatestAnchor {
@@ -634,13 +634,13 @@ func (m *memory) PredicatesForObject(ctx context.Context, o *triple.Object, lo *
 		}()
 	}
 	if lo.FilterOptions != nil {
-		trps, err = executeFilter(trps, nil, lo.FilterOptions)
+		selectedTrpls, err = executeFilter(selectedTrpls, nil, lo.FilterOptions)
 		if err != nil {
 			return err
 		}
 	}
 
-	for _, t := range trps {
+	for _, t := range selectedTrpls {
 		if t != nil && ckr.CheckLimitAndUpdate() {
 			prds <- t.Predicate()
 		}
@@ -662,7 +662,7 @@ func (m *memory) TriplesForSubject(ctx context.Context, s *node.Node, lo *storag
 	defer close(trpls)
 
 	ckr := newChecker(lo, nil)
-	trps := applyGlobalTimeBounds(m.idxS[sUUID], ckr)
+	selectedTrpls := applyGlobalTimeBounds(m.idxS[sUUID], ckr)
 
 	var err error
 	if lo.LatestAnchor {
@@ -679,13 +679,13 @@ func (m *memory) TriplesForSubject(ctx context.Context, s *node.Node, lo *storag
 		}()
 	}
 	if lo.FilterOptions != nil {
-		trps, err = executeFilter(trps, nil, lo.FilterOptions)
+		selectedTrpls, err = executeFilter(selectedTrpls, nil, lo.FilterOptions)
 		if err != nil {
 			return err
 		}
 	}
 
-	for _, t := range trps {
+	for _, t := range selectedTrpls {
 		if t != nil && ckr.CheckLimitAndUpdate() {
 			trpls <- t
 		}
@@ -707,7 +707,7 @@ func (m *memory) TriplesForPredicate(ctx context.Context, p *predicate.Predicate
 	defer close(trpls)
 
 	ckr := newChecker(lo, p)
-	trps := applyGlobalTimeBounds(m.idxP[pUUID], ckr)
+	selectedTrpls := applyGlobalTimeBounds(m.idxP[pUUID], ckr)
 
 	var err error
 	if lo.LatestAnchor {
@@ -724,13 +724,13 @@ func (m *memory) TriplesForPredicate(ctx context.Context, p *predicate.Predicate
 		}()
 	}
 	if lo.FilterOptions != nil {
-		trps, err = executeFilter(trps, p, lo.FilterOptions)
+		selectedTrpls, err = executeFilter(selectedTrpls, p, lo.FilterOptions)
 		if err != nil {
 			return err
 		}
 	}
 
-	for _, t := range trps {
+	for _, t := range selectedTrpls {
 		if t != nil && ckr.CheckLimitAndUpdate() {
 			trpls <- t
 		}
@@ -752,7 +752,7 @@ func (m *memory) TriplesForObject(ctx context.Context, o *triple.Object, lo *sto
 	defer close(trpls)
 
 	ckr := newChecker(lo, nil)
-	trps := applyGlobalTimeBounds(m.idxO[oUUID], ckr)
+	selectedTrpls := applyGlobalTimeBounds(m.idxO[oUUID], ckr)
 
 	var err error
 	if lo.LatestAnchor {
@@ -769,13 +769,13 @@ func (m *memory) TriplesForObject(ctx context.Context, o *triple.Object, lo *sto
 		}()
 	}
 	if lo.FilterOptions != nil {
-		trps, err = executeFilter(trps, nil, lo.FilterOptions)
+		selectedTrpls, err = executeFilter(selectedTrpls, nil, lo.FilterOptions)
 		if err != nil {
 			return err
 		}
 	}
 
-	for _, t := range trps {
+	for _, t := range selectedTrpls {
 		if t != nil && ckr.CheckLimitAndUpdate() {
 			trpls <- t
 		}
@@ -799,7 +799,7 @@ func (m *memory) TriplesForSubjectAndPredicate(ctx context.Context, s *node.Node
 	defer close(trpls)
 
 	ckr := newChecker(lo, p)
-	trps := applyGlobalTimeBounds(m.idxSP[spIdx], ckr)
+	selectedTrpls := applyGlobalTimeBounds(m.idxSP[spIdx], ckr)
 
 	var err error
 	if lo.LatestAnchor {
@@ -816,13 +816,13 @@ func (m *memory) TriplesForSubjectAndPredicate(ctx context.Context, s *node.Node
 		}()
 	}
 	if lo.FilterOptions != nil {
-		trps, err = executeFilter(trps, p, lo.FilterOptions)
+		selectedTrpls, err = executeFilter(selectedTrpls, p, lo.FilterOptions)
 		if err != nil {
 			return err
 		}
 	}
 
-	for _, t := range trps {
+	for _, t := range selectedTrpls {
 		if t != nil && ckr.CheckLimitAndUpdate() {
 			trpls <- t
 		}
@@ -846,7 +846,7 @@ func (m *memory) TriplesForPredicateAndObject(ctx context.Context, p *predicate.
 	defer close(trpls)
 
 	ckr := newChecker(lo, p)
-	trps := applyGlobalTimeBounds(m.idxPO[poIdx], ckr)
+	selectedTrpls := applyGlobalTimeBounds(m.idxPO[poIdx], ckr)
 
 	var err error
 	if lo.LatestAnchor {
@@ -863,13 +863,13 @@ func (m *memory) TriplesForPredicateAndObject(ctx context.Context, p *predicate.
 		}()
 	}
 	if lo.FilterOptions != nil {
-		trps, err = executeFilter(trps, p, lo.FilterOptions)
+		selectedTrpls, err = executeFilter(selectedTrpls, p, lo.FilterOptions)
 		if err != nil {
 			return err
 		}
 	}
 
-	for _, t := range trps {
+	for _, t := range selectedTrpls {
 		if t != nil && ckr.CheckLimitAndUpdate() {
 			trpls <- t
 		}
@@ -899,7 +899,7 @@ func (m *memory) Triples(ctx context.Context, lo *storage.LookupOptions, trpls c
 	defer close(trpls)
 
 	ckr := newChecker(lo, nil)
-	trps := applyGlobalTimeBounds(m.idx, ckr)
+	selectedTrpls := applyGlobalTimeBounds(m.idx, ckr)
 
 	var err error
 	if lo.LatestAnchor {
@@ -916,13 +916,13 @@ func (m *memory) Triples(ctx context.Context, lo *storage.LookupOptions, trpls c
 		}()
 	}
 	if lo.FilterOptions != nil {
-		trps, err = executeFilter(trps, nil, lo.FilterOptions)
+		selectedTrpls, err = executeFilter(selectedTrpls, nil, lo.FilterOptions)
 		if err != nil {
 			return err
 		}
 	}
 
-	for _, t := range trps {
+	for _, t := range selectedTrpls {
 		if t != nil && ckr.CheckLimitAndUpdate() {
 			trpls <- t
 		}

--- a/storage/memory/memory.go
+++ b/storage/memory/memory.go
@@ -412,6 +412,8 @@ func (m *memory) Objects(ctx context.Context, s *node.Node, p *predicate.Predica
 	defer m.rwmu.RUnlock()
 	defer close(objs)
 
+	trps := m.idxSP[spIdx]
+	var err error
 	if lo.LatestAnchor {
 		if lo.FilterOptions != nil {
 			return fmt.Errorf("cannot have LatestAnchor and FilterOptions used at the same time inside lookup options")
@@ -426,20 +428,15 @@ func (m *memory) Objects(ctx context.Context, s *node.Node, p *predicate.Predica
 		}()
 	}
 	if lo.FilterOptions != nil {
-		trps, err := executeFilter(m.idxSP[spIdx], p, lo.FilterOptions)
+		trps, err = executeFilter(trps, p, lo.FilterOptions)
 		if err != nil {
 			return err
 		}
-		for _, trp := range trps {
-			if trp != nil {
-				objs <- trp.Object()
-			}
-		}
-		return nil
 	}
+
 	ckr := newChecker(lo, p)
-	for _, t := range m.idxSP[spIdx] {
-		if ckr.CheckAndUpdate(t.Predicate()) {
+	for _, t := range trps {
+		if t != nil && ckr.CheckAndUpdate(t.Predicate()) {
 			objs <- t.Object()
 		}
 	}
@@ -461,6 +458,8 @@ func (m *memory) Subjects(ctx context.Context, p *predicate.Predicate, o *triple
 	defer m.rwmu.RUnlock()
 	defer close(subjs)
 
+	trps := m.idxPO[poIdx]
+	var err error
 	if lo.LatestAnchor {
 		if lo.FilterOptions != nil {
 			return fmt.Errorf("cannot have LatestAnchor and FilterOptions used at the same time inside lookup options")
@@ -475,20 +474,15 @@ func (m *memory) Subjects(ctx context.Context, p *predicate.Predicate, o *triple
 		}()
 	}
 	if lo.FilterOptions != nil {
-		trps, err := executeFilter(m.idxPO[poIdx], p, lo.FilterOptions)
+		trps, err = executeFilter(trps, p, lo.FilterOptions)
 		if err != nil {
 			return err
 		}
-		for _, trp := range trps {
-			if trp != nil {
-				subjs <- trp.Subject()
-			}
-		}
-		return nil
 	}
+
 	ckr := newChecker(lo, p)
-	for _, t := range m.idxPO[poIdx] {
-		if ckr.CheckAndUpdate(t.Predicate()) {
+	for _, t := range trps {
+		if t != nil && ckr.CheckAndUpdate(t.Predicate()) {
 			subjs <- t.Subject()
 		}
 	}
@@ -510,6 +504,8 @@ func (m *memory) PredicatesForSubjectAndObject(ctx context.Context, s *node.Node
 	defer m.rwmu.RUnlock()
 	defer close(prds)
 
+	trps := m.idxSO[soIdx]
+	var err error
 	if lo.LatestAnchor {
 		if lo.FilterOptions != nil {
 			return fmt.Errorf("cannot have LatestAnchor and FilterOptions used at the same time inside lookup options")
@@ -524,20 +520,15 @@ func (m *memory) PredicatesForSubjectAndObject(ctx context.Context, s *node.Node
 		}()
 	}
 	if lo.FilterOptions != nil {
-		trps, err := executeFilter(m.idxSO[soIdx], nil, lo.FilterOptions)
+		trps, err = executeFilter(trps, nil, lo.FilterOptions)
 		if err != nil {
 			return err
 		}
-		for _, trp := range trps {
-			if trp != nil {
-				prds <- trp.Predicate()
-			}
-		}
-		return nil
 	}
+
 	ckr := newChecker(lo, nil)
-	for _, t := range m.idxSO[soIdx] {
-		if ckr.CheckAndUpdate(t.Predicate()) {
+	for _, t := range trps {
+		if t != nil && ckr.CheckAndUpdate(t.Predicate()) {
 			prds <- t.Predicate()
 		}
 	}
@@ -557,6 +548,8 @@ func (m *memory) PredicatesForSubject(ctx context.Context, s *node.Node, lo *sto
 	defer m.rwmu.RUnlock()
 	defer close(prds)
 
+	trps := m.idxS[sUUID]
+	var err error
 	if lo.LatestAnchor {
 		if lo.FilterOptions != nil {
 			return fmt.Errorf("cannot have LatestAnchor and FilterOptions used at the same time inside lookup options")
@@ -571,20 +564,15 @@ func (m *memory) PredicatesForSubject(ctx context.Context, s *node.Node, lo *sto
 		}()
 	}
 	if lo.FilterOptions != nil {
-		trps, err := executeFilter(m.idxS[sUUID], nil, lo.FilterOptions)
+		trps, err = executeFilter(trps, nil, lo.FilterOptions)
 		if err != nil {
 			return err
 		}
-		for _, trp := range trps {
-			if trp != nil {
-				prds <- trp.Predicate()
-			}
-		}
-		return nil
 	}
+
 	ckr := newChecker(lo, nil)
-	for _, t := range m.idxS[sUUID] {
-		if ckr.CheckAndUpdate(t.Predicate()) {
+	for _, t := range trps {
+		if t != nil && ckr.CheckAndUpdate(t.Predicate()) {
 			prds <- t.Predicate()
 		}
 	}
@@ -604,6 +592,8 @@ func (m *memory) PredicatesForObject(ctx context.Context, o *triple.Object, lo *
 	defer m.rwmu.RUnlock()
 	defer close(prds)
 
+	trps := m.idxO[oUUID]
+	var err error
 	if lo.LatestAnchor {
 		if lo.FilterOptions != nil {
 			return fmt.Errorf("cannot have LatestAnchor and FilterOptions used at the same time inside lookup options")
@@ -618,20 +608,15 @@ func (m *memory) PredicatesForObject(ctx context.Context, o *triple.Object, lo *
 		}()
 	}
 	if lo.FilterOptions != nil {
-		trps, err := executeFilter(m.idxO[oUUID], nil, lo.FilterOptions)
+		trps, err = executeFilter(trps, nil, lo.FilterOptions)
 		if err != nil {
 			return err
 		}
-		for _, trp := range trps {
-			if trp != nil {
-				prds <- trp.Predicate()
-			}
-		}
-		return nil
 	}
+
 	ckr := newChecker(lo, nil)
-	for _, t := range m.idxO[oUUID] {
-		if ckr.CheckAndUpdate(t.Predicate()) {
+	for _, t := range trps {
+		if t != nil && ckr.CheckAndUpdate(t.Predicate()) {
 			prds <- t.Predicate()
 		}
 	}
@@ -651,6 +636,8 @@ func (m *memory) TriplesForSubject(ctx context.Context, s *node.Node, lo *storag
 	defer m.rwmu.RUnlock()
 	defer close(trpls)
 
+	trps := m.idxS[sUUID]
+	var err error
 	if lo.LatestAnchor {
 		if lo.FilterOptions != nil {
 			return fmt.Errorf("cannot have LatestAnchor and FilterOptions used at the same time inside lookup options")
@@ -665,20 +652,15 @@ func (m *memory) TriplesForSubject(ctx context.Context, s *node.Node, lo *storag
 		}()
 	}
 	if lo.FilterOptions != nil {
-		trps, err := executeFilter(m.idxS[sUUID], nil, lo.FilterOptions)
+		trps, err = executeFilter(trps, nil, lo.FilterOptions)
 		if err != nil {
 			return err
 		}
-		for _, trp := range trps {
-			if trp != nil {
-				trpls <- trp
-			}
-		}
-		return nil
 	}
+
 	ckr := newChecker(lo, nil)
-	for _, t := range m.idxS[sUUID] {
-		if ckr.CheckAndUpdate(t.Predicate()) {
+	for _, t := range trps {
+		if t != nil && ckr.CheckAndUpdate(t.Predicate()) {
 			trpls <- t
 		}
 	}
@@ -698,6 +680,8 @@ func (m *memory) TriplesForPredicate(ctx context.Context, p *predicate.Predicate
 	defer m.rwmu.RUnlock()
 	defer close(trpls)
 
+	trps := m.idxP[pUUID]
+	var err error
 	if lo.LatestAnchor {
 		if lo.FilterOptions != nil {
 			return fmt.Errorf("cannot have LatestAnchor and FilterOptions used at the same time inside lookup options")
@@ -712,20 +696,15 @@ func (m *memory) TriplesForPredicate(ctx context.Context, p *predicate.Predicate
 		}()
 	}
 	if lo.FilterOptions != nil {
-		trps, err := executeFilter(m.idxP[pUUID], p, lo.FilterOptions)
+		trps, err = executeFilter(trps, p, lo.FilterOptions)
 		if err != nil {
 			return err
 		}
-		for _, trp := range trps {
-			if trp != nil {
-				trpls <- trp
-			}
-		}
-		return nil
 	}
+
 	ckr := newChecker(lo, p)
-	for _, t := range m.idxP[pUUID] {
-		if ckr.CheckAndUpdate(t.Predicate()) {
+	for _, t := range trps {
+		if t != nil && ckr.CheckAndUpdate(t.Predicate()) {
 			trpls <- t
 		}
 	}
@@ -745,6 +724,8 @@ func (m *memory) TriplesForObject(ctx context.Context, o *triple.Object, lo *sto
 	defer m.rwmu.RUnlock()
 	defer close(trpls)
 
+	trps := m.idxO[oUUID]
+	var err error
 	if lo.LatestAnchor {
 		if lo.FilterOptions != nil {
 			return fmt.Errorf("cannot have LatestAnchor and FilterOptions used at the same time inside lookup options")
@@ -759,20 +740,15 @@ func (m *memory) TriplesForObject(ctx context.Context, o *triple.Object, lo *sto
 		}()
 	}
 	if lo.FilterOptions != nil {
-		trps, err := executeFilter(m.idxO[oUUID], nil, lo.FilterOptions)
+		trps, err = executeFilter(trps, nil, lo.FilterOptions)
 		if err != nil {
 			return err
 		}
-		for _, trp := range trps {
-			if trp != nil {
-				trpls <- trp
-			}
-		}
-		return nil
 	}
+
 	ckr := newChecker(lo, nil)
-	for _, t := range m.idxO[oUUID] {
-		if ckr.CheckAndUpdate(t.Predicate()) {
+	for _, t := range trps {
+		if t != nil && ckr.CheckAndUpdate(t.Predicate()) {
 			trpls <- t
 		}
 	}
@@ -794,6 +770,8 @@ func (m *memory) TriplesForSubjectAndPredicate(ctx context.Context, s *node.Node
 	defer m.rwmu.RUnlock()
 	defer close(trpls)
 
+	trps := m.idxSP[spIdx]
+	var err error
 	if lo.LatestAnchor {
 		if lo.FilterOptions != nil {
 			return fmt.Errorf("cannot have LatestAnchor and FilterOptions used at the same time inside lookup options")
@@ -808,20 +786,15 @@ func (m *memory) TriplesForSubjectAndPredicate(ctx context.Context, s *node.Node
 		}()
 	}
 	if lo.FilterOptions != nil {
-		trps, err := executeFilter(m.idxSP[spIdx], p, lo.FilterOptions)
+		trps, err = executeFilter(trps, p, lo.FilterOptions)
 		if err != nil {
 			return err
 		}
-		for _, trp := range trps {
-			if trp != nil {
-				trpls <- trp
-			}
-		}
-		return nil
 	}
+
 	ckr := newChecker(lo, p)
-	for _, t := range m.idxSP[spIdx] {
-		if ckr.CheckAndUpdate(t.Predicate()) {
+	for _, t := range trps {
+		if t != nil && ckr.CheckAndUpdate(t.Predicate()) {
 			trpls <- t
 		}
 	}
@@ -843,6 +816,8 @@ func (m *memory) TriplesForPredicateAndObject(ctx context.Context, p *predicate.
 	defer m.rwmu.RUnlock()
 	defer close(trpls)
 
+	trps := m.idxPO[poIdx]
+	var err error
 	if lo.LatestAnchor {
 		if lo.FilterOptions != nil {
 			return fmt.Errorf("cannot have LatestAnchor and FilterOptions used at the same time inside lookup options")
@@ -857,20 +832,15 @@ func (m *memory) TriplesForPredicateAndObject(ctx context.Context, p *predicate.
 		}()
 	}
 	if lo.FilterOptions != nil {
-		trps, err := executeFilter(m.idxPO[poIdx], p, lo.FilterOptions)
+		trps, err = executeFilter(trps, p, lo.FilterOptions)
 		if err != nil {
 			return err
 		}
-		for _, trp := range trps {
-			if trp != nil {
-				trpls <- trp
-			}
-		}
-		return nil
 	}
+
 	ckr := newChecker(lo, p)
-	for _, t := range m.idxPO[poIdx] {
-		if ckr.CheckAndUpdate(t.Predicate()) {
+	for _, t := range trps {
+		if t != nil && ckr.CheckAndUpdate(t.Predicate()) {
 			trpls <- t
 		}
 	}
@@ -898,6 +868,8 @@ func (m *memory) Triples(ctx context.Context, lo *storage.LookupOptions, trpls c
 	defer m.rwmu.RUnlock()
 	defer close(trpls)
 
+	trps := m.idx
+	var err error
 	if lo.LatestAnchor {
 		if lo.FilterOptions != nil {
 			return fmt.Errorf("cannot have LatestAnchor and FilterOptions used at the same time inside lookup options")
@@ -912,20 +884,15 @@ func (m *memory) Triples(ctx context.Context, lo *storage.LookupOptions, trpls c
 		}()
 	}
 	if lo.FilterOptions != nil {
-		trps, err := executeFilter(m.idx, nil, lo.FilterOptions)
+		trps, err = executeFilter(trps, nil, lo.FilterOptions)
 		if err != nil {
 			return err
 		}
-		for _, trp := range trps {
-			if trp != nil {
-				trpls <- trp
-			}
-		}
-		return nil
 	}
+
 	ckr := newChecker(lo, nil)
-	for _, t := range m.idx {
-		if ckr.CheckAndUpdate(t.Predicate()) {
+	for _, t := range trps {
+		if t != nil && ckr.CheckAndUpdate(t.Predicate()) {
 			trpls <- t
 		}
 	}

--- a/storage/memory/memory_test.go
+++ b/storage/memory/memory_test.go
@@ -376,6 +376,13 @@ func TestObjectsFilter(t *testing.T) {
 			p:    testutil.MustBuildPredicate(t, `"_predicate"@[]`),
 			want: map[string]int{`"meet"@[2020-04-10T04:21:00Z]`: 1, `"meet"@[2021-04-10T04:21:00Z]`: 1},
 		},
+		{
+			id:   "FILTER latest between",
+			lo:   &storage.LookupOptions{LowerAnchor: testutil.MustBuildTime(t, "2012-04-10T04:21:00Z"), UpperAnchor: testutil.MustBuildTime(t, "2013-04-10T04:21:00Z"), FilterOptions: &filter.StorageOptions{Operation: filter.Latest, Field: filter.PredicateField}},
+			s:    testutil.MustBuildNodeFromStrings(t, "/u", "john"),
+			p:    testutil.MustBuildPredicate(t, `"meet"@[2013-04-10T04:21:00Z]`),
+			want: map[string]int{"/u<mary>": 1},
+		},
 	}
 
 	for _, entry := range testTable {
@@ -522,6 +529,13 @@ func TestSubjectsFilter(t *testing.T) {
 			o:    triple.NewPredicateObject(testutil.MustBuildPredicate(t, `"height_cm"@[]`)),
 			want: map[string]int{},
 		},
+		{
+			id:   "FILTER latest between",
+			lo:   &storage.LookupOptions{LowerAnchor: testutil.MustBuildTime(t, "2012-04-10T04:21:00Z"), UpperAnchor: testutil.MustBuildTime(t, "2013-04-10T04:21:00Z"), FilterOptions: &filter.StorageOptions{Operation: filter.Latest, Field: filter.PredicateField}},
+			p:    testutil.MustBuildPredicate(t, `"meet"@[2013-04-10T04:21:00Z]`),
+			o:    triple.NewNodeObject(testutil.MustBuildNodeFromStrings(t, "/u", "mary")),
+			want: map[string]int{"/u<john>": 1},
+		},
 	}
 
 	for _, entry := range testTable {
@@ -659,6 +673,13 @@ func TestPredicatesForSubjectAndObjectFilter(t *testing.T) {
 			o:    triple.NewPredicateObject(testutil.MustBuildPredicate(t, `"meet"@[2020-04-10T04:21:00Z]`)),
 			want: map[string]int{`"_predicate"@[]`: 1},
 		},
+		{
+			id:   "FILTER latest between",
+			lo:   &storage.LookupOptions{LowerAnchor: testutil.MustBuildTime(t, "2012-04-10T04:21:00Z"), UpperAnchor: testutil.MustBuildTime(t, "2013-04-10T04:21:00Z"), FilterOptions: &filter.StorageOptions{Operation: filter.Latest, Field: filter.PredicateField}},
+			s:    testutil.MustBuildNodeFromStrings(t, "/u", "john"),
+			o:    triple.NewNodeObject(testutil.MustBuildNodeFromStrings(t, "/u", "mary")),
+			want: map[string]int{`"meet"@[2013-04-10T04:21:00Z]`: 1},
+		},
 	}
 
 	for _, entry := range testTable {
@@ -789,6 +810,12 @@ func TestPredicatesForSubjectFilter(t *testing.T) {
 			s:    testutil.MustBuildNodeFromStrings(t, "/_", "bn"),
 			want: map[string]int{`"_predicate"@[]`: 2},
 		},
+		{
+			id:   "FILTER latest between",
+			lo:   &storage.LookupOptions{LowerAnchor: testutil.MustBuildTime(t, "2012-04-10T04:21:00Z"), UpperAnchor: testutil.MustBuildTime(t, "2013-04-10T04:21:00Z"), FilterOptions: &filter.StorageOptions{Operation: filter.Latest, Field: filter.PredicateField}},
+			s:    testutil.MustBuildNodeFromStrings(t, "/u", "john"),
+			want: map[string]int{`"meet"@[2013-04-10T04:21:00Z]`: 1},
+		},
 	}
 
 	for _, entry := range testTable {
@@ -918,6 +945,12 @@ func TestPredicatesForObjectFilter(t *testing.T) {
 			o:    triple.NewPredicateObject(testutil.MustBuildPredicate(t, `"meet"@[2020-04-10T04:21:00Z]`)),
 			want: map[string]int{`"_predicate"@[]`: 1},
 		},
+		{
+			id:   "FILTER latest between",
+			lo:   &storage.LookupOptions{LowerAnchor: testutil.MustBuildTime(t, "2012-04-10T04:21:00Z"), UpperAnchor: testutil.MustBuildTime(t, "2013-04-10T04:21:00Z"), FilterOptions: &filter.StorageOptions{Operation: filter.Latest, Field: filter.PredicateField}},
+			o:    triple.NewNodeObject(testutil.MustBuildNodeFromStrings(t, "/u", "mary")),
+			want: map[string]int{`"meet"@[2013-04-10T04:21:00Z]`: 1},
+		},
 	}
 
 	for _, entry := range testTable {
@@ -1043,6 +1076,12 @@ func TestTriplesForSubjectFilter(t *testing.T) {
 			lo: &storage.LookupOptions{FilterOptions: &filter.StorageOptions{Operation: filter.IsTemporal, Field: filter.ObjectField}},
 			s:  testutil.MustBuildNodeFromStrings(t, "/_", "bn"),
 			want: map[string]int{`/_<bn>	"_predicate"@[]	"meet"@[2020-04-10T04:21:00Z]`: 1, `/_<bn>	"_predicate"@[]	"meet"@[2021-04-10T04:21:00Z]`: 1},
+		},
+		{
+			id: "FILTER latest between",
+			lo: &storage.LookupOptions{LowerAnchor: testutil.MustBuildTime(t, "2012-04-10T04:21:00Z"), UpperAnchor: testutil.MustBuildTime(t, "2013-04-10T04:21:00Z"), FilterOptions: &filter.StorageOptions{Operation: filter.Latest, Field: filter.PredicateField}},
+			s:  testutil.MustBuildNodeFromStrings(t, "/u", "john"),
+			want: map[string]int{`/u<john>	"meet"@[2013-04-10T04:21:00Z]	/u<mary>`: 1},
 		},
 	}
 
@@ -1176,6 +1215,12 @@ func TestTriplesForPredicateFilter(t *testing.T) {
 			p:  testutil.MustBuildPredicate(t, `"_predicate"@[]`),
 			want: map[string]int{`/_<bn>	"_predicate"@[]	"meet"@[2020-04-10T04:21:00Z]`: 1, `/_<bn>	"_predicate"@[]	"meet"@[2021-04-10T04:21:00Z]`: 1},
 		},
+		{
+			id: "FILTER latest between",
+			lo: &storage.LookupOptions{LowerAnchor: testutil.MustBuildTime(t, "2012-04-10T04:21:00Z"), UpperAnchor: testutil.MustBuildTime(t, "2013-04-10T04:21:00Z"), FilterOptions: &filter.StorageOptions{Operation: filter.Latest, Field: filter.PredicateField}},
+			p:  testutil.MustBuildPredicate(t, `"meet"@[2013-04-10T04:21:00Z]`),
+			want: map[string]int{`/u<john>	"meet"@[2013-04-10T04:21:00Z]	/u<mary>`: 1},
+		},
 	}
 
 	for _, entry := range testTable {
@@ -1301,6 +1346,12 @@ func TestTriplesForObjectFilter(t *testing.T) {
 			lo:   &storage.LookupOptions{FilterOptions: &filter.StorageOptions{Operation: filter.IsTemporal, Field: filter.ObjectField}},
 			o:    triple.NewPredicateObject(testutil.MustBuildPredicate(t, `"height_cm"@[]`)),
 			want: map[string]int{},
+		},
+		{
+			id: "FILTER latest between",
+			lo: &storage.LookupOptions{LowerAnchor: testutil.MustBuildTime(t, "2012-04-10T04:21:00Z"), UpperAnchor: testutil.MustBuildTime(t, "2013-04-10T04:21:00Z"), FilterOptions: &filter.StorageOptions{Operation: filter.Latest, Field: filter.PredicateField}},
+			o:  triple.NewNodeObject(testutil.MustBuildNodeFromStrings(t, "/u", "mary")),
+			want: map[string]int{`/u<john>	"meet"@[2013-04-10T04:21:00Z]	/u<mary>`: 1},
 		},
 	}
 
@@ -1485,6 +1536,13 @@ func TestTriplesForSubjectAndPredicateFilter(t *testing.T) {
 			p:  testutil.MustBuildPredicate(t, `"_predicate"@[]`),
 			want: map[string]int{`/_<bn>	"_predicate"@[]	"meet"@[2020-04-10T04:21:00Z]`: 1, `/_<bn>	"_predicate"@[]	"meet"@[2021-04-10T04:21:00Z]`: 1},
 		},
+		{
+			id: "FILTER latest between",
+			lo: &storage.LookupOptions{LowerAnchor: testutil.MustBuildTime(t, "2012-04-10T04:21:00Z"), UpperAnchor: testutil.MustBuildTime(t, "2013-04-10T04:21:00Z"), FilterOptions: &filter.StorageOptions{Operation: filter.Latest, Field: filter.PredicateField}},
+			s:  testutil.MustBuildNodeFromStrings(t, "/u", "john"),
+			p:  testutil.MustBuildPredicate(t, `"meet"@[2013-04-10T04:21:00Z]`),
+			want: map[string]int{`/u<john>	"meet"@[2013-04-10T04:21:00Z]	/u<mary>`: 1},
+		},
 	}
 
 	for _, entry := range testTable {
@@ -1626,6 +1684,13 @@ func TestTriplesForPredicateAndObjectFilter(t *testing.T) {
 			o:    triple.NewPredicateObject(testutil.MustBuildPredicate(t, `"height_cm"@[]`)),
 			want: map[string]int{},
 		},
+		{
+			id: "FILTER latest between",
+			lo: &storage.LookupOptions{LowerAnchor: testutil.MustBuildTime(t, "2012-04-10T04:21:00Z"), UpperAnchor: testutil.MustBuildTime(t, "2013-04-10T04:21:00Z"), FilterOptions: &filter.StorageOptions{Operation: filter.Latest, Field: filter.PredicateField}},
+			p:  testutil.MustBuildPredicate(t, `"meet"@[2013-04-10T04:21:00Z]`),
+			o:  triple.NewNodeObject(testutil.MustBuildNodeFromStrings(t, "/u", "mary")),
+			want: map[string]int{`/u<john>	"meet"@[2013-04-10T04:21:00Z]	/u<mary>`: 1},
+		},
 	}
 
 	for _, entry := range testTable {
@@ -1762,6 +1827,11 @@ func TestTriplesFilter(t *testing.T) {
 			id: "FILTER isTemporal object",
 			lo: &storage.LookupOptions{FilterOptions: &filter.StorageOptions{Operation: filter.IsTemporal, Field: filter.ObjectField}},
 			want: map[string]int{`/_<bn>	"_predicate"@[]	"meet"@[2020-04-10T04:21:00Z]`: 1, `/_<bn>	"_predicate"@[]	"meet"@[2021-04-10T04:21:00Z]`: 1},
+		},
+		{
+			id: "FILTER latest between",
+			lo: &storage.LookupOptions{LowerAnchor: testutil.MustBuildTime(t, "2012-04-10T04:21:00Z"), UpperAnchor: testutil.MustBuildTime(t, "2013-04-10T04:21:00Z"), FilterOptions: &filter.StorageOptions{Operation: filter.Latest, Field: filter.PredicateField}},
+			want: map[string]int{`/u<john>	"meet"@[2013-04-10T04:21:00Z]	/u<mary>`: 1},
 		},
 	}
 

--- a/storage/memory/memory_test.go
+++ b/storage/memory/memory_test.go
@@ -98,10 +98,10 @@ func TestDefaultLookupChecker(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !c.CheckAndUpdate(ip) {
+	if !c.CheckGlobalTimeBounds(ip) {
 		t.Errorf("Immutable predicates should always validate with default lookup %v", dlu)
 	}
-	if !c.CheckAndUpdate(tp) {
+	if !c.CheckGlobalTimeBounds(tp) {
 		t.Errorf("Temporal predicates should always validate with default lookup %v", dlu)
 	}
 }
@@ -109,16 +109,12 @@ func TestDefaultLookupChecker(t *testing.T) {
 func TestLimitedItemsLookupChecker(t *testing.T) {
 	blu := &storage.LookupOptions{MaxElements: 1}
 	c := newChecker(blu, nil)
-	ip, err := predicate.NewImmutable("foo")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !c.CheckAndUpdate(ip) {
-		t.Errorf("The first predicate should always succeed on bounded lookup %v", blu)
+	if !c.CheckLimitAndUpdate() {
+		t.Errorf("The first call to CheckLimitAndUpdate() should always succeed on lookup %v that started with MaxElements set to 1", blu)
 	}
 	for i := 0; i < 10; i++ {
-		if c.CheckAndUpdate(ip) {
-			t.Errorf("Bounded lookup %v should never succeed after being exahausted", blu)
+		if c.CheckLimitAndUpdate() {
+			t.Errorf("Lookup %v should never succeed after being exahausted", blu)
 		}
 	}
 }
@@ -140,26 +136,26 @@ func TestTemporalBoundedLookupChecker(t *testing.T) {
 	lb, _ := lpa.TimeAnchor()
 	blu := &storage.LookupOptions{LowerAnchor: lb}
 	clu := newChecker(blu, nil)
-	if !clu.CheckAndUpdate(mpa) {
+	if !clu.CheckGlobalTimeBounds(mpa) {
 		t.Errorf("Failed to reject invalid predicate %v by checker %v", mpa, clu)
 	}
 	lb, _ = mpa.TimeAnchor()
 	blu = &storage.LookupOptions{LowerAnchor: lb}
 	clu = newChecker(blu, nil)
-	if clu.CheckAndUpdate(lpa) {
+	if clu.CheckGlobalTimeBounds(lpa) {
 		t.Errorf("Failed to reject invalid predicate %v by checker %v", mpa, clu)
 	}
 	// Check upper bound.
 	ub, _ := upa.TimeAnchor()
 	buu := &storage.LookupOptions{UpperAnchor: ub}
 	cuu := newChecker(buu, nil)
-	if !cuu.CheckAndUpdate(mpa) {
+	if !cuu.CheckGlobalTimeBounds(mpa) {
 		t.Errorf("Failed to reject invalid predicate %v by checker %v", mpa, cuu)
 	}
 	ub, _ = mpa.TimeAnchor()
 	buu = &storage.LookupOptions{UpperAnchor: ub}
 	cuu = newChecker(buu, nil)
-	if cuu.CheckAndUpdate(upa) {
+	if cuu.CheckGlobalTimeBounds(upa) {
 		t.Errorf("Failed to reject invalid predicate %v by checker %v", mpa, cuu)
 	}
 }
@@ -181,20 +177,20 @@ func TestTemporalExactChecker(t *testing.T) {
 	lb, _ := lpa.TimeAnchor()
 	blu := &storage.LookupOptions{LowerAnchor: lb}
 	clu := newChecker(blu, mpa)
-	if !clu.CheckAndUpdate(mpa) {
+	if !clu.CheckGlobalTimeBounds(mpa) {
 		t.Errorf("Failed to accept predicate %v by checker %v", mpa, clu)
 	}
 	lb, _ = mpa.TimeAnchor()
 	blu = &storage.LookupOptions{LowerAnchor: lb}
 	clu = newChecker(blu, mpa)
-	if clu.CheckAndUpdate(lpa) {
+	if clu.CheckGlobalTimeBounds(lpa) {
 		t.Errorf("Failed to reject invalid predicate %v by checker %v", mpa, clu)
 	}
 	// Check upper bound.
 	ub, _ := upa.TimeAnchor()
 	buu := &storage.LookupOptions{UpperAnchor: ub}
 	cuu := newChecker(buu, mpa)
-	if !cuu.CheckAndUpdate(mpa) {
+	if !cuu.CheckGlobalTimeBounds(mpa) {
 		t.Errorf("Failed to reject invalid predicate %v by checker %v", mpa, cuu)
 	}
 }


### PR DESCRIPTION
Inside the `LookupOptions` struct that arrives on the driver side we have, other than `FilterOptions`, the variables defining the **global time bounds** (`LowerAnchor` and `UpperAnchor` - that are set when using the keywords `BEFORE`, `AFTER` and `BETWEEN`) and also a `MaxElements` variable **limiting** (when set) the **maximum number of elements** for the driver to return.

Since some of these variables are set at the same time, we want to handle them **coherently** and harmoniously with each other, having an **intuitive final behavior**.

For example, given a `?test` graph with the following triples:

```
/u<peter> "bought"@[2016-02-01T00:00:00-08:00] /c<model s>
/u<peter> "bought"@[2016-03-01T00:00:00-08:00] /c<model x>
/u<peter> "bought"@[2016-04-01T00:00:00-08:00] /c<model y>
```

If we make the following query:

```
SELECT ?p
FROM ?test
WHERE {
  /u<peter> ?p ?o .
  FILTER latest(?p)
}
BETWEEN 2016-02-01T00:00:00-08:00, 2016-03-01T00:00:00-08:00;
```

We expect to see the predicate `"bought"@[2016-03-01T00:00:00-08:00]` in the final result. But, note that if the `FILTER latest` is processed before the `BETWEEN` we have as intermediate result the predicate `"bought"@[2016-04-01T00:00:00-08:00]`, which at the time of the processment of `BETWEEN` would be discarded (since it is out of the specified time bounds), resulting in an empty final result!

Then, we have to be careful with the order of processing these variables from `LookupOptions`.

For the final result to be coherent we must:

1) Process the **global time bounds** first;

2) Process the **`FilterOptions`**;

3) Process the **`MaxElements`** variable (to **limit** the number of elements to be returned) by the end.

The previous code of the volatile driver in `memory.go` was just ignoring the other variables inside `LookupOptions` if a given `FilterOptions` was found first. This PR, then, comes to fix this problem and also enforce the processing order detailed above, for intuitive final results.