### PR TITLE
Store a pointer to slice in `sync.Pool`.

### DIFF
--- a/triple/triple.go
+++ b/triple/triple.go
@@ -263,14 +263,13 @@ func (t *Triple) UUID() uuid.UUID {
 	// value needs to be placed on the heap which causes an extra allocation.
 	// See: https://staticcheck.io/docs/checks#SA6002
 	bp := bufPool.Get().(*[]byte)
-	b := *bp
-	// Even though 'b' is dirty when fetched from the pool we do not
+	// Even though 'bp' is dirty when fetched from the pool we do not
 	// clear it because the contents are always completely overwritten.
 	defer bufPool.Put(bp)
 
 	// A UUID is always 16 bytes.
-	copy(b[:16], t.s.UUID())
-	copy(b[16:32], t.p.UUID())
-	copy(b[32:], t.o.UUID())
-	return uuid.NewSHA1(uuid.NIL, b)
+	copy((*bp)[:16], t.s.UUID())
+	copy((*bp)[16:32], t.p.UUID())
+	copy((*bp)[32:], t.o.UUID())
+	return uuid.NewSHA1(uuid.NIL, (*bp))
 }

--- a/triple/triple.go
+++ b/triple/triple.go
@@ -29,7 +29,7 @@ import (
 
 // bufPool holds a pool of byte arrays used by triple's UUID() method, which needs
 // a buffer big enough to contain the UUIDs for (subject, predicate, object), so 3x16 bytes.
-var bufPool = sync.Pool{New: func() interface{} { return make([]byte, 48) }}
+var bufPool = sync.Pool{New: func() interface{} { b := make([]byte, 48); return &b }}
 
 // Object is the box that either contains a literal, a predicate or a node.
 type Object struct {
@@ -259,10 +259,14 @@ func (t *Triple) Reify() ([]*Triple, *node.Node, error) {
 // implemented as the SHA1 UUID of the concatenated UUIDs of the subject,
 // predicate, and object.
 func (t *Triple) UUID() uuid.UUID {
-	b := bufPool.Get().([]byte)
+	// We need to store a pointer to the value in sync.Pool otherwise the
+	// value needs to be placed on the heap which causes an extra allocation.
+	// See: https://staticcheck.io/docs/checks#SA6002
+	bp := bufPool.Get().(*[]byte)
+	b := *bp
 	// Even though 'b' is dirty when fetched from the pool we do not
 	// clear it because the contents are always completely overwritten.
-	defer bufPool.Put(b)
+	defer bufPool.Put(bp)
 
 	// A UUID is always 16 bytes.
 	copy(b[:16], t.s.UUID())


### PR DESCRIPTION
Storing the slice directly causes the value to be placed on the heap
which means an additional allocation.

See: https://staticcheck.io/docs/checks#SA6002