### PR TITLE
Don't use `bytes.Buffer` unless necessary.

### DIFF
--- a/storage/storage.go
+++ b/storage/storage.go
@@ -54,7 +54,9 @@ type LookupOptions struct {
 
 // String returns a readable version of the LookupOptions instance.
 func (l *LookupOptions) String() string {
-	b := bytes.NewBufferString("<limit=")
+	var b bytes.Buffer
+	b.Grow(80) // We already know we will be writing at least this much from the fixed strings below.
+	b.WriteString("<limit=")
 	b.WriteString(strconv.Itoa(l.MaxElements))
 	b.WriteString(", lower_anchor=")
 	if l.LowerAnchor != nil {
@@ -75,9 +77,9 @@ func (l *LookupOptions) String() string {
 
 // UUID return the UUID of the lookup option.
 func (l *LookupOptions) UUID() uuid.UUID {
-	var buffer bytes.Buffer
-	buffer.WriteString(l.String())
-	return uuid.NewSHA1(uuid.NIL, buffer.Bytes())
+	b := make([]byte, len(l.String()))
+	copy(b, l.String())
+	return uuid.NewSHA1(uuid.NIL, b)
 }
 
 // DefaultLookup provides the default lookup behavior.

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -77,9 +77,7 @@ func (l *LookupOptions) String() string {
 
 // UUID return the UUID of the lookup option.
 func (l *LookupOptions) UUID() uuid.UUID {
-	b := make([]byte, len(l.String()))
-	copy(b, l.String())
-	return uuid.NewSHA1(uuid.NIL, b)
+	return uuid.NewSHA1(uuid.NIL, []byte(l.String()))
 }
 
 // DefaultLookup provides the default lookup behavior.

--- a/triple/literal/literal.go
+++ b/triple/literal/literal.go
@@ -315,7 +315,7 @@ func (l *Literal) UUID() uuid.UUID {
 		binary.LittleEndian.PutUint64(b, bs)
 		buffer.Write(b)
 	case string:
-		buffer.Write([]byte(v))
+		buffer.WriteString(v)
 	case []byte:
 		buffer.Write(v)
 	}

--- a/triple/node/node.go
+++ b/triple/node/node.go
@@ -232,8 +232,8 @@ func NewBlankNode() *Node {
 // UUID returns a global unique identifier for the given node. It is
 // implemented as the SHA1 UUID of the node values.
 func (n *Node) UUID() uuid.UUID {
-	var buffer bytes.Buffer
-	buffer.WriteString(string(*n.t))
-	buffer.WriteString(string(*n.id))
-	return uuid.NewSHA1(uuid.NIL, buffer.Bytes())
+	b := make([]byte, len(*n.t)+len(*n.id))
+	copy(b[:len(*n.t)], *n.t)
+	copy(b[len(*n.t):], *n.id)
+	return uuid.NewSHA1(uuid.NIL, b)
 }

--- a/triple/node/node_test.go
+++ b/triple/node/node_test.go
@@ -15,6 +15,7 @@
 package node
 
 import (
+	"bytes"
 	"testing"
 
 	"github.com/pborman/uuid"
@@ -183,5 +184,18 @@ func TestBlankNode(t *testing.T) {
 		if uuid.Equal(bID, uuid.NIL) {
 			t.Fatalf("NewBlankNode %s could not be decoded properly", b)
 		}
+	}
+}
+
+func TestUUID(t *testing.T) {
+	n, err := Parse("/foo<123>")
+	if err != nil {
+		t.Errorf("node.Parse: failed to parse '/foo<123>'; %v", err)
+	}
+	var buffer bytes.Buffer
+	buffer.WriteString(string(*n.t))
+	buffer.WriteString(string(*n.id))
+	if !uuid.Equal(n.UUID(), uuid.NewSHA1(uuid.NIL, buffer.Bytes())) {
+		t.Fatalf("node.UUID not equal; got %q, want: %q", n.UUID(), uuid.NewSHA1(uuid.NIL, buffer.Bytes()))
 	}
 }

--- a/triple/predicate/predicate.go
+++ b/triple/predicate/predicate.go
@@ -177,7 +177,7 @@ func (p *Predicate) UUID() uuid.UUID {
 // is only useful for driver implementers when they want to take advantage
 // of range reads.
 func (p *Predicate) PartialUUID() uuid.UUID {
-	var buffer bytes.Buffer
-	buffer.WriteString(string(p.id))
-	return uuid.NewSHA1(uuid.NIL, buffer.Bytes())
+	b := make([]byte, len(p.id))
+	copy(b, p.id)
+	return uuid.NewSHA1(uuid.NIL, b)
 }

--- a/triple/predicate/predicate.go
+++ b/triple/predicate/predicate.go
@@ -159,7 +159,7 @@ func NewTemporal(id string, t time.Time) (*Predicate, error) {
 func (p *Predicate) UUID() uuid.UUID {
 	var buffer bytes.Buffer
 
-	buffer.WriteString(string(p.id))
+	buffer.Write([]byte(p.id))
 	if p.anchor == nil {
 		buffer.WriteString("immutable")
 	} else {
@@ -177,7 +177,5 @@ func (p *Predicate) UUID() uuid.UUID {
 // is only useful for driver implementers when they want to take advantage
 // of range reads.
 func (p *Predicate) PartialUUID() uuid.UUID {
-	b := make([]byte, len(p.id))
-	copy(b, p.id)
-	return uuid.NewSHA1(uuid.NIL, b)
+	return uuid.NewSHA1(uuid.NIL, []byte(p.id))
 }

--- a/triple/predicate/predicate_test.go
+++ b/triple/predicate/predicate_test.go
@@ -163,4 +163,7 @@ func TestPartialUUID(t *testing.T) {
 	if uuid1, uuid2 := p1.PartialUUID(), p2.PartialUUID(); !reflect.DeepEqual(uuid1, uuid2) {
 		t.Errorf("predicates %v and %v should have identical partial UUID; got %q=%q", p1, p2, uuid1.String(), uuid2.String())
 	}
+	if !uuid.Equal(p1.PartialUUID(), uuid.NewSHA1(uuid.NIL, []byte("foo"))) {
+		t.Errorf("predicates %v should have partial UUID %q; got %q", p1, uuid.NewSHA1(uuid.NIL, []byte("foo")), p1.PartialUUID().String())
+	}
 }

--- a/triple/predicate/predicate_test.go
+++ b/triple/predicate/predicate_test.go
@@ -19,6 +19,8 @@ import (
 	"reflect"
 	"testing"
 	"time"
+
+	"github.com/pborman/uuid"
 )
 
 var (

--- a/triple/triple.go
+++ b/triple/triple.go
@@ -16,7 +16,6 @@
 package triple
 
 import (
-	"bytes"
 	"fmt"
 	"regexp"
 	"strings"
@@ -255,11 +254,11 @@ func (t *Triple) Reify() ([]*Triple, *node.Node, error) {
 // implemented as the SHA1 UUID of the concatenated UUIDs of the subject,
 // predicate, and object.
 func (t *Triple) UUID() uuid.UUID {
-	var buffer bytes.Buffer
+	ul := len(t.s.UUID())
+	b := make([]byte, 3*ul)
 
-	buffer.Write([]byte(t.s.UUID()))
-	buffer.Write([]byte(t.p.UUID()))
-	buffer.Write([]byte(t.o.UUID()))
-
-	return uuid.NewSHA1(uuid.NIL, buffer.Bytes())
+	copy(b[:ul], t.s.UUID())
+	copy(b[ul:2*ul], t.p.UUID())
+	copy(b[2*ul:], t.o.UUID())
+	return uuid.NewSHA1(uuid.NIL, b)
 }

--- a/triple/triple_test.go
+++ b/triple/triple_test.go
@@ -15,11 +15,13 @@
 package triple
 
 import (
+	"bytes"
 	"testing"
 
 	"github.com/google/badwolf/triple/literal"
 	"github.com/google/badwolf/triple/node"
 	"github.com/google/badwolf/triple/predicate"
+	"github.com/pborman/uuid"
 )
 
 func getTestData(t *testing.T) (*node.Node, *predicate.Predicate, *Object) {
@@ -178,6 +180,13 @@ func TestUUID(t *testing.T) {
 		}
 		if !t1.Equal(t2) {
 			t.Errorf("Failed to equal %s(%s) == %s(%s)", t1, t1.UUID(), t2, t2.UUID())
+		}
+		var b bytes.Buffer
+		b.Write(t1.s.UUID())
+		b.Write(t1.p.UUID())
+		b.Write(t1.o.UUID())
+		if !uuid.Equal(t1.UUID(), uuid.NewSHA1(uuid.NIL, b.Bytes())) {
+			t.Errorf("Failed to equal %s == %s", t1.UUID(), uuid.NewSHA1(uuid.NIL, b.Bytes()))
 		}
 	}
 }


### PR DESCRIPTION
In most of the cases we know exactly how many bytes we actually need
to copy around, so just copy directly into a properly sized byte slice.

`bytes.Buffer` pre-allocates 64 bytes at minimum, which is more than
we actually use in the majority of cases here since UUIDs are 16 bytes.