### PR TITLE
Limit concurrency in planner to runtime.GOMAXPROCS(0)

### DIFF
--- a/bql/planner/planner.go
+++ b/bql/planner/planner.go
@@ -506,7 +506,7 @@ func (p *queryPlan) specifyClauseWithTable(ctx context.Context, cls *semantic.Gr
 			if gCtx.Err() != nil {
 				return gCtx.Err()
 			}
-			if err := sem.Acquire(ctx, 1); err != nil {
+			if err := sem.Acquire(gCtx, 1); err != nil {
 				return err
 			}
 			r := tmpRow
@@ -558,7 +558,7 @@ func (p *queryPlan) filterOnExistence(ctx context.Context, cls *semantic.GraphCl
 			if gCtx.Err() != nil {
 				return gCtx.Err()
 			}
-			if err := sem.Acquire(ctx, 1); err != nil {
+			if err := sem.Acquire(gCtx, 1); err != nil {
 				return err
 			}
 			r := tmp

--- a/bql/planner/planner.go
+++ b/bql/planner/planner.go
@@ -511,6 +511,7 @@ func (p *queryPlan) specifyClauseWithTable(ctx context.Context, cls *semantic.Gr
 			}
 			r := tmpRow
 			grp.Go(func() error {
+				defer sem.Release(1)
 				var tmpCls = *cls
 				// The table manipulations are now thread safe.
 				return p.addSpecifiedData(gCtx, r, &tmpCls, lo)
@@ -564,6 +565,7 @@ func (p *queryPlan) filterOnExistence(ctx context.Context, cls *semantic.GraphCl
 			r := tmp
 			cls := ocls
 			grp.Go(func() error {
+				defer sem.Release(1)
 				sbj, prd, obj := cls.S, cls.P, cls.O
 				// Attempt to rebind the subject.
 				if sbj == nil && p.tbl.HasBinding(cls.SBinding) {


### PR DESCRIPTION
Before this change: planner creates a new goroutine for each row, possibly causing resource exhaustion if there are too many rows.
After this change: planner will only create up to runtime.GOMAXPROCS(0) goroutines, limiting resource usage.

This change is based on the suggested implementation from https://github.com/golang/go/issues/27837.