### PR TITLE
Optimize slice allocation in Badwolf.

### DIFF
--- a/bql/planner/planner.go
+++ b/bql/planner/planner.go
@@ -288,10 +288,6 @@ func (p *queryPlan) Type() string {
 
 // newQueryPlan returns a new query plan ready to be executed.
 func newQueryPlan(ctx context.Context, store storage.Store, stm *semantic.Statement, chanSize int, w io.Writer) (*queryPlan, error) {
-	bs := []string{}
-	for _, b := range stm.Bindings() {
-		bs = append(bs, b)
-	}
 	t, err := table.New([]string{})
 	if err != nil {
 		return nil, err
@@ -299,7 +295,7 @@ func newQueryPlan(ctx context.Context, store storage.Store, stm *semantic.Statem
 	return &queryPlan{
 		stm:       stm,
 		store:     store,
-		bndgs:     bs,
+		bndgs:     stm.Bindings(),
 		grfsNames: stm.InputGraphNames(),
 		clauses:   stm.GraphPatternClauses(),
 		filters:   stm.FilterClauses(),
@@ -764,7 +760,7 @@ func resetFilterOptions(lo *storage.LookupOptions) {
 func (p *queryPlan) processGraphPattern(ctx context.Context, lo *storage.LookupOptions) error {
 	clauses := p.clauses
 	tracer.V(3).Trace(p.tracer, func() *tracer.Arguments {
-		var res []string
+		res := make([]string, 0, len(clauses))
 		for i, cls := range clauses {
 			res = append(res, fmt.Sprintf("Clause %d to process: %v", i, cls))
 		}

--- a/bql/semantic/expression.go
+++ b/bql/semantic/expression.go
@@ -639,7 +639,7 @@ func internalNewEvaluator(ce []ConsumedElement) (Evaluator, []ConsumedElement, e
 		return tailEval, tail, nil
 	}
 
-	var tkns []string
+	tkns := make([]string, 0, len(ce))
 	for _, e := range ce {
 		tkns = append(tkns, fmt.Sprintf("%q", e.token.Type.String()))
 	}

--- a/bql/semantic/semantic.go
+++ b/bql/semantic/semantic.go
@@ -400,8 +400,9 @@ func (c *GraphClause) BindingsMap() map[string]int {
 
 // Bindings returns the list of unique bindings listed in the graph clause.
 func (c *GraphClause) Bindings() []string {
-	var bs []string
-	for k := range c.BindingsMap() {
+	bindingsMap := c.BindingsMap()
+	bs := make([]string, 0, len(bindingsMap))
+	for k := range bindingsMap {
 		bs = append(bs, k)
 	}
 	return bs
@@ -713,8 +714,9 @@ func (s *Statement) BindingsMap() map[string]int {
 // Bindings returns the list of bindings available on the graph clauses for he
 // statement.
 func (s *Statement) Bindings() []string {
-	var bs []string
-	for k := range s.BindingsMap() {
+	bindingsMap := s.BindingsMap()
+	bs := make([]string, 0, len(bindingsMap))
+	for k := range bindingsMap {
 		bs = append(bs, k)
 	}
 	return bs

--- a/bql/table/table.go
+++ b/bql/table/table.go
@@ -323,14 +323,14 @@ func joinWithRange(t, t2 *Table) {
 	ibs := intersectBindings(t.mbs, t2.mbs)
 	ubs := unionBindings(t.mbs, t2.mbs)
 
-	var sbs []string
+	sbs := make([]string, 0, len(ibs))
 	for k := range ibs {
 		sbs = append(sbs, k)
 	}
 	sortTablesData(t, t2, sbs)
 
 	// Create the comparison for row order.
-	var scfg SortConfig
+	scfg := make(SortConfig, 0, len(sbs))
 	for _, k := range sbs {
 		scfg = append(scfg, sortConfig{Binding: k})
 	}
@@ -364,7 +364,7 @@ func joinWithRange(t, t2 *Table) {
 		j = lj
 	}
 
-	// Udate the table.
+	// Update the table.
 	t.mbs = ubs
 	t.AvailableBindings = nil
 	for k := range ubs {
@@ -434,7 +434,7 @@ func sortTablesData(t, t2 *Table, bs []string) {
 	t2.mu.Lock()
 	defer t2.mu.Unlock()
 	d, d2 := t.Data, t2.Data
-	var scfg SortConfig
+	scfg := make(SortConfig, 0, len(bs))
 	for _, k := range bs {
 		scfg = append(scfg, sortConfig{Binding: k})
 	}


### PR DESCRIPTION
There are some cases in the codebase where we know the size of slices beforehand.
Thus, we can pre-allocate them instead of relying on append to dynamically increase the slices.
This change decreases the number of times we call runtime.growslice, optimizing the code a bit, and also helps GC.