### PR TITLE
Use `sync.Pool` to reduce the number of allocations in `UUID()` method all around

### DIFF
--- a/bql/planner/planner.go
+++ b/bql/planner/planner.go
@@ -506,7 +506,7 @@ func (p *queryPlan) specifyClauseWithTable(ctx context.Context, cls *semantic.Gr
 			if gCtx.Err() != nil {
 				return gCtx.Err()
 			}
-			if err := sem.Acquire(ctx, 1); err != nil {
+			if err := sem.Acquire(gCtx, 1); err != nil {
 				return err
 			}
 			r := tmpRow
@@ -558,7 +558,7 @@ func (p *queryPlan) filterOnExistence(ctx context.Context, cls *semantic.GraphCl
 			if gCtx.Err() != nil {
 				return gCtx.Err()
 			}
-			if err := sem.Acquire(ctx, 1); err != nil {
+			if err := sem.Acquire(gCtx, 1); err != nil {
 				return err
 			}
 			r := tmp

--- a/bql/planner/planner.go
+++ b/bql/planner/planner.go
@@ -511,6 +511,7 @@ func (p *queryPlan) specifyClauseWithTable(ctx context.Context, cls *semantic.Gr
 			}
 			r := tmpRow
 			grp.Go(func() error {
+				defer sem.Release(1)
 				var tmpCls = *cls
 				// The table manipulations are now thread safe.
 				return p.addSpecifiedData(gCtx, r, &tmpCls, lo)
@@ -564,6 +565,7 @@ func (p *queryPlan) filterOnExistence(ctx context.Context, cls *semantic.GraphCl
 			r := tmp
 			cls := ocls
 			grp.Go(func() error {
+				defer sem.Release(1)
 				sbj, prd, obj := cls.S, cls.P, cls.O
 				// Attempt to rebind the subject.
 				if sbj == nil && p.tbl.HasBinding(cls.SBinding) {

--- a/triple/triple.go
+++ b/triple/triple.go
@@ -19,12 +19,17 @@ import (
 	"fmt"
 	"regexp"
 	"strings"
+	"sync"
 
 	"github.com/google/badwolf/triple/literal"
 	"github.com/google/badwolf/triple/node"
 	"github.com/google/badwolf/triple/predicate"
 	"github.com/pborman/uuid"
 )
+
+// bufPool holds a pool of byte arrays used by triple's UUID() method, which needs
+// a buffer big enough to contain the UUIDs for (subject, predicate, object), so 3x16 bytes.
+var bufPool = sync.Pool{New: func() interface{} { return make([]byte, 48) }}
 
 // Object is the box that either contains a literal, a predicate or a node.
 type Object struct {
@@ -254,11 +259,14 @@ func (t *Triple) Reify() ([]*Triple, *node.Node, error) {
 // implemented as the SHA1 UUID of the concatenated UUIDs of the subject,
 // predicate, and object.
 func (t *Triple) UUID() uuid.UUID {
-	ul := len(t.s.UUID())
-	b := make([]byte, 3*ul)
+	b := bufPool.Get().([]byte)
+	// Even though 'b' is dirty when fetched from the pool we do not 
+	// clear it because the contents are always completely overwritten.
+	defer bufPool.Put(b)
 
-	copy(b[:ul], t.s.UUID())
-	copy(b[ul:2*ul], t.p.UUID())
-	copy(b[2*ul:], t.o.UUID())
+	// A UUID is always 16 bytes.
+	copy(b[:16], t.s.UUID())
+	copy(b[16:32], t.p.UUID())
+	copy(b[32:], t.o.UUID())
 	return uuid.NewSHA1(uuid.NIL, b)
 }

--- a/triple/triple.go
+++ b/triple/triple.go
@@ -260,7 +260,7 @@ func (t *Triple) Reify() ([]*Triple, *node.Node, error) {
 // predicate, and object.
 func (t *Triple) UUID() uuid.UUID {
 	b := bufPool.Get().([]byte)
-	// Even though 'b' is dirty when fetched from the pool we do not 
+	// Even though 'b' is dirty when fetched from the pool we do not
 	// clear it because the contents are always completely overwritten.
 	defer bufPool.Put(b)
 


### PR DESCRIPTION
Because we use `bytes.Buffer` heavily, keep a pool of `bytes.Buffer` objects to reduce allocations. Exception is the triple `UUID` method where we have a fixed sized buffer as it is a concatenation of three `UUID`s.